### PR TITLE
Declare gum test dependency

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,7 @@ shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 
 [tools]
 bats = "1.13.0"
+gum = "0.17.0"
 "aqua:shenwei356/rush" = "0.9.0"
 "shiv:rudi" = "0.5.1"
 # git-crypt has no macOS binary on GitHub releases.


### PR DESCRIPTION
Fix-it for #86.

The README added in #86 documents `mise install && mise run test`, but fresh installs do not include `gum`, and the non-JSON list tests fail before this dependency is installed. Declare gum in `mise.toml` so the documented verification path is self-contained.

Verification:
- `mise install`
- `mise run test test/list.bats`
- `mise run test`
