### PR TITLE
fix: protect dirty readable notes during deobfuscate

### DIFF
--- a/.mise/tasks/deobfuscate
+++ b/.mise/tasks/deobfuscate
@@ -59,19 +59,21 @@ output=$(rename_to_readable "$abs_notes_dir" "${ARGS[@]}") && rc=0 || rc=$?
 if [ $rc -eq 2 ]; then
   echo "Nothing to deobfuscate."
   exit 0
-elif [ $rc -ne 0 ]; then
-  echo "Error: deobfuscation failed" >&2
-  exit $rc
 fi
 
-# Print what was renamed, collect IDs for scoped suppression
+# Print what was renamed, collect IDs for scoped suppression. We do this even
+# on partial failure (rc != 0) so the state file and assume-unchanged stay
+# consistent with what's actually on disk; the error is reported afterwards.
 restored=0
 suppressed_ids=()
-while IFS=$'\t' read -r id relpath; do
-  echo "  $id → $relpath"
-  suppressed_ids+=("$id")
-  ((restored++)) || true
-done <<< "$output"
+if [ -n "$output" ]; then
+  while IFS=$'\t' read -r id relpath; do
+    [ -z "$id" ] && continue
+    echo "  $id → $relpath"
+    suppressed_ids+=("$id")
+    ((restored++)) || true
+  done <<< "$output"
+fi
 
 # Warn about unknown IDs in scoped mode (matches dry-run behavior)
 if [ ${#ARGS[@]} -gt 0 ]; then
@@ -86,9 +88,19 @@ if [ ${#ARGS[@]} -gt 0 ]; then
   done
 fi
 
-# Set status suppression only for the IDs we just deobfuscated
-set_status_suppression "$abs_notes_dir" "${suppressed_ids[@]}"
-_record_deobfuscation_base_hashes "$abs_notes_dir" "${suppressed_ids[@]}"
+# Record state for IDs that DID succeed even if a later one in the batch
+# errored out -- otherwise those files have no recorded base hash and a
+# future post-pull update is rejected without --force, even though the user
+# did nothing wrong.
+if [ ${#suppressed_ids[@]} -gt 0 ]; then
+  set_status_suppression "$abs_notes_dir" "${suppressed_ids[@]}"
+  _record_deobfuscation_base_hashes "$abs_notes_dir" "${suppressed_ids[@]}"
+fi
+
+if [ $rc -ne 0 ]; then
+  echo "Error: deobfuscation failed after restoring $restored file(s)" >&2
+  exit $rc
+fi
 
 echo ""
 echo "Restored $restored file(s). Manifest preserved for stable IDs."

--- a/.mise/tasks/deobfuscate
+++ b/.mise/tasks/deobfuscate
@@ -61,9 +61,8 @@ if [ $rc -eq 2 ]; then
   exit 0
 fi
 
-# Print what was renamed, collect IDs for scoped suppression. We do this even
-# on partial failure (rc != 0) so the state file and assume-unchanged stay
-# consistent with what's actually on disk; the error is reported afterwards.
+# Print what was renamed, collect IDs. Do this even on partial failure so
+# the state file stays consistent with disk; surface the rc afterwards.
 restored=0
 suppressed_ids=()
 if [ -n "$output" ]; then
@@ -88,13 +87,14 @@ if [ ${#ARGS[@]} -gt 0 ]; then
   done
 fi
 
-# Record state for IDs that DID succeed even if a later one in the batch
-# errored out -- otherwise those files have no recorded base hash and a
-# future post-pull update is rejected without --force, even though the user
-# did nothing wrong.
+# Record state for what *did* succeed, even on partial failure. Tolerate
+# helper errors with `|| warn` so the original rename rc isn't masked under
+# `set -e`.
 if [ ${#suppressed_ids[@]} -gt 0 ]; then
-  set_status_suppression "$abs_notes_dir" "${suppressed_ids[@]}"
-  _record_deobfuscation_base_hashes "$abs_notes_dir" "${suppressed_ids[@]}"
+  set_status_suppression "$abs_notes_dir" "${suppressed_ids[@]}" \
+    || echo "Warning: failed to update status suppression" >&2
+  _record_deobfuscation_base_hashes "$abs_notes_dir" "${suppressed_ids[@]}" \
+    || echo "Warning: failed to record deobfuscation base hashes" >&2
 fi
 
 if [ $rc -ne 0 ]; then

--- a/.mise/tasks/deobfuscate
+++ b/.mise/tasks/deobfuscate
@@ -2,6 +2,7 @@
 #MISE description="Restore obfuscated filenames to their original names"
 #USAGE flag "--dir <dir>" help="Notes directory relative to repo root (default: notes)"
 #USAGE flag "--dry-run" help="Show what would be renamed without doing it"
+#USAGE flag "--force" help="Overwrite existing readable files intentionally"
 #USAGE arg "[files]..." help="Specific obfuscated IDs to deobfuscate. Omit for all."
 set -eo pipefail
 
@@ -53,6 +54,7 @@ fi
 # Perform the rename via Layer 1
 # Exit codes: 0=success, 2=nothing to do, 1=error
 # Use subshell to capture exit code without triggering errexit.
+export NOTES_DEOBFUSCATE_FORCE="${usage_force:-false}"
 output=$(rename_to_readable "$abs_notes_dir" "${ARGS[@]}") && rc=0 || rc=$?
 if [ $rc -eq 2 ]; then
   echo "Nothing to deobfuscate."
@@ -86,6 +88,7 @@ fi
 
 # Set status suppression only for the IDs we just deobfuscated
 set_status_suppression "$abs_notes_dir" "${suppressed_ids[@]}"
+_record_deobfuscation_base_hashes "$abs_notes_dir" "${suppressed_ids[@]}"
 
 echo ""
 echo "Restored $restored file(s). Manifest preserved for stable IDs."

--- a/.mise/tasks/unlock
+++ b/.mise/tasks/unlock
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Unlock encrypted files using your GPG key"
+#USAGE flag "--force" help="Overwrite existing readable note files during deobfuscation"
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
@@ -17,5 +18,9 @@ echo "Note: unlock decrypts all encrypted files in this repo (rudi#5)."
 
 # Deobfuscate filenames if a manifest exists
 if [ -f "$TARGET_DIR/notes/.manifest" ]; then
-  cd "$MISE_CONFIG_ROOT" && CALLER_PWD="$TARGET_DIR" mise run -q deobfuscate
+  if [ "${usage_force:-false}" = "true" ]; then
+    cd "$MISE_CONFIG_ROOT" && CALLER_PWD="$TARGET_DIR" mise run -q deobfuscate -- --force
+  else
+    cd "$MISE_CONFIG_ROOT" && CALLER_PWD="$TARGET_DIR" mise run -q deobfuscate
+  fi
 fi

--- a/lib/obfuscate.sh
+++ b/lib/obfuscate.sh
@@ -186,7 +186,11 @@ _deobfuscation_base_hash_for_id() {
   local state
   state=$(_deobfuscation_state_file "$notes_dir") || return 0
   [ -f "$state" ] || return 0
-  awk -F '\t' -v wanted="$id" '$1 == wanted { print $2; exit }' "$state"
+  # Last entry wins. The state file is append-only (see
+  # _record_deobfuscation_base_hashes); newer writes shadow older ones, and
+  # concurrent writers can't corrupt each other the way a tmp+mv
+  # read-modify-write would.
+  awk -F '\t' -v wanted="$id" '$1 == wanted { found=$2 } END { if (found != "") print found }' "$state"
 }
 
 _record_deobfuscation_base_hashes() {
@@ -201,36 +205,24 @@ _record_deobfuscation_base_hashes() {
   local repo_root="$RESOLVED_REPO_ROOT"
   local state="$repo_root/.git/info/notes-obfuscation-state"
   mkdir -p "$(dirname "$state")"
+  touch "$state"
 
-  local tmp
-  tmp=$(mktemp) || return 1
-
-  if [ -f "$state" ]; then
-    while IFS=$'\t' read -r existing_id existing_hash; do
-      [ -z "$existing_id" ] && continue
-      local replace=false
-      for id in "${ids[@]}"; do
-        if [ "$existing_id" = "$id" ]; then
-          replace=true
-          break
-        fi
-      done
-      if [ "$replace" = false ]; then
-        printf '%s\t%s\n' "$existing_id" "$existing_hash" >> "$tmp"
-      fi
-    done < "$state"
-  fi
-
+  # Append-only writes: each line is a single short id\thash row, atomic per
+  # POSIX for writes under PIPE_BUF (we're well under). The lookup helper
+  # takes the last entry per id, so newer writes shadow older ones. This
+  # avoids the read-modify-write race that a tmp+mv pattern is prone to when
+  # two deobfuscate processes interleave (manual unlock vs post-merge hook,
+  # sibling agents in shared worktrees). Periodic compaction is a separate
+  # concern; growth is bounded by the number of (id, content) pairs the
+  # repo has ever held, which is small for note-sized repos.
   for id in "${ids[@]}"; do
     local relpath sha
     relpath=$(manifest_name_for_id "$manifest" "$id")
     [ -z "$relpath" ] && continue
     [ -f "$notes_dir/$relpath" ] || continue
-    sha=$(git -C "$repo_root" hash-object -- "$notes_dir/$relpath") || { rm -f "$tmp"; return 1; }
-    printf '%s\t%s\n' "$id" "$sha" >> "$tmp"
+    sha=$(git -C "$repo_root" hash-object -- "$notes_dir/$relpath") || return 1
+    printf '%s\t%s\n' "$id" "$sha" >> "$state"
   done
-
-  mv -f "$tmp" "$state"
 }
 
 # Rename a single obfuscated ID back to its readable name.
@@ -247,14 +239,24 @@ _rename_one_to_readable() {
   [ ! -d "$target_dir" ] && mkdir -p "$target_dir"
 
   if [ -e "$notes_dir/$relpath" ] && ! cmp -s "$notes_dir/$id" "$notes_dir/$relpath"; then
-    local current_hash base_hash
+    local current_hash base_hash state_file
+    state_file=$(_deobfuscation_state_file "$notes_dir" 2>/dev/null) || state_file=""
     current_hash=$(git -C "$notes_dir" hash-object -- "$notes_dir/$relpath" 2>/dev/null || true)
     base_hash=$(_deobfuscation_base_hash_for_id "$notes_dir" "$id")
 
-    if [ -z "$base_hash" ] || [ "$current_hash" != "$base_hash" ]; then
+    # Skip the dirty check entirely when no state file has ever been written
+    # in this clone. Two cases land here: a fresh clone before its first
+    # successful deobfuscate (no readable can collide with a recorded hash
+    # because nothing has been recorded), and an upgrade from a notes version
+    # before this safety landed (no state file yet). In both cases, treat the
+    # readable as trusted and let the rename proceed; the very next successful
+    # deobfuscate writes the state file and re-establishes the invariant.
+    if [ -n "$state_file" ] && [ -f "$state_file" ] \
+      && { [ -z "$base_hash" ] || [ "$current_hash" != "$base_hash" ]; }; then
       if [ "${NOTES_DEOBFUSCATE_FORCE:-false}" != "true" ]; then
         echo "Error: refusing to overwrite dirty readable note: $relpath" >&2
-        echo "Run 'notes changes $relpath' to inspect it, stage/commit it, or rerun with --force to overwrite intentionally." >&2
+        echo "This may be a real local edit, or a cosmetic editor re-save (trailing-newline trim, BOM, line-ending change)." >&2
+        echo "Run 'notes changes $relpath' to inspect; rerun with --force to overwrite intentionally." >&2
         return 1
       fi
     fi

--- a/lib/obfuscate.sh
+++ b/lib/obfuscate.sh
@@ -172,6 +172,67 @@ rename_to_obfuscated() {
   rm -f "$merged" "$new_entries"
 }
 
+# Local state file recording the content hash last restored for each ID.
+# This lets deobfuscation distinguish a clean stale readable file (safe to
+# update after pull/merge) from a locally-edited readable file (must preserve).
+_deobfuscation_state_file() {
+  local notes_dir="$1"
+  resolve_notes_dir "$notes_dir" || return 1
+  printf '%s/.git/info/notes-obfuscation-state' "$RESOLVED_REPO_ROOT"
+}
+
+_deobfuscation_base_hash_for_id() {
+  local notes_dir="$1" id="$2"
+  local state
+  state=$(_deobfuscation_state_file "$notes_dir") || return 0
+  [ -f "$state" ] || return 0
+  awk -F '\t' -v wanted="$id" '$1 == wanted { print $2; exit }' "$state"
+}
+
+_record_deobfuscation_base_hashes() {
+  local notes_dir="$1"
+  shift
+  local ids=("$@")
+  local manifest="$notes_dir/.manifest"
+  [ -f "$manifest" ] || return 0
+  [ ${#ids[@]} -gt 0 ] || return 0
+
+  resolve_notes_dir "$notes_dir" || return 0
+  local repo_root="$RESOLVED_REPO_ROOT"
+  local state="$repo_root/.git/info/notes-obfuscation-state"
+  mkdir -p "$(dirname "$state")"
+
+  local tmp
+  tmp=$(mktemp) || return 1
+
+  if [ -f "$state" ]; then
+    while IFS=$'\t' read -r existing_id existing_hash; do
+      [ -z "$existing_id" ] && continue
+      local replace=false
+      for id in "${ids[@]}"; do
+        if [ "$existing_id" = "$id" ]; then
+          replace=true
+          break
+        fi
+      done
+      if [ "$replace" = false ]; then
+        printf '%s\t%s\n' "$existing_id" "$existing_hash" >> "$tmp"
+      fi
+    done < "$state"
+  fi
+
+  for id in "${ids[@]}"; do
+    local relpath sha
+    relpath=$(manifest_name_for_id "$manifest" "$id")
+    [ -z "$relpath" ] && continue
+    [ -f "$notes_dir/$relpath" ] || continue
+    sha=$(git -C "$repo_root" hash-object -- "$notes_dir/$relpath") || { rm -f "$tmp"; return 1; }
+    printf '%s\t%s\n' "$id" "$sha" >> "$tmp"
+  done
+
+  mv -f "$tmp" "$state"
+}
+
 # Rename a single obfuscated ID back to its readable name.
 # Returns: 0=renamed, 2=skipped (not found/no match), 1=error (mv failed).
 _rename_one_to_readable() {
@@ -185,8 +246,22 @@ _rename_one_to_readable() {
   target_dir=$(dirname "$notes_dir/$relpath")
   [ ! -d "$target_dir" ] && mkdir -p "$target_dir"
 
-  # Use -f to handle the case where the readable name already exists
-  # (e.g., committed with both readable and obfuscated names).
+  if [ -e "$notes_dir/$relpath" ] && ! cmp -s "$notes_dir/$id" "$notes_dir/$relpath"; then
+    local current_hash base_hash
+    current_hash=$(git -C "$notes_dir" hash-object -- "$notes_dir/$relpath" 2>/dev/null || true)
+    base_hash=$(_deobfuscation_base_hash_for_id "$notes_dir" "$id")
+
+    if [ -z "$base_hash" ] || [ "$current_hash" != "$base_hash" ]; then
+      if [ "${NOTES_DEOBFUSCATE_FORCE:-false}" != "true" ]; then
+        echo "Error: refusing to overwrite dirty readable note: $relpath" >&2
+        echo "Run 'notes changes $relpath' to inspect it, stage/commit it, or rerun with --force to overwrite intentionally." >&2
+        return 1
+      fi
+    fi
+  fi
+
+  # Use -f only after the safety check above. Identical readable copies are
+  # harmless; differing copies require explicit --force.
   if ! mv -f "$notes_dir/$id" "$notes_dir/$relpath"; then
     echo "Error: failed to rename $id → $relpath" >&2
     return 1

--- a/lib/obfuscate.sh
+++ b/lib/obfuscate.sh
@@ -207,14 +207,10 @@ _record_deobfuscation_base_hashes() {
   mkdir -p "$(dirname "$state")"
   touch "$state"
 
-  # Append-only writes: each line is a single short id\thash row, atomic per
-  # POSIX for writes under PIPE_BUF (we're well under). The lookup helper
-  # takes the last entry per id, so newer writes shadow older ones. This
-  # avoids the read-modify-write race that a tmp+mv pattern is prone to when
-  # two deobfuscate processes interleave (manual unlock vs post-merge hook,
-  # sibling agents in shared worktrees). Periodic compaction is a separate
-  # concern; growth is bounded by the number of (id, content) pairs the
-  # repo has ever held, which is small for note-sized repos.
+  # Append-only on purpose: O_APPEND under PIPE_BUF is atomic, so concurrent
+  # writers get out-of-order rows but never torn ones, and the lookup helper
+  # takes the last matching entry. Don't "fix" this back to tmp+mv -- that's
+  # the read-modify-write race we're avoiding.
   for id in "${ids[@]}"; do
     local relpath sha
     relpath=$(manifest_name_for_id "$manifest" "$id")
@@ -244,13 +240,9 @@ _rename_one_to_readable() {
     current_hash=$(git -C "$notes_dir" hash-object -- "$notes_dir/$relpath" 2>/dev/null || true)
     base_hash=$(_deobfuscation_base_hash_for_id "$notes_dir" "$id")
 
-    # Skip the dirty check entirely when no state file has ever been written
-    # in this clone. Two cases land here: a fresh clone before its first
-    # successful deobfuscate (no readable can collide with a recorded hash
-    # because nothing has been recorded), and an upgrade from a notes version
-    # before this safety landed (no state file yet). In both cases, treat the
-    # readable as trusted and let the rename proceed; the very next successful
-    # deobfuscate writes the state file and re-establishes the invariant.
+    # No state file (fresh clone or pre-safety upgrade) -> trust the readable
+    # and let the rename proceed. Force-prompting on every file would train
+    # users into --force-as-default, which is worse than the one-time window.
     if [ -n "$state_file" ] && [ -f "$state_file" ] \
       && { [ -z "$base_hash" ] || [ "$current_hash" != "$base_hash" ]; }; then
       if [ "${NOTES_DEOBFUSCATE_FORCE:-false}" != "true" ]; then

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -838,23 +838,32 @@ EOF
   [ "$obfuscated_count" -eq 1 ]
 }
 
-@test "deobfuscate refuses to overwrite dirty readable note" {
+@test "deobfuscate trusts existing readable when no state file (upgrade/fresh-clone path)" {
+  # Regression: notes#59 finding 1. Before this fix, the first deobfuscate
+  # after upgrading to the dirty-protection version would refuse every
+  # readable that differs from its obfuscated source -- because no state
+  # file existed yet, so every base_hash lookup returned empty, which the
+  # check treated as dirty. That forced users straight to --force on first
+  # run, training them to bypass the protection forever.
   notes obfuscate
   local alpha_id
   alpha_id=$(grep "alpha.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
   [ -f "$CALLER_PWD/notes/$alpha_id" ]
 
-  echo "local edit" > "$CALLER_PWD/notes/alpha.md"
+  # Simulate a pre-fix clone: a stale readable on disk, no state file.
+  echo "stale readable from before the upgrade" > "$CALLER_PWD/notes/alpha.md"
+  rm -f "$CALLER_PWD/.git/info/notes-obfuscation-state"
 
   run notes deobfuscate
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"refusing to overwrite dirty readable note"* ]]
-  [[ "$output" == *"alpha.md"* ]]
-
-  # Neither side should be destroyed on refusal.
-  [ -f "$CALLER_PWD/notes/$alpha_id" ]
-  [ -f "$CALLER_PWD/notes/alpha.md" ]
-  [[ "$(cat "$CALLER_PWD/notes/alpha.md")" == "local edit" ]]
+  [ "$status" -eq 0 ]
+  # The readable was overwritten with the obfuscated content (the protection
+  # is opt-in only after the state file exists; on the upgrade run we trust
+  # the existing readable so users don't get force-prompted on every file).
+  [[ "$(cat "$CALLER_PWD/notes/alpha.md")" == *"# Alpha"* ]]
+  # And the very next deobfuscate is now protected -- the state file got
+  # written on this run.
+  [ -f "$CALLER_PWD/.git/info/notes-obfuscation-state" ]
+  grep -q "^${alpha_id}"$'\t' "$CALLER_PWD/.git/info/notes-obfuscation-state"
 }
 
 @test "deobfuscate refuses dirty readable note with recorded base hash" {
@@ -907,6 +916,98 @@ EOF
   [ "$status" -eq 0 ]
   [ -f "$CALLER_PWD/notes/alpha.md" ]
   [[ "$(cat "$CALLER_PWD/notes/alpha.md")" == *"# Alpha"* ]]
+}
+
+@test "deobfuscate records state for files renamed before mid-batch refusal" {
+  # Regression: notes#59 finding 2. rename_to_readable aborts on the first
+  # dirty file in a batch, but files renamed *before* that point are already
+  # moved on disk. Pre-fix, the deobfuscate task exit'd on rc != 0 before
+  # recording state, so those successfully-renamed files had no recorded base
+  # hash -- and the next post-pull update of any of them would be refused
+  # without --force, even though the user did nothing wrong.
+  notes obfuscate
+  local alpha_id beta_id
+  alpha_id=$(grep "alpha.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
+  beta_id=$(grep "beta.md"  "$CALLER_PWD/notes/.manifest" | cut -f1)
+  git -C "$CALLER_PWD" add -A notes
+  git -C "$CALLER_PWD" commit -q -m "obfuscate"
+
+  # Establish state-file invariant for both files.
+  notes deobfuscate
+  [ -f "$CALLER_PWD/.git/info/notes-obfuscation-state" ]
+
+  # Dirty beta and re-obfuscate just the obfuscated source for both, then
+  # simulate a pull bringing back the obfuscated form alongside the dirty
+  # readable.
+  echo "local edit on beta" > "$CALLER_PWD/notes/beta.md"
+  git -C "$CALLER_PWD" update-index --no-assume-unchanged "notes/$alpha_id" "notes/$beta_id" 2>/dev/null || true
+  git -C "$CALLER_PWD" checkout -- "notes/$alpha_id" "notes/$beta_id"
+  # Now alpha.md is up-to-date but the obfuscated source has been re-restored;
+  # beta has a dirty readable that should refuse.
+
+  # Touch the alpha readable so it differs from the restored obfuscated source
+  # (cmp -s mismatch triggers the dirty path), but match the recorded base
+  # hash so the rename is allowed and we genuinely test the partial-batch
+  # bookkeeping rather than just the refusal path.
+  rm -f "$CALLER_PWD/notes/alpha.md"
+
+  run notes deobfuscate
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"refusing to overwrite dirty readable note"* ]]
+  # Alpha was renamed despite beta's failure...
+  [ -f "$CALLER_PWD/notes/alpha.md" ]
+  # ...and the state file records it (this is the bug being fixed -- pre-fix
+  # the task exit'd before _record_deobfuscation_base_hashes was called).
+  grep -q "^${alpha_id}"$'\t' "$CALLER_PWD/.git/info/notes-obfuscation-state"
+}
+
+@test "deobfuscation state file is append-only and last-entry-wins" {
+  # Regression: notes#59 finding 3. The state file is now append-only to
+  # avoid a tmp+mv read-modify-write race when two deobfuscate processes
+  # interleave. Two invariants we test here:
+  #   (a) re-recording an id appends a new row instead of rewriting the file
+  #   (b) the lookup semantic takes the *last* matching row, so newer writes
+  #       shadow older ones (which is what makes append-only safe).
+  notes obfuscate
+  local alpha_id
+  alpha_id=$(grep "alpha.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
+  git -C "$CALLER_PWD" add -A notes
+  git -C "$CALLER_PWD" commit -q -m "obfuscate"
+
+  notes deobfuscate
+  local state="$CALLER_PWD/.git/info/notes-obfuscation-state"
+  [ -f "$state" ]
+
+  local rows_before alpha_rows_before
+  rows_before=$(wc -l < "$state" | tr -d ' ')
+  alpha_rows_before=$(grep -c "^${alpha_id}"$'\t' "$state" || true)
+  [ "$alpha_rows_before" -eq 1 ]
+
+  # Drive another deobfuscate cycle: dirty the readable, restore the
+  # obfuscated source from the commit (simulating a pull), then force.
+  # Pre-fix this rewrote the state file (rows_after == rows_before);
+  # post-fix it appends (rows_after > rows_before).
+  echo "local edit" >> "$CALLER_PWD/notes/alpha.md"
+  git -C "$CALLER_PWD" update-index --no-assume-unchanged "notes/$alpha_id" 2>/dev/null || true
+  git -C "$CALLER_PWD" checkout -- "notes/$alpha_id"
+  notes deobfuscate -- --force
+
+  local rows_after alpha_rows_after
+  rows_after=$(wc -l < "$state" | tr -d ' ')
+  alpha_rows_after=$(grep -c "^${alpha_id}"$'\t' "$state" || true)
+  [ "$rows_after" -gt "$rows_before" ]
+  [ "$alpha_rows_after" -gt "$alpha_rows_before" ]
+
+  # Last-entry-wins lookup: inject a stale row at the end and confirm the
+  # awk "last match" semantic the helper uses returns the stale one (i.e.
+  # whatever was written most recently wins). This is the property that
+  # makes append-only safe under concurrent writes.
+  local stale_hash="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+  printf '%s\t%s\n' "$alpha_id" "$stale_hash" >> "$state"
+
+  local last
+  last=$(awk -F '\t' -v wanted="$alpha_id" '$1 == wanted { found=$2 } END { if (found != "") print found }' "$state")
+  [ "$last" = "$stale_hash" ]
 }
 
 # ── Refuse re-obfuscation of already-hex-named files ──────────

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -1016,11 +1016,11 @@ EOF
   local stale_hash="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
   printf '%s\t%s\n' "$alpha_id" "$stale_hash" >> "$state"
 
-  # Mirror the helper's awk semantic. Calling the helper directly would be
-  # tighter, but bats doesn't propagate sourced functions from setup() into
-  # the test body's exec context, so it shows up as "command not found."
+  # Pin the contract on the helper, not its implementation -- a future
+  # rewrite of _deobfuscation_base_hash_for_id (different awk, perl, etc.)
+  # that silently broke last-entry-wins would then fail this test.
   local last
-  last=$(awk -F '\t' -v wanted="$alpha_id" '$1 == wanted { found=$2 } END { if (found != "") print found }' "$state")
+  last=$(_deobfuscation_base_hash_for_id "$CALLER_PWD/notes" "$alpha_id")
   [ "$last" = "$stale_hash" ]
 }
 

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -934,21 +934,28 @@ EOF
 
   # Establish state-file invariant for both files.
   notes deobfuscate
-  [ -f "$CALLER_PWD/.git/info/notes-obfuscation-state" ]
+  local state="$CALLER_PWD/.git/info/notes-obfuscation-state"
+  [ -f "$state" ]
 
-  # Dirty beta and re-obfuscate just the obfuscated source for both, then
-  # simulate a pull bringing back the obfuscated form alongside the dirty
-  # readable.
+  # Snapshot the count of rows for alpha_id BEFORE the partial-failure run.
+  # Pre-fix the task exit'd before re-recording, so this count would not
+  # change after the partial-failure run; post-fix it must increment.
+  # (Asserting a row simply *exists* would not catch the regression -- the
+  # row from this first deobfuscate is already present either way.)
+  local alpha_rows_before
+  alpha_rows_before=$(grep -c "^${alpha_id}"$'\t' "$state" || true)
+  [ "$alpha_rows_before" -eq 1 ]
+
+  # Dirty beta and restore the obfuscated source for both, simulating a pull
+  # that brings back the obfuscated form alongside the dirty readable.
   echo "local edit on beta" > "$CALLER_PWD/notes/beta.md"
   git -C "$CALLER_PWD" update-index --no-assume-unchanged "notes/$alpha_id" "notes/$beta_id" 2>/dev/null || true
   git -C "$CALLER_PWD" checkout -- "notes/$alpha_id" "notes/$beta_id"
   # Now alpha.md is up-to-date but the obfuscated source has been re-restored;
   # beta has a dirty readable that should refuse.
 
-  # Touch the alpha readable so it differs from the restored obfuscated source
-  # (cmp -s mismatch triggers the dirty path), but match the recorded base
-  # hash so the rename is allowed and we genuinely test the partial-batch
-  # bookkeeping rather than just the refusal path.
+  # Remove the alpha readable so the rename re-creates it from scratch (cmp -s
+  # mismatch triggers the rename path); beta refuses on the dirty check.
   rm -f "$CALLER_PWD/notes/alpha.md"
 
   run notes deobfuscate
@@ -956,9 +963,13 @@ EOF
   [[ "$output" == *"refusing to overwrite dirty readable note"* ]]
   # Alpha was renamed despite beta's failure...
   [ -f "$CALLER_PWD/notes/alpha.md" ]
-  # ...and the state file records it (this is the bug being fixed -- pre-fix
-  # the task exit'd before _record_deobfuscation_base_hashes was called).
-  grep -q "^${alpha_id}"$'\t' "$CALLER_PWD/.git/info/notes-obfuscation-state"
+  # ...and the state file recorded its base hash again (the actual regression
+  # under test). Pre-fix the task exit'd before _record_deobfuscation_base_hashes
+  # was called, so alpha_rows_after == alpha_rows_before. Post-fix the recording
+  # runs even on partial failure, so the row count strictly increases.
+  local alpha_rows_after
+  alpha_rows_after=$(grep -c "^${alpha_id}"$'\t' "$state" || true)
+  [ "$alpha_rows_after" -gt "$alpha_rows_before" ]
 }
 
 @test "deobfuscation state file is append-only and last-entry-wins" {
@@ -1005,6 +1016,9 @@ EOF
   local stale_hash="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
   printf '%s\t%s\n' "$alpha_id" "$stale_hash" >> "$state"
 
+  # Mirror the helper's awk semantic. Calling the helper directly would be
+  # tighter, but bats doesn't propagate sourced functions from setup() into
+  # the test body's exec context, so it shows up as "command not found."
   local last
   last=$(awk -F '\t' -v wanted="$alpha_id" '$1 == wanted { found=$2 } END { if (found != "") print found }' "$state")
   [ "$last" = "$stale_hash" ]

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -838,24 +838,75 @@ EOF
   [ "$obfuscated_count" -eq 1 ]
 }
 
-@test "deobfuscate succeeds when readable name already exists on disk" {
-  # Simulate the bug: both obfuscated ID and readable name exist
+@test "deobfuscate refuses to overwrite dirty readable note" {
   notes obfuscate
   local alpha_id
   alpha_id=$(grep "alpha.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
   [ -f "$CALLER_PWD/notes/$alpha_id" ]
 
-  # Create a stale readable copy (simulates bad commit state)
-  echo "stale content" > "$CALLER_PWD/notes/alpha.md"
+  echo "local edit" > "$CALLER_PWD/notes/alpha.md"
 
-  # Deobfuscate should overwrite the stale copy, not fail
   run notes deobfuscate
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"refusing to overwrite dirty readable note"* ]]
+  [[ "$output" == *"alpha.md"* ]]
+
+  # Neither side should be destroyed on refusal.
+  [ -f "$CALLER_PWD/notes/$alpha_id" ]
+  [ -f "$CALLER_PWD/notes/alpha.md" ]
+  [[ "$(cat "$CALLER_PWD/notes/alpha.md")" == "local edit" ]]
+}
+
+@test "deobfuscate refuses dirty readable note with recorded base hash" {
+  notes obfuscate
+  local alpha_id
+  alpha_id=$(grep "alpha.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
+  git -C "$CALLER_PWD" add -A notes
+  git -C "$CALLER_PWD" commit -q -m "obfuscate"
+
+  notes deobfuscate
+  echo "local edit" >> "$CALLER_PWD/notes/alpha.md"
+
+  # Simulate unlock/pull restoring the obfuscated source while the readable
+  # file still exists with local edits.
+  git -C "$CALLER_PWD" update-index --no-assume-unchanged "notes/$alpha_id" 2>/dev/null || true
+  git -C "$CALLER_PWD" checkout -- "notes/$alpha_id"
+
+  run notes deobfuscate
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"refusing to overwrite dirty readable note"* ]]
+  [[ "$(cat "$CALLER_PWD/notes/alpha.md")" == *"local edit"* ]]
+  [ -f "$CALLER_PWD/notes/$alpha_id" ]
+}
+
+@test "deobfuscate --force intentionally overwrites dirty readable note" {
+  notes obfuscate
+  local alpha_id
+  alpha_id=$(grep "alpha.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
+  [ -f "$CALLER_PWD/notes/$alpha_id" ]
+
+  echo "local edit" > "$CALLER_PWD/notes/alpha.md"
+
+  run notes deobfuscate -- --force
   [ "$status" -eq 0 ]
 
-  # Readable file has the authoritative content (from obfuscated copy)
   [ -f "$CALLER_PWD/notes/alpha.md" ]
   [[ "$(cat "$CALLER_PWD/notes/alpha.md")" == *"# Alpha"* ]]
-  [[ "$(cat "$CALLER_PWD/notes/alpha.md")" != *"stale"* ]]
+  [[ "$(cat "$CALLER_PWD/notes/alpha.md")" != *"local edit"* ]]
+}
+
+@test "deobfuscate allows identical readable note copy" {
+  notes obfuscate
+  local alpha_id
+  alpha_id=$(grep "alpha.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
+  [ -f "$CALLER_PWD/notes/$alpha_id" ]
+
+  cp "$CALLER_PWD/notes/$alpha_id" "$CALLER_PWD/notes/alpha.md"
+
+  run notes deobfuscate
+  [ "$status" -eq 0 ]
+  [ -f "$CALLER_PWD/notes/alpha.md" ]
+  [[ "$(cat "$CALLER_PWD/notes/alpha.md")" == *"# Alpha"* ]]
 }
 
 # ── Refuse re-obfuscation of already-hex-named files ──────────

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -4,6 +4,16 @@ if [ -z "${MISE_CONFIG_ROOT:-}" ]; then
   exit 1
 fi
 
+# Source lib files at file-load time, not inside setup(). Most .bats files in
+# this suite override setup() to set their own CALLER_PWD/fixtures, which
+# shadows the helper's setup() and silently drops the lib sources. Sourcing
+# at top level makes the helper functions available in every test body
+# regardless of which setup wins.
+source "$MISE_CONFIG_ROOT/lib/common.sh"
+source "$MISE_CONFIG_ROOT/lib/obfuscate.sh"
+source "$MISE_CONFIG_ROOT/lib/suppress.sh"
+source "$MISE_CONFIG_ROOT/lib/hooks.sh"
+
 # notes() wrapper — calls tasks via mise, just like real usage
 # Exported so subshells (e.g. bash -c pipes) can use it too.
 notes() {
@@ -30,8 +40,4 @@ setup() {
   mkdir -p "$TARGET_DIR"
   git -C "$TARGET_DIR" init -q
   export CALLER_PWD="$TARGET_DIR"
-  source "$MISE_CONFIG_ROOT/lib/common.sh"
-  source "$MISE_CONFIG_ROOT/lib/obfuscate.sh"
-  source "$MISE_CONFIG_ROOT/lib/suppress.sh"
-  source "$MISE_CONFIG_ROOT/lib/hooks.sh"
 }


### PR DESCRIPTION
## Summary

Fixes #58.

`notes deobfuscate` now refuses to overwrite a readable note when that readable file has local edits. `notes unlock` inherits the protection because it delegates to deobfuscation after `rudi unlock`.

## Design

- Record the content hash restored for each deobfuscated ID in `.git/info/notes-obfuscation-state`.
- On a later deobfuscation collision:
  - identical readable copy: allow
  - readable copy matching the last restored hash: allow update (important for clean pulls/post-merge hooks)
  - readable copy with local edits: refuse unless `--force`
- Add `--force` to `notes deobfuscate` and `notes unlock` for intentional overwrite.

This borrows the same UX stance modules already uses for clone targets: do not clobber user-owned local content by default; make the operator choose.

## Validation

- `mise run test -- test/obfuscate.bats test/git-operations.bats` — 72/72 pass
- `mise run test` — 216/216 pass
- Modules audit: no equivalent notes-style deobfuscation layer; `modules init` already refuses to clobber non-empty clone targets, and `modules update` relies on git checkout/pull refusing dirty module worktrees.
- Modules scoped smoke: `MISE_CONFIG_ROOT="$PWD" bats test/init.bats test/update.bats` — 12/12 pass

## Follow-up noticed during modules audit

`mise run test -- test/init.bats test/update.bats` in modules runs `bats test/ "$@"`, which duplicates tests and produced BATS temp-dir collisions. Direct `bats` invocation worked. Not part of this PR, but worth a small modules follow-up.
