### PR TITLE
Delegate lock/unlock to rudi

### DIFF
--- a/.mise/tasks/lock
+++ b/.mise/tasks/lock
@@ -1,21 +1,17 @@
 #!/usr/bin/env bash
 #MISE description="Lock encrypted files (re-encrypt on disk)"
-#USAGE flag "--all" help="Lock all keys, not just default"
+#USAGE flag "-k --key <name>" help="Lock only this named key's files (default: lock all)"
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
 require_git
 require_initialized
+require_rudi
 
-if ! command -v git-crypt &>/dev/null; then
-  echo "Error: git-crypt not found. Install it: rudi install" >&2
-  exit 1
-fi
+cd "$TARGET_DIR"
 
-if [ "${usage_all:-}" = "true" ]; then
-  git -C "$TARGET_DIR" crypt lock --all
-  echo "Locked all keys."
+if [ -n "${usage_key:-}" ]; then
+  rudi lock --key "$usage_key"
 else
-  git -C "$TARGET_DIR" crypt lock
-  echo "Locked default key. Use --all to lock all keys."
+  rudi lock
 fi

--- a/.mise/tasks/unlock
+++ b/.mise/tasks/unlock
@@ -5,12 +5,7 @@ set -eo pipefail
 source "$MISE_CONFIG_ROOT/lib/common.sh"
 require_git
 require_initialized
+require_rudi
 
-if ! command -v git-crypt &>/dev/null; then
-  echo "Error: git-crypt not found. Install it: rudi install" >&2
-  exit 1
-fi
-
-echo "Unlocking with your GPG key..."
-git -C "$TARGET_DIR" crypt unlock
-echo "Unlocked. Encrypted files are now readable."
+cd "$TARGET_DIR"
+rudi unlock


### PR DESCRIPTION
## Summary

- `notes lock` and `notes unlock` now delegate to `rudi lock` / `rudi unlock` instead of calling git-crypt directly
- Completes the delegation started in #14 (which covered add-user, setup, status, verify)
- The old `--all` flag on `notes lock` is replaced by `--key` (passthrough to `rudi lock --key`), since rudi already defaults to locking all keys

## Context

This is the notes-side counterpart to KnickKnackLabs/rudi#1, which added lock/unlock tasks to rudi. Together they fix fold CI — `notes unlock` no longer needs to resolve notes' global Python dependency just to run a bash-only git-crypt operation.

Remaining: notes#16 (move `python = "3"` to task-level on `index` only).

## Test plan

- [x] All 22 notes tests pass
- [x] Test 20: lock/unlock round-trip preserves file content
- [x] Test 22: full workflow (setup → add-user → commit → lock → unlock → verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)