### PR TITLE
Fix post-merge deobfuscation with dirty readables

### DIFF
--- a/hooks/post-commit-deobfuscate.template
+++ b/hooks/post-commit-deobfuscate.template
@@ -26,6 +26,6 @@ if [ -f "$NOTES_ROOT/.manifest" ]; then
     CALLER_PWD="$(git rev-parse --show-toplevel)"
     # Suppress stdout (rename output) but let stderr through so errors
     # from Layer 1 (mv failures, permission issues) are visible.
-    notes deobfuscate >/dev/null || true
+    notes deobfuscate >/dev/null
   fi
 fi

--- a/hooks/post-merge-deobfuscate.template
+++ b/hooks/post-merge-deobfuscate.template
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# After pull/merge, refresh readable note filenames from the merged obfuscated
+# files. Unlike post-commit, post-merge runs unconditionally when a manifest is
+# present: a pull can update tracked obfuscated IDs while readable names remain
+# excluded locally, so pre-scanning for obfuscated filenames is the wrong gate.
+set -eo pipefail
+
+NOTES_ROOT="__NOTES_DIR__"
+
+if [ -f "$NOTES_ROOT/.manifest" ]; then
+  # Set CALLER_PWD so the notes shim resolves to this repo.
+  export CALLER_PWD
+  CALLER_PWD="$(git rev-parse --show-toplevel)"
+  # Suppress stdout (rename output) but let stderr through so dirty-readable
+  # refusals and hard failures are visible to the user/agent.
+  notes deobfuscate >/dev/null
+fi

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -56,21 +56,23 @@ install_manifest_merge_driver() {
   fi
 }
 
-# Install the post-commit deobfuscation hook.
-# After a commit obfuscates filenames, this restores them for the working tree.
+# Install deobfuscation hooks.
+# After a commit obfuscates filenames, post-commit restores readable names.
+# After a merge/pull updates obfuscated files, post-merge refreshes readable names.
 install_deobfuscation_hook() {
   local notes_dir="${1:-notes}"
-  local template="$HOOKS_DIR/post-commit-deobfuscate.template"
+  local commit_template="$HOOKS_DIR/post-commit-deobfuscate.template"
+  local merge_template="$HOOKS_DIR/post-merge-deobfuscate.template"
 
   # Install for post-commit (deobfuscate after committing)
   ensure_hook_dispatcher post-commit
   local target="$TARGET_DIR/.git/hooks/post-commit.d/deobfuscation"
-  sed "s|__NOTES_DIR__|$notes_dir|g" "$template" > "$target"
+  sed "s|__NOTES_DIR__|$notes_dir|g" "$commit_template" > "$target"
   chmod +x "$target"
 
   # Install for post-merge (deobfuscate after pulling)
   ensure_hook_dispatcher post-merge
   local merge_target="$TARGET_DIR/.git/hooks/post-merge.d/deobfuscation"
-  sed "s|__NOTES_DIR__|$notes_dir|g" "$template" > "$merge_target"
+  sed "s|__NOTES_DIR__|$notes_dir|g" "$merge_template" > "$merge_target"
   chmod +x "$merge_target"
 }

--- a/lib/obfuscate.sh
+++ b/lib/obfuscate.sh
@@ -222,7 +222,8 @@ _record_deobfuscation_base_hashes() {
 }
 
 # Rename a single obfuscated ID back to its readable name.
-# Returns: 0=renamed, 2=skipped (not found/no match), 1=error (mv failed).
+# Returns: 0=renamed, 2=skipped (not found/no match),
+#          3=dirty readable preserved, 1=error (mv failed).
 _rename_one_to_readable() {
   local notes_dir="$1" manifest="$2" id="$3"
   local relpath
@@ -249,7 +250,7 @@ _rename_one_to_readable() {
         echo "Error: refusing to overwrite dirty readable note: $relpath" >&2
         echo "This may be a real local edit, or a cosmetic editor re-save (trailing-newline trim, BOM, line-ending change)." >&2
         echo "Run 'notes changes $relpath' to inspect; rerun with --force to overwrite intentionally." >&2
-        return 1
+        return 3
       fi
     fi
   fi
@@ -265,7 +266,8 @@ _rename_one_to_readable() {
 
 # Rename obfuscated IDs back to readable names.
 # Outputs "<id>\t<relpath>" per renamed file.
-# Returns 0 on success, 2 if nothing to do, 1 on error.
+# Returns 0 on success, 2 if nothing to do, 3 if dirty readables were
+# preserved, 1 on hard error.
 # Usage: rename_to_readable <notes_dir> [id...]
 #   Without ids: deobfuscates all files listed in the manifest.
 #   With ids: only deobfuscates the specified IDs.
@@ -274,17 +276,19 @@ rename_to_readable() {
   shift
   local scoped_ids=("$@")
   local manifest="$notes_dir/.manifest"
-  local count=0
+  local count=0 dirty_count=0
 
   [ ! -f "$manifest" ] && return 1
 
-  # _rename_one_to_readable returns: 0=renamed, 2=skipped, 1=error.
+  # _rename_one_to_readable returns: 0=renamed, 2=skipped,
+  # 3=dirty readable preserved, 1=hard error.
   if [ ${#scoped_ids[@]} -gt 0 ] && [ -n "${scoped_ids[0]}" ]; then
     for id in "${scoped_ids[@]}"; do
       local _rc
       _rename_one_to_readable "$notes_dir" "$manifest" "$id" && _rc=0 || _rc=$?
       case $_rc in
         0) ((count++)) || true ;;
+        3) ((dirty_count++)) || true ;;
         1) return 1 ;;
       esac
     done
@@ -295,11 +299,13 @@ rename_to_readable() {
       _rename_one_to_readable "$notes_dir" "$manifest" "$id" && _rc=0 || _rc=$?
       case $_rc in
         0) ((count++)) || true ;;
+        3) ((dirty_count++)) || true ;;
         1) return 1 ;;
       esac
     done < "$manifest"
   fi
 
+  [ "$dirty_count" -gt 0 ] && return 3
   [ "$count" -eq 0 ] && return 2
   return 0
 }

--- a/test/git-operations.bats
+++ b/test/git-operations.bats
@@ -132,6 +132,35 @@ setup() {
   [[ "$(cat "$LOCAL/notes/alpha.md")" == *"origin change"* ]]
 }
 
+@test "pull: dirty readable does not block safe remote updates later in manifest" {
+  local alpha_id beta_id
+  alpha_id=$(grep "alpha.md" "$LOCAL/notes/.manifest" | cut -f1)
+  beta_id=$(grep "beta.md" "$LOCAL/notes/.manifest" | cut -f1)
+
+  # Origin edits both notes and pushes. Manifest order is alpha, then beta.
+  echo "origin alpha change" >> "$ORIGIN/notes/alpha.md"
+  echo "origin beta change" >> "$ORIGIN/notes/beta.md"
+  CALLER_PWD="$ORIGIN" notes stage alpha.md beta.md
+  git -C "$ORIGIN" commit -q -m "edit alpha and beta"
+  git -C "$ORIGIN" push -q
+
+  # Local has a real edit to alpha.md. The post-merge hook must preserve it,
+  # but that dirty alpha should not leave the unrelated beta readable stale.
+  echo "local alpha edit" >> "$LOCAL/notes/alpha.md"
+  run git -C "$LOCAL" pull -q
+  [ "$status" -eq 0 ]
+
+  [[ "$(cat "$LOCAL/notes/alpha.md")" == *"local alpha edit"* ]]
+  [[ "$(cat "$LOCAL/notes/alpha.md")" != *"origin alpha change"* ]]
+  [ -f "$LOCAL/notes/$alpha_id" ]
+
+  [[ "$(cat "$LOCAL/notes/beta.md")" == *"origin beta change"* ]]
+  [ ! -f "$LOCAL/notes/$beta_id" ]
+
+  [[ "$output" == *"refusing to overwrite dirty readable note: alpha.md"* ]]
+  [[ "$output" == *"post-merge hook failed"* ]]
+}
+
 # ── Merge ─────────────────────────────────────────────────────
 
 @test "merge: concurrent note additions auto-merge via manifest driver" {


### PR DESCRIPTION
## Summary

Fixes the post-merge stale-readable path from #85:

- `rename_to_readable` now treats dirty readable notes as recoverable conflicts, preserves them, and keeps processing later manifest entries.
- post-merge deobfuscation has its own template and runs `notes deobfuscate` unconditionally when a manifest exists.
- deobfuscation hooks no longer hide `notes deobfuscate` failures with `|| true`, so the dispatcher emits a visible hook failure.

This preserves real local edits while still refreshing unrelated safe readables after pull.

## Tests

- `mise run test test/git-operations.bats --filter 'dirty readable does not block safe remote updates'`
- `mise run test test/obfuscate.bats --filter 'deobfuscate refuses dirty|deobfuscate records state|deobfuscation state file|post-merge deobfuscation hook'`
- `mise run test test/git-operations.bats`
- `mise run test test/obfuscate.bats`
- `mise run test`
- `bash -n lib/obfuscate.sh lib/hooks.sh hooks/post-commit-deobfuscate.template hooks/post-merge-deobfuscate.template test/git-operations.bats`
- `git diff --check`

## Follow-up

The sibling pre-merge failure where `notes/.manifest` can be hidden by assume-unchanged while `git pull` refuses is tracked separately in #90.

Closes #85.
