### PR TITLE
Fix scoped obfuscate dry-run existing IDs

### DIFF
--- a/.mise/tasks/obfuscate
+++ b/.mise/tasks/obfuscate
@@ -38,7 +38,12 @@ if [ "${usage_dry_run:-}" = "true" ]; then
       [ ! -f "$abs_notes_dir/$relpath" ] && continue
       base=$(basename "$relpath")
       manifest_has_id "$manifest" "$base" && continue
-      echo "  $relpath → (will be assigned)"
+      existing_id=$(manifest_id_for_name "$manifest" "$relpath" || true)
+      if [ -n "$existing_id" ]; then
+        echo "  $relpath → $existing_id"
+      else
+        echo "  $relpath → (will be assigned)"
+      fi
     done
   else
     while IFS= read -r f; do

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -74,12 +74,39 @@ setup() {
 }
 
 @test "obfuscate dry-run shows plan without renaming" {
-  run notes obfuscate -- --dry-run
+  run notes obfuscate --dry-run
   [ "$status" -eq 0 ]
   [[ "$output" == *"alpha.md"* ]]
 
   [ -f "$CALLER_PWD/notes/alpha.md" ]
   [ ! -f "$CALLER_PWD/notes/.manifest" ]
+}
+
+@test "scoped obfuscate dry-run shows existing manifest ID for readable file" {
+  notes obfuscate
+  alpha_id=$(grep $'\talpha\.md$' "$CALLER_PWD/notes/.manifest" | cut -f1)
+
+  notes deobfuscate
+
+  run notes obfuscate --dry-run alpha.md
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"alpha.md → $alpha_id"* ]]
+  [[ "$output" != *"alpha.md → (will be assigned)"* ]]
+
+  [ -f "$CALLER_PWD/notes/alpha.md" ]
+  [ ! -f "$CALLER_PWD/notes/$alpha_id" ]
+}
+
+@test "scoped obfuscate dry-run skips already-obfuscated IDs" {
+  notes obfuscate
+  alpha_id=$(grep $'\talpha\.md$' "$CALLER_PWD/notes/.manifest" | cut -f1)
+
+  run notes obfuscate --dry-run "$alpha_id"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"$alpha_id"* ]]
+  [[ "$output" != *"will be assigned"* ]]
+
+  [ -f "$CALLER_PWD/notes/$alpha_id" ]
 }
 
 @test "obfuscate handles new files added after initial obfuscation" {


### PR DESCRIPTION
## Summary
- Make scoped `notes obfuscate --dry-run <file>` look up existing manifest IDs by readable name
- Keep already-obfuscated IDs skipped in scoped dry-run
- Add regression coverage for both scoped dry-run paths

Closes #53.

## Tests
- `mise run test test/obfuscate.bats --filter 'scoped obfuscate dry-run|obfuscate dry-run shows plan'`\n- `mise run test test/obfuscate.bats`\n- `mise run test test/*.bats` excluding `test/integration.bats` (200 tests pass)\n\nFull `mise run test` currently fails in `test/integration.bats` lock/git-crypt tests; the same failures reproduce on `origin/main`.