### PR TITLE
Fix repeated setup pattern parsing

### DIFF
--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -60,7 +60,10 @@ gitattributes_has_encrypted_pattern() {
 }
 
 if [ -n "${usage_pattern:-}" ]; then
-  IFS=$'\n' read -r -d '' -a patterns <<< "$usage_pattern" || true
+  patterns=()
+  while IFS= read -r pattern; do
+    patterns+=("$pattern")
+  done < <(printf '%s' "$usage_pattern" | xargs printf '%s\n')
 else
   patterns=("notes/**")
 fi

--- a/test/encrypt.bats
+++ b/test/encrypt.bats
@@ -53,17 +53,16 @@ load test_helper
   run notes setup
   [ "$status" -eq 0 ]
 
-  grep -q "\.modules/manifest" "$TARGET_DIR/.gitattributes"
-  grep -q "notes/\*\*" "$TARGET_DIR/.gitattributes"
-  grep -q "git-crypt" "$TARGET_DIR/.gitattributes"
+  grep -Eq "^\.modules/manifest[[:space:]]+filter=git-crypt" "$TARGET_DIR/.gitattributes"
+  grep -Eq "^notes/\*\*[[:space:]]+filter=git-crypt" "$TARGET_DIR/.gitattributes"
 }
 
 @test "setup with custom patterns writes them to .gitattributes" {
   run notes setup -- --pattern "agents/*/Zettels/**" --pattern "notes/private/**"
   [ "$status" -eq 0 ]
 
-  grep -q "agents/\*/Zettels/\*\*" "$TARGET_DIR/.gitattributes"
-  grep -q "notes/private/\*\*" "$TARGET_DIR/.gitattributes"
+  grep -Eq "^agents/\*/Zettels/\*\*[[:space:]]+filter=git-crypt" "$TARGET_DIR/.gitattributes"
+  grep -Eq "^notes/private/\*\*[[:space:]]+filter=git-crypt" "$TARGET_DIR/.gitattributes"
 }
 
 @test "setup installs pre-commit hooks" {


### PR DESCRIPTION
Fix-it for #61.

The setup task was treating repeated `--pattern` values as one shell-quoted string, so `rudi assign` wrote one malformed `.gitattributes` line. This parses the mise variadic flag value before checking/assigning patterns and tightens the tests so the old malformed combined line fails.

Verification: `mise run test`
