### PR TITLE
Fix setup encrypted attribute token detection

### DIFF
--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -54,7 +54,11 @@ GITATTRIBUTES="$TARGET_DIR/.gitattributes"
 gitattributes_has_encrypted_pattern() {
   local pattern="$1"
   awk -v pattern="$pattern" '
-    $1 == pattern && /filter=git-crypt/ { found = 1 }
+    $1 == pattern {
+      for (i = 2; i <= NF; i++) {
+        if ($i == "filter=git-crypt") found = 1
+      }
+    }
     END { exit(found ? 0 : 1) }
   ' "$GITATTRIBUTES" 2>/dev/null
 }

--- a/test/encrypt.bats
+++ b/test/encrypt.bats
@@ -58,6 +58,17 @@ load test_helper
   grep -q "git-crypt" "$TARGET_DIR/.gitattributes"
 }
 
+@test "setup treats disabled filter attribute as missing encrypted pattern" {
+  git -C "$TARGET_DIR" crypt init
+  echo "notes/** -filter=git-crypt diff=git-crypt" > "$TARGET_DIR/.gitattributes"
+
+  run notes setup
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Configuring encrypted patterns"* ]]
+
+  grep -q "notes/\*\*.*filter=git-crypt" "$TARGET_DIR/.gitattributes"
+}
+
 @test "setup with custom patterns writes them to .gitattributes" {
   run notes setup -- --pattern "agents/*/Zettels/**" --pattern "notes/private/**"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Fix-it for #61.\n\nThe new setup helper matched /filter=git-crypt/ across the whole .gitattributes line, so an explicit disabled attribute like `notes/** -filter=git-crypt diff=git-crypt` was treated as already encrypted. This changes detection to require a literal `filter=git-crypt` attribute token and adds regression coverage.\n\nVerification:\n- `mise run test test/encrypt.bats test/obfuscate.bats`\n- `git diff --check`