### PR TITLE
Declare gum for notes tests

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,7 @@ shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 
 [tools]
 bats = "1.13.0"
+gum = "0.17.0"
 "aqua:shenwei356/rush" = "0.9.0"
 "shiv:rudi" = "0.5.1"
 # git-crypt has no macOS binary on GitHub releases.


### PR DESCRIPTION
## Summary

Fix-it for #86: declare `gum = "0.17.0"` in `mise.toml` so the BATS harness cleanup and README development path load every tool used by the test suite.

Without this, a clean repo-local `mise env` still leaves `notes list` text-mode tests failing with `No version is set for shim: gum`.

## Verification

- `mise install`
- `mise run test test/list.bats`
- `mise run test`
- `git diff --check origin/main...HEAD`
- `bash -n .mise/tasks/setup .mise/tasks/lock lib/common.sh lib/hooks.sh test/test_helper.bash`
