### PR TITLE
Remove python from global tool dependencies

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,4 @@
 [tools]
-python = "3"
 bats = "1.13.0"
 # git-crypt has no macOS binary on GitHub releases.
 # macOS: brew install git-crypt


### PR DESCRIPTION
## Summary

Removes `python = "3"` from mise.toml. The only Python task (`graph`) uses stdlib only — `#!/usr/bin/env python3` resolves to system Python without needing mise-managed Python.

## Context

This is the final piece to unblock fold CI. The failure chain was:

1. mise sees `python = "3"` in notes' mise.toml
2. Tries to install managed Python on GitHub Actions runner → fails
3. `notes unlock` never runs → identity files stay encrypted → `agent:identity` fails

With this change plus the lock/unlock delegation to rudi (#17), fold CI should work again.

Closes #16.

## Test plan

- [x] All 42 tests pass, including graph tests (13-18) which exercise the Python task via system Python

🤖 Generated with [Claude Code](https://claude.com/claude-code)