### PR TITLE
fix: catch plaintext encrypted staged blobs

### DIFF
--- a/hooks/encryption
+++ b/hooks/encryption
@@ -13,7 +13,7 @@ encrypted_files=$(git-crypt status -e 2>/dev/null | awk '{print $2}' || true)
 
 while IFS= read -r file; do
   if echo "$encrypted_files" | grep -qxF "$file"; then
-    if git-crypt status "$file" 2>&1 | grep -q "not encrypted"; then
+    if { git-crypt status "$file" 2>&1 || true; } | grep -qi "not encrypted"; then
       bad_files+=("$file")
     fi
   fi

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -394,6 +394,28 @@ setup() {
   grep -q "manifest" "$CALLER_PWD/.git/hooks/pre-commit.d/obfuscation"
 }
 
+@test "encryption pre-commit hook rejects plaintext staged encrypted blobs" {
+  if ! command -v git-crypt >/dev/null; then
+    skip "git-crypt not installed"
+  fi
+
+  ( cd "$CALLER_PWD" && git-crypt init >/dev/null 2>&1 ) || skip "git-crypt init failed"
+  echo "notes/** filter=git-crypt diff=git-crypt" > "$CALLER_PWD/.gitattributes"
+  git -C "$CALLER_PWD" add .gitattributes
+  git -C "$CALLER_PWD" commit -q --no-verify -m "enable encryption"
+
+  notes install-hooks
+
+  local blob
+  blob=$(printf 'aaa00001\talpha.md\n' | git -C "$CALLER_PWD" hash-object -w --stdin)
+  git -C "$CALLER_PWD" update-index --add --cacheinfo 100644 "$blob" notes/.manifest
+
+  run git -C "$CALLER_PWD" commit -m "force plaintext manifest"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Staged files should be encrypted but are plaintext"* ]]
+  [[ "$output" == *"notes/.manifest"* ]]
+}
+
 @test "deobfuscate does not install hooks" {
   notes obfuscate
   git -C "$CALLER_PWD" add -A


### PR DESCRIPTION
Fix-it for #79.

The encryption pre-commit hook currently misses the exact plaintext-index warning shape from git-crypt because `git-crypt status <file>` exits non-zero under `pipefail`, and the warning says `NOT ENCRYPTED` uppercase. This makes `notes install-hooks` install a guard that does not actually reject forced plaintext blobs.

Changes:
- ignore the status command's non-zero warning exit while still grepping its output
- match `not encrypted` case-insensitively
- add a regression that forces a plaintext blob into the index for an encrypted manifest path and verifies commit rejection

Verified: `mise run test test/merge-driver.bats test/git-operations.bats test/obfuscate.bats`.
