### PR TITLE
feat(stage): require explicit file argument(s) — closes #45

### DIFF
--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -2,7 +2,7 @@
 #MISE description="Stage notes for commit (bypasses exclude)"
 #USAGE flag "--dir <dir>" help="Notes directory relative to repo root (default: notes)"
 #USAGE flag "--dry-run" help="Show what would be staged without doing it"
-#USAGE arg "[files]..." help="Specific notes to stage (readable names, relative to notes dir). Omit to stage modified/deleted only; new notes require explicit files."
+#USAGE arg "<files>..." help="Specific notes to stage (readable names, relative to notes dir). At least one file argument is required; use shell globs (e.g. notes/*.md) to stage multiple."
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
@@ -27,6 +27,20 @@ if [ -n "${usage_files:-}" ]; then
   done < <(printf '%s' "${usage_files}" | xargs printf '%s\n')
 fi
 
+# Require explicit file argument(s); see KKL/notes#45.
+if [ ${#ARGS[@]} -eq 0 ] || [ -z "${ARGS[0]:-}" ]; then
+  cat >&2 <<EOF
+error: notes stage requires explicit file argument(s)
+
+Usage:
+  notes stage <file>...          # stage specific notes
+  notes stage $notes_dir/*.md         # stage all dirty notes via shell glob
+
+See 'notes changes' to list dirty notes.
+EOF
+  exit 2
+fi
+
 # Detect changes
 changes=$(detect_changes "$abs_notes_dir") || true
 
@@ -35,46 +49,23 @@ if [ -z "$changes" ]; then
   exit 0
 fi
 
-# Filter and collect files to stage. With no explicit file arguments, stage only
-# modifications/deletions (git add -u semantics). New notes must be staged
-# explicitly so stale readable files left by a different branch cannot silently
-# enter the next commit.
-explicit_files=false
-if [ ${#ARGS[@]} -gt 0 ] && [ -n "${ARGS[0]}" ]; then
-  explicit_files=true
-fi
+# Filter and collect files to stage. Each invocation names its files
+# explicitly (validated above); silently no-op for args that aren't in
+# the changes set so shell globs like `notes stage notes/*.md` work
+# cleanly even when most matched files are clean.
 
 to_stage=()
-skipped_new=()
-
-print_skipped_new() {
-  [ ${#skipped_new[@]} -eq 0 ] && return 0
-
-  echo "Skipped ${#skipped_new[@]} new note(s). Stage explicitly with: notes stage <file>"
-  for relpath in "${skipped_new[@]}"; do
-    echo "  new: $relpath"
-  done
-}
 
 while IFS=$'\t' read -r status relpath; do
-  if $explicit_files; then
-    match=false
-    for f in "${ARGS[@]}"; do
-      [ "$f" = "$relpath" ] && match=true && break
-    done
-    $match || continue
-  fi
+  match=false
+  for f in "${ARGS[@]}"; do
+    [ "$f" = "$relpath" ] && match=true && break
+  done
+  $match || continue
 
   case "$status" in
-    modified)
+    modified|new)
       to_stage+=("$relpath")
-      ;;
-    new)
-      if $explicit_files; then
-        to_stage+=("$relpath")
-      else
-        skipped_new+=("$relpath")
-      fi
       ;;
     deleted)
       # For deleted notes, we need to remove the obfuscated file from the index
@@ -84,8 +75,7 @@ while IFS=$'\t' read -r status relpath; do
 done <<< "$changes"
 
 if [ ${#to_stage[@]} -eq 0 ]; then
-  echo "No changes to stage."
-  print_skipped_new
+  echo "No matching changes to stage."
   exit 0
 fi
 
@@ -94,7 +84,6 @@ if [ "${usage_dry_run:-}" = "true" ]; then
   for relpath in "${to_stage[@]}"; do
     echo "  $relpath"
   done
-  print_skipped_new
   exit 0
 fi
 
@@ -120,4 +109,3 @@ done
 
 echo ""
 echo "Staged $staged file(s). Run 'git commit' to commit."
-print_skipped_new

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -263,19 +263,30 @@ setup() {
   [[ "$output" == *"alpha.md"* ]]
 }
 
-@test "notes stage: no args skips new notes but stages modified notes" {
+@test "notes stage: bare invocation errors with usage hint" {
+  # Per KKL/notes#45.
   echo "# Alpha modified" > "$CALLER_PWD/notes/alpha.md"
   echo "# Gamma" > "$CALLER_PWD/notes/gamma.md"
 
   run notes stage
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"requires explicit file argument"* ]]
+  [[ "$output" == *"notes stage <file>"* ]]
+
+  # No side effect: index must remain empty.
+  run git -C "$CALLER_PWD" diff --cached --name-only
+  [ -z "$output" ]
+}
+
+@test "notes stage: explicit file stages a modified note" {
+  echo "# Alpha modified" > "$CALLER_PWD/notes/alpha.md"
+
+  run notes stage alpha.md
   [ "$status" -eq 0 ]
   [[ "$output" == *"staged: alpha.md"* ]]
-  [[ "$output" == *"Skipped 1 new note(s)"* ]]
-  [[ "$output" == *"new: gamma.md"* ]]
 
   run git -C "$CALLER_PWD" diff --cached --name-only
   [[ "$output" == *"notes/alpha.md"* ]]
-  [[ "$output" != *"notes/gamma.md"* ]]
 }
 
 @test "notes stage: explicit file stages a new note" {
@@ -289,7 +300,37 @@ setup() {
   [[ "$output" == *"notes/gamma.md"* ]]
 }
 
-@test "notes stage: no args skips readable files left from another branch" {
+@test "notes stage: multiple explicit files stage in one call" {
+  echo "# Alpha modified" > "$CALLER_PWD/notes/alpha.md"
+  echo "# Gamma" > "$CALLER_PWD/notes/gamma.md"
+
+  run notes stage alpha.md gamma.md
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"staged: alpha.md"* ]]
+  [[ "$output" == *"staged: gamma.md"* ]]
+
+  run git -C "$CALLER_PWD" diff --cached --name-only
+  [[ "$output" == *"notes/alpha.md"* ]]
+  [[ "$output" == *"notes/gamma.md"* ]]
+}
+
+@test "notes stage: arg not in change set is silently no-op (supports shell globs)" {
+  # Simulates `notes stage notes/*.md`: task filters clean args so globs work.
+  echo "# Alpha modified" > "$CALLER_PWD/notes/alpha.md"
+  # beta.md is unchanged; passed as a simulated-glob arg.
+  echo "# Beta" > "$CALLER_PWD/notes/beta.md"
+  git -C "$CALLER_PWD" add -f "$CALLER_PWD/notes/beta.md"
+  git -C "$CALLER_PWD" commit -q -m "add beta"
+
+  run notes stage alpha.md beta.md
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"staged: alpha.md"* ]]
+  [[ "$output" != *"staged: beta.md"* ]]
+}
+
+@test "notes stage: errors with helpful message even when readable files left from another branch" {
+  # Regression: branch checkout leaves readable files for unowned notes;
+  # bare stage must error safely rather than heuristically skip.
   local repo="$BATS_TEST_TMPDIR/branch-repo"
   mkdir -p "$repo/notes"
   git -C "$repo" init -q -b main
@@ -317,17 +358,20 @@ setup() {
   echo "alpha edit" >> "$repo/notes/alpha.md"
 
   CALLER_PWD="$repo" run notes stage
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"requires explicit file argument"* ]]
+
+  CALLER_PWD="$repo" run notes stage alpha.md
   [ "$status" -eq 0 ]
   [[ "$output" == *"staged: alpha.md"* ]]
-  [[ "$output" == *"Skipped 1 new note(s)"* ]]
-  [[ "$output" == *"new: beta.md"* ]]
 
   run git -C "$repo" diff --cached --name-only
   [[ "$output" == *"notes/alpha.md"* ]]
   [[ "$output" != *"notes/beta.md"* ]]
 }
 
-@test "notes stage: skipped new manifest entry does not leak through pre-commit hook" {
+@test "notes stage: explicit-args path does not leak unrelated manifest entries through pre-commit hook" {
+  # Regression: stale manifest entry for unstaged note must not enter the commit.
   source "$MISE_CONFIG_ROOT/lib/hooks.sh"
   install_obfuscation_hook
   install_deobfuscation_hook
@@ -336,11 +380,10 @@ setup() {
   printf 'cccccccc\tgamma.md\n' >> "$MANIFEST"
   echo "# Alpha modified" > "$CALLER_PWD/notes/alpha.md"
 
-  run notes stage
+  run notes stage alpha.md
   [ "$status" -eq 0 ]
   [[ "$output" == *"staged: alpha.md"* ]]
-  [[ "$output" == *"Skipped 1 new note(s)"* ]]
-  [[ "$output" == *"new: gamma.md"* ]]
+  [[ "$output" != *"staged: gamma.md"* ]]
 
   git -C "$CALLER_PWD" commit -q -m "update alpha"
 


### PR DESCRIPTION
Closes #45.

## What

Bare `notes stage` previously staged all modified+deleted notes (skipping new files). This change requires explicit file argument(s); bare invocation exits 2 with a usage hint pointing at `notes changes`.

```
$ notes stage
error: notes stage requires explicit file argument(s)

Usage:
  notes stage <file>...          # stage specific notes
  notes stage notes/*.md         # stage all dirty notes via shell glob

See 'notes changes' to list dirty notes.
```

Shell globs work cleanly: args not in the change set are silently filtered, so `notes stage notes/*.md` stages just the dirty ones.

## Why

Per #45: bare invocation was a footgun for accumulated changes (it could silently stage unrelated dirty notes). Required explicit args makes the commit content known at call time, which (as a bonus) makes per-commit graph-delta analytics tractable downstream — see #81.

## Tests

`test/changes.bats` updated:
- Replaced bare-stage behavior tests with explicit-args coverage.
- Added: bare invocation errors with usage hint (no side effect on index).
- Added: multiple explicit files in one call.
- Added: clean args from shell-glob expansion are silently filtered.
- Carried forward the pre-commit-hook-leak regression against the explicit-args path.

Full suite green: 220 pass + 3 expected skips, no regressions.

## Context

Multi-session plan note in fold: `notes/notes-graph-and-commit-discipline.md`. This is Slice 1; subsequent slices (audit extension #81 part 3, graph metrics at commit time #81 parts 1+2, eventual stage→commit rename) build on it.
