### PR TITLE
fix: preserve encrypted manifest during rebase

### DIFF
--- a/.mise/tasks/install-hooks
+++ b/.mise/tasks/install-hooks
@@ -9,11 +9,13 @@ require_git
 
 notes_dir="${usage_dir:-notes}"
 
+install_encryption_hook
 install_obfuscation_hook "$notes_dir"
 install_deobfuscation_hook "$notes_dir"
 install_manifest_merge_driver "$notes_dir"
 
 echo "Installed hooks:"
+echo "  pre-commit.d/encryption — rejects plaintext staged encrypted files"
 echo "  pre-commit.d/obfuscation — auto-obfuscates staged readable names"
 echo "  post-commit.d/deobfuscation — restores readable names after commit"
 echo "  post-merge.d/deobfuscation — restores readable names after pull"

--- a/hooks/encryption
+++ b/hooks/encryption
@@ -13,7 +13,7 @@ encrypted_files=$(git-crypt status -e 2>/dev/null | awk '{print $2}' || true)
 
 while IFS= read -r file; do
   if echo "$encrypted_files" | grep -qxF "$file"; then
-    if git-crypt status "$file" 2>&1 | grep -q "not encrypted"; then
+    if { git-crypt status "$file" 2>&1 || true; } | grep -qi "not encrypted"; then
       bad_files+=("$file")
     fi
   fi

--- a/lib/manifest-merge-driver.sh
+++ b/lib/manifest-merge-driver.sh
@@ -43,12 +43,9 @@ trap 'rm -rf "$WORK"' EXIT
 # behavior: git then surfaces a merge conflict on the manifest, and the
 # user is forced to investigate rather than silently accepting a corrupted
 # merged manifest.
-decrypt_if_needed() {
-  local src="$1" dst="$2"
-  if [ ! -s "$src" ]; then
-    : > "$dst"
-    return 0
-  fi
+is_gitcrypt_file() {
+  local src="$1"
+  [ -s "$src" ] || return 1
   # git-crypt files begin with the 10-byte header \0 G I T C R Y P T \0.
   # Bash strings can't hold the leading \0 (it terminates the string), so
   # read bytes 2-9 and check they spell "GITCRYPT". Files shorter than 9
@@ -56,7 +53,16 @@ decrypt_if_needed() {
   # match, and we treat it as plaintext.
   local header
   header=$(dd if="$src" bs=1 skip=1 count=8 2>/dev/null)
-  if [ "$header" = "GITCRYPT" ]; then
+  [ "$header" = "GITCRYPT" ]
+}
+
+decrypt_if_needed() {
+  local src="$1" dst="$2"
+  if [ ! -s "$src" ]; then
+    : > "$dst"
+    return 0
+  fi
+  if is_gitcrypt_file "$src"; then
     if ! git-crypt smudge < "$src" > "$dst" 2>/dev/null; then
       echo "manifest-merge-driver: git-crypt smudge failed on $src — is the repo unlocked?" >&2
       echo "manifest-merge-driver: aborting merge to avoid producing a corrupt manifest." >&2
@@ -64,6 +70,19 @@ decrypt_if_needed() {
     fi
   else
     cp "$src" "$dst"
+  fi
+}
+
+write_success_result() {
+  local plaintext="$1"
+  if is_gitcrypt_file "$ANCESTOR" || is_gitcrypt_file "$OURS" || is_gitcrypt_file "$THEIRS"; then
+    if ! git-crypt clean < "$plaintext" > "$OURS" 2>/dev/null; then
+      echo "manifest-merge-driver: git-crypt clean failed — is this a git-crypt repo?" >&2
+      echo "manifest-merge-driver: aborting merge to avoid committing a plaintext manifest." >&2
+      return 1
+    fi
+  else
+    cp "$plaintext" "$OURS"
   fi
 }
 
@@ -153,12 +172,16 @@ while IFS= read -r name; do
   fi
 done < "$WORK/all_names"
 
-# Write result to OURS (git expects the merge result there)
-sort -t$'\t' -k2 "$WORK/merged" > "$OURS"
+# Write result to OURS (git expects the merge result there). On successful
+# git-crypt-backed merges, write encrypted output because rebase/custom-driver
+# paths can commit %A directly without running the clean filter again.
+sort -t$'\t' -k2 "$WORK/merged" > "$WORK/result"
 
 if [ "$has_conflict" = true ]; then
+  cp "$WORK/result" "$OURS"
   cat "$WORK/conflicts" >> "$OURS"
   exit 1
 else
+  write_success_result "$WORK/result"
   exit 0
 fi

--- a/test/git-operations.bats
+++ b/test/git-operations.bats
@@ -6,6 +6,13 @@
 
 load test_helper
 
+assert_gitcrypt_blob() {
+  local repo="$1" ref_path="$2"
+  local header
+  header=$(git -C "$repo" cat-file -p "$ref_path" | dd bs=1 skip=1 count=8 2>/dev/null)
+  [ "$header" = "GITCRYPT" ] || fail "expected encrypted blob at $ref_path"
+}
+
 # Override default setup — we need a remote + local pair, not a single repo.
 setup() {
   source "$MISE_CONFIG_ROOT/lib/common.sh"
@@ -259,4 +266,62 @@ setup() {
   # Manifest has all entries
   grep -q "feature.md" "$LOCAL/notes/.manifest"
   grep -q "other.md" "$LOCAL/notes/.manifest"
+}
+
+@test "rebase: git-crypt manifest stays encrypted in rebased commit" {
+  if ! command -v git-crypt >/dev/null; then
+    skip "git-crypt not installed"
+  fi
+
+  local repo="$BATS_TEST_TMPDIR/crypt-rebase"
+  mkdir -p "$repo/notes"
+  git -C "$repo" init -q -b main
+  git -C "$repo" config user.email "test@test.com"
+  git -C "$repo" config user.name "Test"
+  ( cd "$repo" && git-crypt init >/dev/null 2>&1 ) || skip "git-crypt init failed"
+
+  cat > "$repo/.gitattributes" <<'EOT'
+notes/** filter=git-crypt diff=git-crypt
+notes/.manifest merge=manifest
+EOT
+  cat > "$repo/notes/.manifest" <<'EOT'
+aaa00001	alpha.md
+EOT
+  echo "alpha" > "$repo/notes/aaa00001"
+  git -C "$repo" add .gitattributes notes/.manifest notes/aaa00001
+  git -C "$repo" commit -q -m "init"
+
+  CALLER_PWD="$repo" notes install-hooks >/dev/null
+
+  git -C "$repo" switch -q -c feature
+  cat > "$repo/notes/.manifest" <<'EOT'
+aaa00001	alpha.md
+bbb00001	beta.md
+EOT
+  echo "beta" > "$repo/notes/bbb00001"
+  git -C "$repo" add notes/.manifest notes/bbb00001
+  git -C "$repo" commit -q --no-verify -m "feature manifest"
+
+  git -C "$repo" switch -q main
+  cat > "$repo/notes/.manifest" <<'EOT'
+aaa00001	alpha.md
+ccc00001	gamma.md
+EOT
+  echo "gamma" > "$repo/notes/ccc00001"
+  git -C "$repo" add notes/.manifest notes/ccc00001
+  git -C "$repo" commit -q --no-verify -m "main manifest"
+
+  git -C "$repo" switch -q feature
+  run git -C "$repo" rebase main
+  [ "$status" -eq 0 ]
+
+  assert_gitcrypt_blob "$repo" "HEAD:notes/.manifest"
+  grep -qF "beta.md" "$repo/notes/.manifest"
+  grep -qF "gamma.md" "$repo/notes/.manifest"
+  [ -z "$(git -C "$repo" status --short)" ]
+
+  local merged_plain="$BATS_TEST_TMPDIR/crypt-rebase-merged"
+  git -C "$repo" cat-file -p HEAD:notes/.manifest | (cd "$repo" && git-crypt smudge) > "$merged_plain"
+  grep -qF "beta.md" "$merged_plain"
+  grep -qF "gamma.md" "$merged_plain"
 }

--- a/test/merge-driver.bats
+++ b/test/merge-driver.bats
@@ -18,6 +18,18 @@ make_manifest() {
   done
 }
 
+assert_gitcrypt_file() {
+  local file="$1"
+  local header
+  header=$(dd if="$file" bs=1 skip=1 count=8 2>/dev/null)
+  [ "$header" = "GITCRYPT" ] || fail "expected git-crypt output, got: $(head -c 20 "$file" | od -An -c)"
+}
+
+decrypt_gitcrypt_file() {
+  local encrypted="$1" plaintext="$2"
+  git-crypt smudge < "$encrypted" > "$plaintext"
+}
+
 setup() {
   export TARGET_DIR="$BATS_TEST_TMPDIR/test-repo"
   mkdir -p "$TARGET_DIR"
@@ -328,17 +340,18 @@ EOT
   # Expect successful merge (no conflict; union of additions)
   [ "$status" -eq 0 ]
 
-  # Result is written back to `ours` — and git will run the clean filter on
-  # it before writing to the index, so the driver must output PLAINTEXT.
-  local result_size
-  result_size=$(wc -c < "$encrypted_ours" | tr -d ' ')
-  [ "$result_size" -gt 0 ] || fail "driver wrote empty result — encrypted input not decrypted"
+  # Result is written back to `ours`. Successful encrypted-input merges must
+  # leave encrypted output because rebase/custom-driver paths can commit %A
+  # directly without running the clean filter again.
+  assert_gitcrypt_file "$encrypted_ours"
+  local merged_plain="$BATS_TEST_TMPDIR/merged_plain"
+  decrypt_gitcrypt_file "$encrypted_ours" "$merged_plain"
 
   # All three entries should be present (alpha from ancestor, gamma from ours, delta from theirs)
-  grep -qF "alpha.md" "$encrypted_ours" || fail "missing alpha.md: $(cat "$encrypted_ours")"
-  grep -qF "beta.md"  "$encrypted_ours" || fail "missing beta.md"
-  grep -qF "gamma.md" "$encrypted_ours" || fail "missing gamma.md"
-  grep -qF "delta.md" "$encrypted_ours" || fail "missing delta.md"
+  grep -qF "alpha.md" "$merged_plain" || fail "missing alpha.md: $(cat "$merged_plain")"
+  grep -qF "beta.md"  "$merged_plain" || fail "missing beta.md"
+  grep -qF "gamma.md" "$merged_plain" || fail "missing gamma.md"
+  grep -qF "delta.md" "$merged_plain" || fail "missing delta.md"
 }
 
 @test "merge driver: plaintext inputs (no git-crypt) still merge correctly" {
@@ -507,8 +520,11 @@ EOT
   run bash "$DRIVER" "$empty_anc" "$enc_ours" "$enc_theirs"
   [ "$status" -eq 0 ]
 
-  grep -qF "alpha.md" "$enc_ours" || fail "missing alpha.md"
-  grep -qF "beta.md"  "$enc_ours" || fail "missing beta.md"
+  assert_gitcrypt_file "$enc_ours"
+  local merged_plain="$BATS_TEST_TMPDIR/empty_anc_merged_plain"
+  decrypt_gitcrypt_file "$enc_ours" "$merged_plain"
+  grep -qF "alpha.md" "$merged_plain" || fail "missing alpha.md"
+  grep -qF "beta.md"  "$merged_plain" || fail "missing beta.md"
 }
 
 @test "merge driver: mixed encrypted + plaintext inputs merge normally" {
@@ -556,9 +572,12 @@ EOT
   run bash "$DRIVER" "$enc_anc" "$enc_ours" "$plain_theirs"
   [ "$status" -eq 0 ]
 
-  grep -qF "alpha.md" "$enc_ours" || fail "missing alpha.md"
-  grep -qF "gamma.md" "$enc_ours" || fail "missing gamma.md (from encrypted ours)"
-  grep -qF "delta.md" "$enc_ours" || fail "missing delta.md (from plaintext theirs)"
+  assert_gitcrypt_file "$enc_ours"
+  local merged_plain="$BATS_TEST_TMPDIR/mixed_merged_plain"
+  decrypt_gitcrypt_file "$enc_ours" "$merged_plain"
+  grep -qF "alpha.md" "$merged_plain" || fail "missing alpha.md"
+  grep -qF "gamma.md" "$merged_plain" || fail "missing gamma.md (from encrypted ours)"
+  grep -qF "delta.md" "$merged_plain" || fail "missing delta.md (from plaintext theirs)"
 }
 
 @test "merge driver: files shorter than 9 bytes are treated as plaintext" {

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -394,6 +394,28 @@ setup() {
   grep -q "manifest" "$CALLER_PWD/.git/hooks/pre-commit.d/obfuscation"
 }
 
+@test "encryption pre-commit hook rejects plaintext staged encrypted blobs" {
+  if ! command -v git-crypt >/dev/null; then
+    skip "git-crypt not installed"
+  fi
+
+  ( cd "$CALLER_PWD" && git-crypt init >/dev/null 2>&1 ) || skip "git-crypt init failed"
+  echo "notes/** filter=git-crypt diff=git-crypt" > "$CALLER_PWD/.gitattributes"
+  git -C "$CALLER_PWD" add .gitattributes
+  git -C "$CALLER_PWD" commit -q --no-verify -m "enable encryption"
+
+  notes install-hooks
+
+  local blob
+  blob=$(printf 'aaa00001\talpha.md\n' | git -C "$CALLER_PWD" hash-object -w --stdin)
+  git -C "$CALLER_PWD" update-index --add --cacheinfo 100644 "$blob" notes/.manifest
+
+  run git -C "$CALLER_PWD" commit -m "force plaintext manifest"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Staged files should be encrypted but are plaintext"* ]]
+  [[ "$output" == *"notes/.manifest"* ]]
+}
+
 @test "deobfuscate does not install hooks" {
   notes obfuscate
   git -C "$CALLER_PWD" add -A

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -383,11 +383,13 @@ setup() {
 
 # --- Hook installation ---
 
-@test "install-hooks installs obfuscation pre-commit hook" {
+@test "install-hooks installs pre-commit hooks" {
   notes install-hooks
 
   [ -x "$CALLER_PWD/.git/hooks/pre-commit" ]
   grep -q "Generic hook dispatcher" "$CALLER_PWD/.git/hooks/pre-commit"
+  [ -x "$CALLER_PWD/.git/hooks/pre-commit.d/encryption" ]
+  grep -q "git-crypt status" "$CALLER_PWD/.git/hooks/pre-commit.d/encryption"
   [ -x "$CALLER_PWD/.git/hooks/pre-commit.d/obfuscation" ]
   grep -q "manifest" "$CALLER_PWD/.git/hooks/pre-commit.d/obfuscation"
 }


### PR DESCRIPTION
## Summary

Fixes KnickKnackLabs/notes#77.

- Re-encrypt successful git-crypt-backed `.manifest` merge-driver output before returning it to Git.
- Keep conflict results plaintext/readable when the driver exits non-zero.
- Install the existing `pre-commit.d/encryption` guard from `notes install-hooks`.
- Add a rebase regression that asserts `HEAD:notes/.manifest` remains encrypted while the working tree stays readable/clean.

## Why

`git pull --rebase` can replay a manifest merge-driver result directly into the rebased commit. The driver already decrypted encrypted inputs, but it wrote plaintext back to `%A`; in the rebase path that produced a plaintext committed `notes/.manifest`.

## Validation

- `mise run test test/merge-driver.bats test/git-operations.bats test/obfuscate.bats`
- `mise run test`
- manual smoke: git-crypt rebase leaves `HEAD:notes/.manifest` encrypted, worktree manifest ASCII/readable, and `git status --short` clean
