### PR TITLE
Confirm destructive setup and lock tasks

### DIFF
--- a/.mise/tasks/lock
+++ b/.mise/tasks/lock
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Lock encrypted files (re-encrypt on disk)"
-#USAGE flag "-k --key <name>" help="Lock only this named key's files (default: lock all)"
+#USAGE flag "-y --yes" default=#false help="Skip confirmation prompt"
+#USAGE flag "-k --key <name>" default="" help="Lock only this named key's files (default: lock all)"
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
@@ -9,6 +10,12 @@ require_initialized
 require_rudi
 
 cd "$TARGET_DIR"
+
+if [ -n "${usage_key:-}" ]; then
+  confirm_destructive "notes lock will obfuscate/stage notes and re-encrypt encrypted files for key '$usage_key' in this repo. Continue?"
+else
+  confirm_destructive "notes lock will obfuscate/stage notes and re-encrypt all git-crypt files in this repo. Continue?"
+fi
 
 # Obfuscate filenames before locking if currently deobfuscated.
 # The committed state should always be obfuscated — deobfuscation

--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -2,7 +2,8 @@
 #MISE description="Initialize encryption in the current repo"
 #USAGE flag "-y --yes" default=#false help="Skip confirmation prompt"
 #USAGE flag "--gpg-key <fingerprint>" var=#true default="" help="GPG key fingerprint(s) to add as collaborators"
-#USAGE flag "--pattern <pattern>" var=#true default="" help="Gitattributes patterns to encrypt (default: notes/**)"
+#USAGE flag "--pattern <pattern>" var=#true default="" help="Gitattributes patterns to encrypt (default: <dir>/**)"
+#USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root"
 #USAGE flag "--unlock" default=#false help="Unlock after setup (for joining an existing repo)"
 set -eo pipefail
 
@@ -14,7 +15,9 @@ require_rudi
 # Ensure rudi operates on the target repo (shiv shims set CALLER_PWD=$PWD)
 cd "$TARGET_DIR"
 
-setup_confirmation_message="notes setup will initialize/update git-crypt, .gitattributes, notes/.manifest, and notes git hooks in this repo."
+NOTES_DIR="${usage_dir:-notes}"
+
+setup_confirmation_message="notes setup will initialize/update git-crypt, .gitattributes, $NOTES_DIR/.manifest, and git hooks for $NOTES_DIR/ in this repo."
 if [ "${usage_unlock:-false}" = "true" ]; then
   setup_confirmation_message="$setup_confirmation_message It will also unlock/decrypt all git-crypt files after setup."
 fi
@@ -82,7 +85,7 @@ if [ -n "${usage_pattern:-}" ]; then
   done < <(printf '%s' "$usage_pattern" | xargs printf '%s\n')
 fi
 if [ ${#patterns[@]} -eq 0 ]; then
-  patterns=("notes/**")
+  patterns=("$NOTES_DIR/**")
 fi
 
 missing_patterns=()
@@ -112,7 +115,6 @@ else
 fi
 
 # --- Bootstrap obfuscation manifest ---
-NOTES_DIR="notes"
 if [ ! -f "$TARGET_DIR/$NOTES_DIR/.manifest" ]; then
   mkdir -p "$TARGET_DIR/$NOTES_DIR"
   touch "$TARGET_DIR/$NOTES_DIR/.manifest"

--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 #MISE description="Initialize encryption in the current repo"
-#USAGE flag "--gpg-key <fingerprint>" var=#true help="GPG key fingerprint(s) to add as collaborators"
-#USAGE flag "--pattern <pattern>" var=#true help="Gitattributes patterns to encrypt (default: notes/**)"
-#USAGE flag "--unlock" help="Unlock after setup (for joining an existing repo)"
+#USAGE flag "-y --yes" default=#false help="Skip confirmation prompt"
+#USAGE flag "--gpg-key <fingerprint>" var=#true default="" help="GPG key fingerprint(s) to add as collaborators"
+#USAGE flag "--pattern <pattern>" var=#true default="" help="Gitattributes patterns to encrypt (default: notes/**)"
+#USAGE flag "--unlock" default=#false help="Unlock after setup (for joining an existing repo)"
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
@@ -13,6 +14,12 @@ require_rudi
 # Ensure rudi operates on the target repo (shiv shims set CALLER_PWD=$PWD)
 cd "$TARGET_DIR"
 
+setup_confirmation_message="notes setup will initialize/update git-crypt, .gitattributes, notes/.manifest, and notes git hooks in this repo."
+if [ "${usage_unlock:-false}" = "true" ]; then
+  setup_confirmation_message="$setup_confirmation_message It will also unlock/decrypt all git-crypt files after setup."
+fi
+confirm_destructive "$setup_confirmation_message Continue?"
+
 # --- Initialize via rudi ---
 if is_initialized || [ -d "$TARGET_DIR/.git/git-crypt" ]; then
   echo "git-crypt already initialized — updating auxiliary files..."
@@ -22,14 +29,19 @@ else
 fi
 
 # --- Add GPG keys via rudi ---
+keys=()
 if [ -n "${usage_gpg_key:-}" ]; then
+  while IFS= read -r key; do
+    [ -n "$key" ] && keys+=("$key")
+  done < <(printf '%s' "$usage_gpg_key" | xargs printf '%s\n')
+fi
+
+if [ ${#keys[@]} -gt 0 ]; then
   echo ""
   echo "Adding GPG collaborators..."
 
-  IFS=$'\n' read -r -d '' -a keys <<< "$usage_gpg_key" || true
   skipped=0
   for key in "${keys[@]}"; do
-    [ -z "$key" ] && continue
     if gpg --list-keys "$key" &>/dev/null; then
       uid=$(gpg --list-keys --with-colons "$key" 2>/dev/null \
         | awk -F: '/^uid/{print $10; exit}')
@@ -63,12 +75,13 @@ gitattributes_has_encrypted_pattern() {
   ' "$GITATTRIBUTES" 2>/dev/null
 }
 
+patterns=()
 if [ -n "${usage_pattern:-}" ]; then
-  patterns=()
   while IFS= read -r pattern; do
-    patterns+=("$pattern")
+    [ -n "$pattern" ] && patterns+=("$pattern")
   done < <(printf '%s' "$usage_pattern" | xargs printf '%s\n')
-else
+fi
+if [ ${#patterns[@]} -eq 0 ]; then
   patterns=("notes/**")
 fi
 
@@ -99,7 +112,7 @@ else
 fi
 
 # --- Bootstrap obfuscation manifest ---
-NOTES_DIR="${usage_dir:-notes}"
+NOTES_DIR="notes"
 if [ ! -f "$TARGET_DIR/$NOTES_DIR/.manifest" ]; then
   mkdir -p "$TARGET_DIR/$NOTES_DIR"
   touch "$TARGET_DIR/$NOTES_DIR/.manifest"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,85 @@
+# notes
+
+**Collective memory, encrypted.**
+
+`notes` is a small CLI for keeping Markdown notes in a Git repo while protecting the private parts with `git-crypt`. It handles the boring-but-dangerous edges around encryption setup, collaborator keys, filename obfuscation, and staging files that Git would otherwise hide from you.
+
+The shape is intentionally simple: write normal Markdown in `notes/`, let the tool keep encrypted filenames safe for GitHub, and use explicit commands when crossing encryption boundaries.
+
+## Quick start
+
+```sh
+# One-time setup in a Git repo. This mutates encryption config and hooks.
+notes setup --yes
+
+# Add a note with YAML frontmatter.
+notes new --slug project-plan --title "Project plan" --tags planning
+
+# See note metadata.
+notes list
+
+# Check encryption + obfuscation state.
+notes status
+
+# Stage changed notes through notes' obfuscation/exclude rules.
+notes stage notes/project-plan.md
+```
+
+For an existing encrypted repo:
+
+```sh
+notes setup --yes --unlock
+notes status
+```
+
+## Daily workflow
+
+```sh
+# Show note changes against HEAD.
+notes changes
+notes changes --summary
+
+# Stage modified/deleted notes. New notes should be explicit.
+notes stage
+notes stage notes/new-note.md
+
+# Re-encrypt local files before handoff or archival.
+notes lock --yes
+
+# Decrypt again when you need to work locally.
+notes unlock
+```
+
+`setup` and `lock` require confirmation because they mutate repository encryption state. In automation, pass `--yes` explicitly.
+
+## What notes manages
+
+- **Encryption setup** — initializes `git-crypt` through `rudi`, configures `.gitattributes`, and installs hooks.
+- **Collaborator access** — adds GPG keys to the repo's encrypted key material.
+- **Filename obfuscation** — stores notes with opaque filenames in Git while restoring readable names locally.
+- **Manifest merging** — uses a custom merge driver for `notes/.manifest` so concurrent note additions can merge cleanly.
+- **Safe staging** — stages notes despite local exclude/assume-unchanged rules used for readable working copies.
+
+## Important gotchas
+
+- `notes lock` currently re-encrypts **all git-crypt files in the repo**, not just `notes/` files. This is a `rudi` limitation tracked separately.
+- Use `notes stage` for notes, not raw `git add notes/`; readable note names are intentionally excluded locally.
+- After pulling shared note repos, inspect `notes status` and `notes changes --summary` before committing follow-up changes.
+
+## Development
+
+```sh
+gh repo clone KnickKnackLabs/notes
+cd notes
+mise trust
+mise install
+mise run test
+```
+
+The test suite is BATS-based. Target a subset with:
+
+```sh
+mise run test test/encrypt.bats test/integration.bats
+```
+
+Tiny encrypted filing cabinet, very serious about labels.

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -10,8 +10,11 @@
 # The target repo is always CALLER_PWD (set by shiv shim)
 TARGET_DIR="${CALLER_PWD:-.}"
 
-# Where the hook source files live (in the notes repo)
-HOOKS_DIR="${MISE_CONFIG_ROOT}/hooks"
+# Locate repo resources from this library file, not from MISE_CONFIG_ROOT.
+# MISE_CONFIG_ROOT is task-scoped and can be stale when libs are sourced by tests.
+NOTES_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NOTES_REPO_DIR="$(cd "$NOTES_LIB_DIR/.." && pwd)"
+HOOKS_DIR="$NOTES_REPO_DIR/hooks"
 
 # ── Require checks ────────────────────────────────────────────
 
@@ -38,6 +41,47 @@ require_initialized() {
     echo "Error: git-crypt not initialized. Run: notes setup" >&2
     exit 1
   fi
+}
+
+# ── Confirmation helpers ─────────────────────────────────────
+
+is_truthy() {
+  case "${1:-}" in
+    true|1|yes|y) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+confirm_destructive() {
+  local message="$1"
+  local tty_path="${NOTES_CONFIRM_TTY:-/dev/tty}"
+  local answer=""
+
+  if is_truthy "${usage_yes:-false}" || is_truthy "${NOTES_YES:-}" || is_truthy "${MISE_YES:-}"; then
+    return 0
+  fi
+
+  if [ ! -c "$tty_path" ] || ! { exec 3<"$tty_path"; exec 4>"$tty_path"; } 2>/dev/null; then
+    { exec 3<&-; exec 4>&-; } 2>/dev/null
+    echo "Error: confirmation required for destructive operation." >&2
+    echo "$message" >&2
+    echo "Re-run with --yes to confirm." >&2
+    return 2
+  fi
+
+  printf '%s [y/N] ' "$message" >&4
+  if ! IFS= read -r answer <&3; then
+    answer=""
+  fi
+  exec 3<&- 4>&-
+
+  case "$answer" in
+    y|Y|yes|YES) return 0 ;;
+    *)
+      echo "Aborted." >&2
+      return 2
+      ;;
+  esac
 }
 
 # ── Path helpers ────────────────────────────────────────────

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -10,8 +10,6 @@
 # The target repo is always CALLER_PWD (set by shiv shim)
 TARGET_DIR="${CALLER_PWD:-.}"
 
-# Locate repo resources from this library file, not from MISE_CONFIG_ROOT.
-# MISE_CONFIG_ROOT is task-scoped and can be stale when libs are sourced by tests.
 NOTES_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NOTES_REPO_DIR="$(cd "$NOTES_LIB_DIR/.." && pwd)"
 HOOKS_DIR="$NOTES_REPO_DIR/hooks"
@@ -61,19 +59,25 @@ confirm_destructive() {
     return 0
   fi
 
-  if [ ! -c "$tty_path" ] || ! { exec 3<"$tty_path"; exec 4>"$tty_path"; } 2>/dev/null; then
-    { exec 3<&-; exec 4>&-; } 2>/dev/null
+  if [ ! -c "$tty_path" ] || ! { : <"$tty_path"; } 2>/dev/null || ! { : >"$tty_path"; } 2>/dev/null; then
     echo "Error: confirmation required for destructive operation." >&2
     echo "$message" >&2
     echo "Re-run with --yes to confirm." >&2
     return 2
   fi
 
-  printf '%s [y/N] ' "$message" >&4
-  if ! IFS= read -r answer <&3; then
+  if command -v gum >/dev/null 2>&1; then
+    if gum confirm "$message" <"$tty_path" >"$tty_path" 2>"$tty_path"; then
+      return 0
+    fi
+    echo "Aborted." >&2
+    return 2
+  fi
+
+  { printf '%s [y/N] ' "$message" >"$tty_path"; } 2>/dev/null
+  if ! IFS= read -r answer <"$tty_path"; then
     answer=""
   fi
-  exec 3<&- 4>&-
 
   case "$answer" in
     y|Y|yes|YES) return 0 ;;

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # hooks.sh — Git hook installation helpers
 
+HOOKS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOKS_REPO_DIR="$(cd "$HOOKS_LIB_DIR/.." && pwd)"
+
 # Ensure a hook dispatcher is installed for the given hook type.
 # Usage: ensure_hook_dispatcher <pre-commit|post-commit|post-merge>
 ensure_hook_dispatcher() {
@@ -39,7 +42,7 @@ install_obfuscation_hook() {
 # Configures git to use our custom merge driver for .manifest files.
 install_manifest_merge_driver() {
   local notes_dir="${1:-notes}"
-  local driver_path="$MISE_CONFIG_ROOT/lib/manifest-merge-driver.sh"
+  local driver_path="$HOOKS_REPO_DIR/lib/manifest-merge-driver.sh"
   local gitattributes="$TARGET_DIR/.gitattributes"
 
   # Register the merge driver in git config

--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,7 @@ shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 
 [tools]
 bats = "1.13.0"
+gum = "0.17.0"
 "aqua:shenwei356/rush" = "0.9.0"
 "shiv:rudi" = "0.5.1"
 # git-crypt has no macOS binary on GitHub releases.

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -6,10 +6,10 @@ load test_helper
 
 setup() {
   export CALLER_PWD="$BATS_TEST_TMPDIR"
-  source "$MISE_CONFIG_ROOT/lib/common.sh"
-  source "$MISE_CONFIG_ROOT/lib/obfuscate.sh"
-  source "$MISE_CONFIG_ROOT/lib/suppress.sh"
-  source "$MISE_CONFIG_ROOT/lib/changes.sh"
+  source "$REPO_DIR/lib/common.sh"
+  source "$REPO_DIR/lib/obfuscate.sh"
+  source "$REPO_DIR/lib/suppress.sh"
+  source "$REPO_DIR/lib/changes.sh"
 
   # Create a git repo with obfuscated notes
   git -C "$CALLER_PWD" init -q
@@ -328,7 +328,7 @@ setup() {
 }
 
 @test "notes stage: skipped new manifest entry does not leak through pre-commit hook" {
-  source "$MISE_CONFIG_ROOT/lib/hooks.sh"
+  source "$REPO_DIR/lib/hooks.sh"
   install_obfuscation_hook
   install_deobfuscation_hook
 
@@ -356,7 +356,7 @@ setup() {
 
 @test "full cycle: edit → stage → commit → clean status" {
   # Install hooks so post-commit deobfuscates
-  source "$MISE_CONFIG_ROOT/lib/hooks.sh"
+  source "$REPO_DIR/lib/hooks.sh"
   install_obfuscation_hook
   install_deobfuscation_hook
 

--- a/test/common.bats
+++ b/test/common.bats
@@ -7,10 +7,52 @@ load test_helper
 
 setup() {
   export CALLER_PWD="$BATS_TEST_TMPDIR"
-  source "$MISE_CONFIG_ROOT/lib/common.sh"
+  source "$REPO_DIR/lib/common.sh"
 
   mkdir -p "$CALLER_PWD/notes"
   MANIFEST="$CALLER_PWD/notes/.manifest"
+}
+
+# ── Confirmation helpers ─────────────────────────────────────
+
+@test "confirm_destructive accepts --yes flag" {
+  export usage_yes=true
+  run confirm_destructive "Danger?"
+  unset usage_yes
+  [ "$status" -eq 0 ]
+}
+
+@test "confirm_destructive accepts NOTES_YES" {
+  export NOTES_YES=1
+  run confirm_destructive "Danger?"
+  unset NOTES_YES
+  [ "$status" -eq 0 ]
+}
+
+@test "confirm_destructive accepts MISE_YES" {
+  export MISE_YES=yes
+  run confirm_destructive "Danger?"
+  unset MISE_YES
+  [ "$status" -eq 0 ]
+}
+
+@test "confirm_destructive requires exact truthy env approval" {
+  unset usage_yes MISE_YES
+  export NOTES_YES=TRUE
+  export NOTES_CONFIRM_TTY="$BATS_TEST_TMPDIR/missing-tty"
+  run confirm_destructive "Danger?"
+  unset NOTES_YES NOTES_CONFIRM_TTY
+  [ "$status" -eq 2 ]
+}
+
+@test "confirm_destructive refuses without tty or bypass" {
+  unset usage_yes NOTES_YES MISE_YES
+  export NOTES_CONFIRM_TTY="$BATS_TEST_TMPDIR/missing-tty"
+  run confirm_destructive "Danger?"
+  unset NOTES_CONFIRM_TTY
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"confirmation required"* ]]
+  [[ "$output" == *"Re-run with --yes"* ]]
 }
 
 # ── Manifest helpers ──────────────────────────────────────────

--- a/test/encrypt.bats
+++ b/test/encrypt.bats
@@ -76,6 +76,17 @@ load test_helper
   grep -Eq "^notes/private/\*\*[[:space:]]+filter=git-crypt" "$TARGET_DIR/.gitattributes"
 }
 
+@test "setup with custom dir writes manifest and default encrypted pattern there" {
+  run notes setup --yes --dir private-notes
+  [ "$status" -eq 0 ]
+
+  [ -f "$TARGET_DIR/private-notes/.manifest" ]
+  [ ! -f "$TARGET_DIR/notes/.manifest" ]
+  grep -Eq "^private-notes/\*\*[[:space:]]+filter=git-crypt" "$TARGET_DIR/.gitattributes"
+  grep -qF "private-notes/.manifest merge=manifest" "$TARGET_DIR/.gitattributes"
+  grep -q "private-notes" "$TARGET_DIR/.git/hooks/pre-commit.d/obfuscation"
+}
+
 @test "setup installs pre-commit hooks" {
   notes setup --yes
 

--- a/test/encrypt.bats
+++ b/test/encrypt.bats
@@ -16,7 +16,7 @@ load test_helper
 @test "require_git fails on non-git directory" {
   export CALLER_PWD="$BATS_TEST_TMPDIR/not-a-repo"
   mkdir -p "$CALLER_PWD"
-  source "$MISE_CONFIG_ROOT/lib/common.sh"
+  source "$REPO_DIR/lib/common.sh"
   run require_git
   [ "$status" -ne 0 ]
   [[ "$output" == *"not a git repository"* ]]
@@ -29,7 +29,7 @@ load test_helper
 }
 
 @test "setup writes .gitattributes with default pattern" {
-  run notes setup
+  run notes setup --yes
   [ "$status" -eq 0 ]
 
   [ -f "$TARGET_DIR/.gitattributes" ]
@@ -38,9 +38,9 @@ load test_helper
 }
 
 @test "setup is idempotent" {
-  notes setup
+  notes setup --yes
 
-  run notes setup
+  run notes setup --yes
   [ "$status" -eq 0 ]
   [[ "$output" == *"git-crypt already initialized — updating auxiliary files..."* ]]
   [[ "$output" == *"Requested encrypted patterns already configured"* ]]
@@ -50,7 +50,7 @@ load test_helper
   git -C "$TARGET_DIR" crypt init
   echo ".modules/manifest filter=git-crypt diff=git-crypt" > "$TARGET_DIR/.gitattributes"
 
-  run notes setup
+  run notes setup --yes
   [ "$status" -eq 0 ]
 
   grep -Eq "^\.modules/manifest[[:space:]]+filter=git-crypt" "$TARGET_DIR/.gitattributes"
@@ -61,7 +61,7 @@ load test_helper
   git -C "$TARGET_DIR" crypt init
   echo "notes/** -filter=git-crypt diff=git-crypt" > "$TARGET_DIR/.gitattributes"
 
-  run notes setup
+  run notes setup --yes
   [ "$status" -eq 0 ]
   [[ "$output" == *"Configuring encrypted patterns"* ]]
 
@@ -69,7 +69,7 @@ load test_helper
 }
 
 @test "setup with custom patterns writes them to .gitattributes" {
-  run notes setup -- --pattern "agents/*/Zettels/**" --pattern "notes/private/**"
+  run notes setup --yes --pattern "agents/*/Zettels/**" --pattern "notes/private/**"
   [ "$status" -eq 0 ]
 
   grep -Eq "^agents/\*/Zettels/\*\*[[:space:]]+filter=git-crypt" "$TARGET_DIR/.gitattributes"
@@ -77,7 +77,7 @@ load test_helper
 }
 
 @test "setup installs pre-commit hooks" {
-  notes setup
+  notes setup --yes
 
   # Dispatcher
   [ -x "$TARGET_DIR/.git/hooks/pre-commit" ]
@@ -91,10 +91,22 @@ load test_helper
 }
 
 @test "setup without keys does not add gpg users" {
-  notes setup
+  notes setup --yes
 
   # .git-crypt/keys/default/0/ only exists after first add-gpg-user
   [ ! -d "$TARGET_DIR/.git-crypt/keys/default/0" ]
+}
+
+@test "setup refuses without confirmation before mutation" {
+  run without_confirmation "$BATS_TEST_TMPDIR/missing-tty" notes setup
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"confirmation required"* ]]
+  [[ "$output" == *"Re-run with --yes"* ]]
+  [ ! -d "$TARGET_DIR/.git/git-crypt" ]
+  [ ! -d "$TARGET_DIR/.git-crypt" ]
+  [ ! -f "$TARGET_DIR/.gitattributes" ]
+  [ ! -f "$TARGET_DIR/notes/.manifest" ]
 }
 
 # --- verify tests ---
@@ -156,7 +168,7 @@ generate_test_key() {
 }
 
 @test "setup creates empty .manifest for obfuscation bootstrap" {
-  notes setup
+  notes setup --yes
 
   [ -f "$TARGET_DIR/notes/.manifest" ]
   [ ! -s "$TARGET_DIR/notes/.manifest" ]  # empty
@@ -166,7 +178,7 @@ generate_test_key() {
   mkdir -p "$TARGET_DIR/notes"
   printf 'aaa00001\texisting.md\n' > "$TARGET_DIR/notes/.manifest"
 
-  notes setup
+  notes setup --yes
 
   [ -f "$TARGET_DIR/notes/.manifest" ]
   grep -q "existing.md" "$TARGET_DIR/notes/.manifest"
@@ -175,7 +187,7 @@ generate_test_key() {
 # --- setup next-steps ---
 
 @test "setup shows unlock hint when repo has encrypted notes" {
-  notes setup
+  notes setup --yes
   mkdir -p "$TARGET_DIR/notes"
   echo -e "---\ntitle: Test\n---" > "$TARGET_DIR/notes/test.md"
   git -C "$TARGET_DIR" add -A
@@ -184,14 +196,14 @@ generate_test_key() {
   # Simulate encrypted notes by writing a GITCRYPT header
   printf '\x00GITCRYPT\x00' > "$TARGET_DIR/notes/test.md"
 
-  run notes setup
+  run notes setup --yes
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "notes unlock"
   echo "$output" | grep -q "already has encrypted notes"
 }
 
 @test "setup shows unlock hint even when first file is plaintext" {
-  notes setup
+  notes setup --yes
   mkdir -p "$TARGET_DIR/notes/archive"
   # Plaintext file at top level
   echo "readme" > "$TARGET_DIR/notes/README.md"
@@ -200,14 +212,14 @@ generate_test_key() {
   git -C "$TARGET_DIR" add -A
   git -C "$TARGET_DIR" commit -q -m "add notes"
 
-  run notes setup
+  run notes setup --yes
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "notes unlock"
   echo "$output" | grep -q "already has encrypted notes"
 }
 
 @test "setup shows standard next steps on fresh repo" {
-  run notes setup
+  run notes setup --yes
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "Commit the setup"
   # Should NOT mention unlock
@@ -218,7 +230,7 @@ generate_test_key() {
   # --unlock on a fresh repo (no GPG users) will fail at unlock
   # because there's nothing to decrypt. But setup should complete
   # and then attempt unlock.
-  run notes setup -- --unlock
+  run notes setup --yes --unlock
   # Verify setup completed before unlock was attempted
   echo "$output" | grep -q "Installed hooks"
   echo "$output" | grep -q "Unlocking"

--- a/test/git-operations.bats
+++ b/test/git-operations.bats
@@ -15,7 +15,7 @@ assert_gitcrypt_blob() {
 
 # Override default setup — we need a remote + local pair, not a single repo.
 setup() {
-  source "$MISE_CONFIG_ROOT/lib/common.sh"
+  source "$REPO_DIR/lib/common.sh"
 
   # Create a bare "remote" repo
   export REMOTE="$BATS_TEST_TMPDIR/remote.git"

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -16,7 +16,7 @@ setup() {
   git -C "$TARGET_DIR" config commit.gpgsign false
 
   export CALLER_PWD="$TARGET_DIR"
-  source "$MISE_CONFIG_ROOT/lib/common.sh"
+  source "$REPO_DIR/lib/common.sh"
 
   # Isolated GPG home
   export GNUPGHOME="$TEST_DIR/gpg"
@@ -40,7 +40,7 @@ generate_test_key() {
 # --- add-user ---
 
 @test "add-user adds collaborator via rudi" {
-  notes setup
+  notes setup --yes
 
   local fpr
   fpr=$(generate_test_key "$GNUPGHOME")
@@ -56,7 +56,7 @@ generate_test_key() {
 # --- lock / unlock round-trip ---
 
 @test "lock and unlock round-trip preserves file content" {
-  notes setup
+  notes setup --yes
 
   local fpr
   fpr=$(generate_test_key "$GNUPGHOME")
@@ -69,7 +69,7 @@ generate_test_key() {
   git -C "$TARGET_DIR" commit -q -m "Add encrypted note"
 
   # Lock
-  run notes lock
+  run notes lock --yes
   [ "$status" -eq 0 ]
 
   # File should not be readable as plaintext
@@ -83,10 +83,33 @@ generate_test_key() {
   grep -q "secret content" "$TARGET_DIR/notes/secret.md"
 }
 
+@test "lock refuses without confirmation before staging or obfuscating" {
+  notes setup --yes
+
+  local fpr
+  fpr=$(generate_test_key "$GNUPGHOME")
+  notes add-user -- --gpg-key "$fpr"
+
+  mkdir -p "$TARGET_DIR/notes"
+  echo "plain note" > "$TARGET_DIR/notes/plain.md"
+  git -C "$TARGET_DIR" add .
+  git -C "$TARGET_DIR" commit -q --no-verify -m "Add encrypted note"
+
+  run without_confirmation "$TEST_DIR/missing-tty" notes lock
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"confirmation required"* ]]
+  [[ "$output" == *"Re-run with --yes"* ]]
+  [ -f "$TARGET_DIR/notes/plain.md" ]
+  grep -q "plain note" "$TARGET_DIR/notes/plain.md"
+  ! grep -q "plain.md" "$TARGET_DIR/notes/.manifest"
+  [ -z "$(git -C "$TARGET_DIR" diff --cached --name-only)" ]
+}
+
 # --- status ---
 
 @test "status shows encryption info" {
-  notes setup
+  notes setup --yes
 
   local fpr
   fpr=$(generate_test_key "$GNUPGHOME")
@@ -101,7 +124,7 @@ generate_test_key() {
 
 @test "full workflow: setup → add-user → commit → lock → unlock → verify" {
   # 1. Setup with default pattern
-  run notes setup
+  run notes setup --yes
   [ "$status" -eq 0 ]
   [ -f "$TARGET_DIR/.gitattributes" ]
 
@@ -120,7 +143,7 @@ generate_test_key() {
   git -C "$TARGET_DIR" commit -q -m "Add files"
 
   # 4. Lock
-  notes lock
+  notes lock --yes
   ! grep -q "top secret" "$TARGET_DIR/notes/classified.md" 2>/dev/null
   ! grep -q "also secret" "$TARGET_DIR/notes/private.md" 2>/dev/null
   # Public file should be unaffected
@@ -142,7 +165,7 @@ generate_test_key() {
 # --- lock/unlock + obfuscation chaining ---
 
 setup_encrypted_repo_with_obfuscation() {
-  notes setup
+  notes setup --yes
 
   local fpr
   fpr=$(generate_test_key "$GNUPGHOME")
@@ -176,7 +199,7 @@ setup_encrypted_repo_with_obfuscation() {
   [ -f "$TARGET_DIR/notes/alpha.md" ]
   [ -f "$TARGET_DIR/notes/beta.md" ]
 
-  notes lock
+  notes lock --yes
 
   # Files should be obfuscated (hex IDs, not readable names)
   [ ! -f "$TARGET_DIR/notes/alpha.md" ]
@@ -190,7 +213,7 @@ setup_encrypted_repo_with_obfuscation() {
   skip "git-crypt lock rejects deobfuscated working tree (needs rudi --force)"
   setup_encrypted_repo_with_obfuscation
 
-  notes lock
+  notes lock --yes
   # Files are obfuscated + encrypted
   [ ! -f "$TARGET_DIR/notes/alpha.md" ]
 
@@ -207,7 +230,7 @@ setup_encrypted_repo_with_obfuscation() {
   skip "git-crypt lock rejects deobfuscated working tree (needs rudi --force)"
   setup_encrypted_repo_with_obfuscation
 
-  notes lock
+  notes lock --yes
   notes unlock
 
   grep -q "alpha content" "$TARGET_DIR/notes/alpha.md"
@@ -216,7 +239,7 @@ setup_encrypted_repo_with_obfuscation() {
 
 @test "unlock without manifest does not attempt deobfuscation" {
   # Plain encrypted repo, no obfuscation
-  notes setup
+  notes setup --yes
 
   local fpr
   fpr=$(generate_test_key "$GNUPGHOME")
@@ -227,7 +250,7 @@ setup_encrypted_repo_with_obfuscation() {
   git -C "$TARGET_DIR" add .
   git -C "$TARGET_DIR" commit -q -m "Add note"
 
-  notes lock
+  notes lock --yes
   run notes unlock
   [ "$status" -eq 0 ]
 
@@ -237,7 +260,7 @@ setup_encrypted_repo_with_obfuscation() {
 }
 
 @test "lock obfuscates when setup-created manifest exists" {
-  notes setup
+  notes setup --yes
 
   local fpr
   fpr=$(generate_test_key "$GNUPGHOME")
@@ -253,7 +276,7 @@ setup_encrypted_repo_with_obfuscation() {
   id=$(awk '$2 == "plain.md" { print $1 }' "$TARGET_DIR/notes/.manifest")
   [ -n "$id" ]
 
-  run notes lock
+  run notes lock --yes
   [ "$status" -eq 0 ]
 
   # setup creates .manifest, so lock should keep the committed obfuscated shape.

--- a/test/merge-driver.bats
+++ b/test/merge-driver.bats
@@ -6,7 +6,7 @@
 
 load test_helper
 
-DRIVER="$MISE_CONFIG_ROOT/lib/manifest-merge-driver.sh"
+DRIVER="$REPO_DIR/lib/manifest-merge-driver.sh"
 
 # Helper: create a manifest file from lines
 make_manifest() {
@@ -35,7 +35,7 @@ setup() {
   mkdir -p "$TARGET_DIR"
   git -C "$TARGET_DIR" init -q
   export CALLER_PWD="$TARGET_DIR"
-  source "$MISE_CONFIG_ROOT/lib/common.sh"
+  source "$REPO_DIR/lib/common.sh"
 
   # Temp files for ancestor/ours/theirs
   ANCESTOR="$BATS_TEST_TMPDIR/ancestor"

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -476,7 +476,7 @@ EOF
 # tests in control of when obfuscation happens.
 
 @test "pre-commit hook rejects un-obfuscated files in guard mode" {
-  notes setup
+  notes setup --yes
   git -C "$CALLER_PWD" add -A
   git -C "$CALLER_PWD" commit --no-verify -q -m "setup"
 
@@ -494,7 +494,7 @@ EOF
 }
 
 @test "pre-commit hook allows obfuscated files" {
-  notes setup
+  notes setup --yes
   git -C "$CALLER_PWD" add -A
   git -C "$CALLER_PWD" commit --no-verify -q -m "setup"
 
@@ -506,7 +506,7 @@ EOF
 }
 
 @test "pre-commit hook rejects staged renames in guard mode" {
-  notes setup
+  notes setup --yes
   git -C "$CALLER_PWD" add -A
   git -C "$CALLER_PWD" commit --no-verify -q -m "setup"
 
@@ -629,10 +629,10 @@ EOF
 
 @test "obfuscate works without associative arrays (bash 3.2)" {
   # Verify no declare -A in task scripts or hook templates
-  ! grep -q 'declare -A' "$MISE_CONFIG_ROOT/.mise/tasks/obfuscate"
-  ! grep -q 'declare -A' "$MISE_CONFIG_ROOT/.mise/tasks/deobfuscate"
-  ! grep -q 'declare -A' "$MISE_CONFIG_ROOT/hooks/obfuscation.template"
-  ! grep -q 'declare -A' "$MISE_CONFIG_ROOT/hooks/post-commit-deobfuscate.template"
+  ! grep -q 'declare -A' "$REPO_DIR/.mise/tasks/obfuscate"
+  ! grep -q 'declare -A' "$REPO_DIR/.mise/tasks/deobfuscate"
+  ! grep -q 'declare -A' "$REPO_DIR/hooks/obfuscation.template"
+  ! grep -q 'declare -A' "$REPO_DIR/hooks/post-commit-deobfuscate.template"
 }
 
 @test "obfuscate succeeds with single file" {
@@ -647,7 +647,7 @@ EOF
 }
 
 @test "pre-commit hook allows commits when no manifest exists" {
-  notes setup
+  notes setup --yes
   git -C "$CALLER_PWD" add -A
   git -C "$CALLER_PWD" commit -q -m "setup"
 

--- a/test/rename.bats
+++ b/test/rename.bats
@@ -8,8 +8,8 @@ load test_helper
 
 setup() {
   export CALLER_PWD="$BATS_TEST_TMPDIR"
-  source "$MISE_CONFIG_ROOT/lib/common.sh"
-  source "$MISE_CONFIG_ROOT/lib/obfuscate.sh"
+  source "$REPO_DIR/lib/common.sh"
+  source "$REPO_DIR/lib/obfuscate.sh"
 
   mkdir -p "$CALLER_PWD/notes"
   echo "# Alpha" > "$CALLER_PWD/notes/alpha.md"

--- a/test/status.bats
+++ b/test/status.bats
@@ -17,7 +17,7 @@ load test_helper
 }
 
 @test "status shows encryption unlocked after setup" {
-  notes setup
+  notes setup --yes
   run notes status
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "unlocked"
@@ -36,7 +36,7 @@ load test_helper
 }
 
 @test "status shows obfuscation state after obfuscate" {
-  notes setup
+  notes setup --yes
   mkdir -p "$TARGET_DIR/notes"
   echo -e "---\ntitle: Test\n---\n# Test" > "$TARGET_DIR/notes/test-note.md"
   git -C "$TARGET_DIR" add -A
@@ -72,7 +72,7 @@ load test_helper
 }
 
 @test "status --json shows unlocked after setup" {
-  notes setup
+  notes setup --yes
   run notes status -- --json
   [ "$status" -eq 0 ]
   echo "$output" | jq -e '.encryption.status == "unlocked"'
@@ -87,7 +87,7 @@ load test_helper
 }
 
 @test "status --json shows note count after obfuscate" {
-  notes setup
+  notes setup --yes
   mkdir -p "$TARGET_DIR/notes"
   echo -e "---\ntitle: Alpha\n---\n# Alpha" > "$TARGET_DIR/notes/alpha.md"
   echo -e "---\ntitle: Beta\n---\n# Beta" > "$TARGET_DIR/notes/beta.md"
@@ -119,7 +119,7 @@ load test_helper
 }
 
 @test "status --json shows deobfuscated after deobfuscate" {
-  notes setup
+  notes setup --yes
   mkdir -p "$TARGET_DIR/notes"
   echo -e "---\ntitle: Test\n---\n# Test" > "$TARGET_DIR/notes/test-note.md"
   git -C "$TARGET_DIR" add -A

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,18 +1,21 @@
-# Tests must be run via `mise run test` (or `notes test`)
-if [ -z "${MISE_CONFIG_ROOT:-}" ]; then
-  echo "MISE_CONFIG_ROOT not set — run tests via: mise run test" >&2
-  exit 1
-fi
+# Derive the repo root from BATS, not MISE_CONFIG_ROOT. Agent sessions can
+# inherit a stale MISE_CONFIG_ROOT from the launcher repo.
+REPO_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+export REPO_DIR
+
+# Load this repo's declared tools even when a developer runs `bats test/foo.bats`
+# directly instead of going through `mise run test`.
+eval "$(cd "$REPO_DIR" && mise env)"
 
 # Source lib files at file-load time, not inside setup(). Most .bats files in
 # this suite override setup() to set their own CALLER_PWD/fixtures, which
 # shadows the helper's setup() and silently drops the lib sources. Sourcing
 # at top level makes the helper functions available in every test body
 # regardless of which setup wins.
-source "$MISE_CONFIG_ROOT/lib/common.sh"
-source "$MISE_CONFIG_ROOT/lib/obfuscate.sh"
-source "$MISE_CONFIG_ROOT/lib/suppress.sh"
-source "$MISE_CONFIG_ROOT/lib/hooks.sh"
+source "$REPO_DIR/lib/common.sh"
+source "$REPO_DIR/lib/obfuscate.sh"
+source "$REPO_DIR/lib/suppress.sh"
+source "$REPO_DIR/lib/hooks.sh"
 
 # notes() wrapper — calls tasks via mise, just like real usage
 # Exported so subshells (e.g. bash -c pipes) can use it too.
@@ -21,9 +24,19 @@ notes() {
     echo "CALLER_PWD not set" >&2
     return 1
   fi
-  cd "$MISE_CONFIG_ROOT" && CALLER_PWD="$CALLER_PWD" mise run -q "$@"
+  cd "$REPO_DIR" && CALLER_PWD="$CALLER_PWD" mise run -q "$@"
 }
 export -f notes
+
+without_confirmation() (
+  local tty_path="$1"
+  shift
+  export usage_yes=true
+  unset NOTES_YES MISE_YES
+  export NOTES_CONFIRM_TTY="$tty_path"
+  "$@"
+)
+export -f without_confirmation
 
 # rudi() wrapper — calls rudi with CALLER_PWD set
 rudi() {


### PR DESCRIPTION
## Summary

Closes #15.

Adds explicit confirmation gates to destructive notes tasks:

- `notes setup --yes`
- `notes lock --yes`
- `NOTES_YES` / `MISE_YES` automation bypasses
- non-TTY refusal before mutation when approval is missing

Also tightens the test harness around current mise/BATS guidance:

- tests derive `REPO_DIR` from `$BATS_TEST_DIRNAME` instead of `$MISE_CONFIG_ROOT`
- libs self-locate via `${BASH_SOURCE[0]}` instead of relying on task-scoped `$MISE_CONFIG_ROOT`
- mutating tests pass `--yes` visibly at each call site
- refusal regressions cover setup and lock before mutation

Finally adds a concise static README, since the repo did not have one yet. A generated `README.tsx` can follow separately.

## Verification

- `mise run test` — 227 tests pass, 3 expected skips
- `mise run test test/common.bats test/encrypt.bats test/integration.bats`
- `bats test/common.bats`
- `bash -n .mise/tasks/setup .mise/tasks/lock lib/common.sh lib/hooks.sh test/test_helper.bash`
- `git diff --check`
- manual smoke: inherited `usage_yes=true` without `--yes` refuses before setup mutation

## Follow-ups captured

- codebase#37 — lint `$MISE_CONFIG_ROOT` in lib shell files
- codebase#38 — lint raw mise dispatch in BATS tests
- codebase#39 — warn on `-- --flag` before task-owned `#USAGE` flags
- codebase#40 — lint persistent `exec ... 2>/dev/null` footgun
- notes#85 comment — related hidden manifest/pull failure mode observed in fold
