### PR TITLE
Use NOTES_CALLER_PWD for target repo resolution

### DIFF
--- a/.mise/tasks/graph
+++ b/.mise/tasks/graph
@@ -43,7 +43,7 @@ def scan_wiki_links(text):
 
 
 def main():
-    target_dir = os.environ.get("CALLER_PWD", ".")
+    target_dir = os.environ.get("NOTES_CALLER_PWD") or os.environ.get("CALLER_PWD", ".")
     notes_subdir = os.environ.get("usage_dir", "notes")
     notes_dir = Path(target_dir) / notes_subdir
 

--- a/.mise/tasks/list
+++ b/.mise/tasks/list
@@ -6,7 +6,7 @@
 #USAGE flag "--dir <dir>" help="Notes directory relative to repo root (default: notes)"
 set -eo pipefail
 
-TARGET_DIR="${CALLER_PWD:-.}"
+TARGET_DIR="${NOTES_CALLER_PWD:-${CALLER_PWD:-.}}"
 notes_dir="$TARGET_DIR/${usage_dir:-notes}"
 
 if [ ! -d "$notes_dir" ]; then

--- a/.mise/tasks/lock
+++ b/.mise/tasks/lock
@@ -21,7 +21,7 @@ fi
 # The committed state should always be obfuscated — deobfuscation
 # is a local convenience that unlock provides.
 if [ -f "$TARGET_DIR/notes/.manifest" ]; then
-  (cd "$MISE_CONFIG_ROOT" && CALLER_PWD="$TARGET_DIR" mise run -q obfuscate)
+  (cd "$MISE_CONFIG_ROOT" && NOTES_CALLER_PWD="$TARGET_DIR" mise run -q obfuscate)
   # Stage obfuscated files but don't auto-commit — the caller decides
   # when to commit. git-crypt lock works on staged content, so staging
   # here is sufficient. No existing automation relies on auto-commit;

--- a/.mise/tasks/new
+++ b/.mise/tasks/new
@@ -10,7 +10,7 @@
 #USAGE flag "--dir <dir>" help="Notes directory relative to repo root (default: notes)"
 set -eo pipefail
 
-TARGET_DIR="${CALLER_PWD:-.}"
+TARGET_DIR="${NOTES_CALLER_PWD:-${CALLER_PWD:-.}}"
 notes_dir="$TARGET_DIR/${usage_dir:-notes}"
 today=$(date +%Y-%m-%d)
 

--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -12,7 +12,7 @@ source "$MISE_CONFIG_ROOT/lib/hooks.sh"
 require_git
 require_rudi
 
-# Ensure rudi operates on the target repo (shiv shims set CALLER_PWD=$PWD)
+# Ensure rudi operates on the target repo (notes shims set NOTES_CALLER_PWD=$PWD)
 cd "$TARGET_DIR"
 
 NOTES_DIR="${usage_dir:-notes}"
@@ -132,7 +132,7 @@ echo "  Installed hooks"
 if [ "${usage_unlock:-false}" = "true" ]; then
   echo ""
   echo "Unlocking..."
-  cd "$MISE_CONFIG_ROOT" && CALLER_PWD="$TARGET_DIR" mise run -q unlock
+  cd "$MISE_CONFIG_ROOT" && NOTES_CALLER_PWD="$TARGET_DIR" mise run -q unlock
   echo ""
   echo "Done! Repo is set up and unlocked."
 else

--- a/.mise/tasks/unlock
+++ b/.mise/tasks/unlock
@@ -19,8 +19,8 @@ echo "Note: unlock decrypts all encrypted files in this repo (rudi#5)."
 # Deobfuscate filenames if a manifest exists
 if [ -f "$TARGET_DIR/notes/.manifest" ]; then
   if [ "${usage_force:-false}" = "true" ]; then
-    cd "$MISE_CONFIG_ROOT" && CALLER_PWD="$TARGET_DIR" mise run -q deobfuscate -- --force
+    cd "$MISE_CONFIG_ROOT" && NOTES_CALLER_PWD="$TARGET_DIR" mise run -q deobfuscate -- --force
   else
-    cd "$MISE_CONFIG_ROOT" && CALLER_PWD="$TARGET_DIR" mise run -q deobfuscate
+    cd "$MISE_CONFIG_ROOT" && NOTES_CALLER_PWD="$TARGET_DIR" mise run -q deobfuscate
   fi
 fi

--- a/hooks/obfuscation.template
+++ b/hooks/obfuscation.template
@@ -22,9 +22,9 @@ if [ -f "$NOTES_ROOT/.manifest" ]; then
   if [ "${#unobfuscated[@]}" -gt 0 ]; then
     if [ "$MODE" = "auto" ]; then
       echo "Auto-obfuscating ${#unobfuscated[@]} file(s)..." >&2
-      # Set CALLER_PWD so the notes shim resolves to this repo
-      export CALLER_PWD
-      CALLER_PWD="$(git rev-parse --show-toplevel)"
+      # Set NOTES_CALLER_PWD so the notes shim resolves to this repo
+      export NOTES_CALLER_PWD
+      NOTES_CALLER_PWD="$(git rev-parse --show-toplevel)"
       # Pass only the staged unobfuscated files
       notes obfuscate "${unobfuscated[@]}" >&2
     else

--- a/hooks/post-commit-deobfuscate.template
+++ b/hooks/post-commit-deobfuscate.template
@@ -21,9 +21,9 @@ if [ -f "$NOTES_ROOT/.manifest" ]; then
   done
 
   if [ "$obfuscated" -eq 1 ]; then
-    # Set CALLER_PWD so the notes shim resolves to this repo
-    export CALLER_PWD
-    CALLER_PWD="$(git rev-parse --show-toplevel)"
+    # Set NOTES_CALLER_PWD so the notes shim resolves to this repo
+    export NOTES_CALLER_PWD
+    NOTES_CALLER_PWD="$(git rev-parse --show-toplevel)"
     # Suppress stdout (rename output) but let stderr through so errors
     # from Layer 1 (mv failures, permission issues) are visible.
     notes deobfuscate >/dev/null

--- a/hooks/post-merge-deobfuscate.template
+++ b/hooks/post-merge-deobfuscate.template
@@ -8,9 +8,9 @@ set -eo pipefail
 NOTES_ROOT="__NOTES_DIR__"
 
 if [ -f "$NOTES_ROOT/.manifest" ]; then
-  # Set CALLER_PWD so the notes shim resolves to this repo.
-  export CALLER_PWD
-  CALLER_PWD="$(git rev-parse --show-toplevel)"
+  # Set NOTES_CALLER_PWD so the notes shim resolves to this repo.
+  export NOTES_CALLER_PWD
+  NOTES_CALLER_PWD="$(git rev-parse --show-toplevel)"
   # Suppress stdout (rename output) but let stderr through so dirty-readable
   # refusals and hard failures are visible to the user/agent.
   notes deobfuscate >/dev/null

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -7,8 +7,10 @@
 #   - suppress.sh  — status suppression (assume-unchanged + exclude)
 #   - hooks.sh     — git hook installation
 
-# The target repo is always CALLER_PWD (set by shiv shim)
-TARGET_DIR="${CALLER_PWD:-.}"
+# Prefer the notes-specific caller dir to avoid inheriting stale generic
+# caller context from another shiv-managed tool. CALLER_PWD remains a
+# temporary migration fallback for older shims/callers.
+TARGET_DIR="${NOTES_CALLER_PWD:-${CALLER_PWD:-.}}"
 
 NOTES_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NOTES_REPO_DIR="$(cd "$NOTES_LIB_DIR/.." && pwd)"

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -5,43 +5,43 @@
 load test_helper
 
 setup() {
-  export CALLER_PWD="$BATS_TEST_TMPDIR"
+  export NOTES_CALLER_PWD="$BATS_TEST_TMPDIR"
   source "$REPO_DIR/lib/common.sh"
   source "$REPO_DIR/lib/obfuscate.sh"
   source "$REPO_DIR/lib/suppress.sh"
   source "$REPO_DIR/lib/changes.sh"
 
   # Create a git repo with obfuscated notes
-  git -C "$CALLER_PWD" init -q
-  git -C "$CALLER_PWD" config user.name "Test"
-  git -C "$CALLER_PWD" config user.email "test@test.com"
+  git -C "$NOTES_CALLER_PWD" init -q
+  git -C "$NOTES_CALLER_PWD" config user.name "Test"
+  git -C "$NOTES_CALLER_PWD" config user.email "test@test.com"
 
-  mkdir -p "$CALLER_PWD/notes"
-  echo "# Alpha" > "$CALLER_PWD/notes/alpha.md"
-  echo "# Beta" > "$CALLER_PWD/notes/beta.md"
+  mkdir -p "$NOTES_CALLER_PWD/notes"
+  echo "# Alpha" > "$NOTES_CALLER_PWD/notes/alpha.md"
+  echo "# Beta" > "$NOTES_CALLER_PWD/notes/beta.md"
 
-  MANIFEST="$CALLER_PWD/notes/.manifest"
+  MANIFEST="$NOTES_CALLER_PWD/notes/.manifest"
 
   # Obfuscate, commit, then deobfuscate (simulates normal state)
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q -m "initial"
-  rename_to_readable "$CALLER_PWD/notes" > /dev/null
-  set_status_suppression "$CALLER_PWD/notes"
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "initial"
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
+  set_status_suppression "$NOTES_CALLER_PWD/notes"
 }
 
 # ── detect_changes ────────────────────────────────────────────
 
 @test "detect_changes: no changes when files match HEAD" {
-  run detect_changes "$CALLER_PWD/notes"
+  run detect_changes "$NOTES_CALLER_PWD/notes"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
 
 @test "detect_changes: detects modified file" {
-  echo "# Alpha modified" > "$CALLER_PWD/notes/alpha.md"
+  echo "# Alpha modified" > "$NOTES_CALLER_PWD/notes/alpha.md"
 
-  run detect_changes "$CALLER_PWD/notes"
+  run detect_changes "$NOTES_CALLER_PWD/notes"
   [ "$status" -eq 0 ]
   [[ "$output" == *"modified"*"alpha.md"* ]]
   # Beta should not appear
@@ -49,42 +49,42 @@ setup() {
 }
 
 @test "detect_changes: detects new file not in manifest" {
-  echo "# Gamma" > "$CALLER_PWD/notes/gamma.md"
+  echo "# Gamma" > "$NOTES_CALLER_PWD/notes/gamma.md"
 
-  run detect_changes "$CALLER_PWD/notes"
+  run detect_changes "$NOTES_CALLER_PWD/notes"
   [ "$status" -eq 0 ]
   [[ "$output" == *"new"*"gamma.md"* ]]
 }
 
 @test "detect_changes: detects new file in manifest but not in HEAD" {
-  echo "# Gamma" > "$CALLER_PWD/notes/gamma.md"
+  echo "# Gamma" > "$NOTES_CALLER_PWD/notes/gamma.md"
   # Manifest entry exists but file was never committed
   printf 'cccccccc\tgamma.md\n' >> "$MANIFEST"
 
-  run detect_changes "$CALLER_PWD/notes"
+  run detect_changes "$NOTES_CALLER_PWD/notes"
   [ "$status" -eq 0 ]
   [[ "$output" == *"new"*"gamma.md"* ]]
 }
 
 @test "detect_changes: detects deleted file" {
   # Remove the readable file and the obfuscated file
-  rm "$CALLER_PWD/notes/alpha.md"
+  rm "$NOTES_CALLER_PWD/notes/alpha.md"
   local alpha_id
   alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
   # The obfuscated file shouldn't exist (we're in deobfuscated state)
   # but make sure it's gone
-  rm -f "$CALLER_PWD/notes/$alpha_id"
+  rm -f "$NOTES_CALLER_PWD/notes/$alpha_id"
 
-  run detect_changes "$CALLER_PWD/notes"
+  run detect_changes "$NOTES_CALLER_PWD/notes"
   [ "$status" -eq 0 ]
   [[ "$output" == *"deleted"*"alpha.md"* ]]
 }
 
 @test "detect_changes: multiple changes detected" {
-  echo "# Alpha modified" > "$CALLER_PWD/notes/alpha.md"
-  echo "# Gamma" > "$CALLER_PWD/notes/gamma.md"
+  echo "# Alpha modified" > "$NOTES_CALLER_PWD/notes/alpha.md"
+  echo "# Gamma" > "$NOTES_CALLER_PWD/notes/gamma.md"
 
-  run detect_changes "$CALLER_PWD/notes"
+  run detect_changes "$NOTES_CALLER_PWD/notes"
   [ "$status" -eq 0 ]
   [[ "$output" == *"modified"*"alpha.md"* ]]
   [[ "$output" == *"new"*"gamma.md"* ]]
@@ -92,7 +92,7 @@ setup() {
 
 @test "detect_changes: unchanged files not reported" {
   # Make no changes
-  run detect_changes "$CALLER_PWD/notes"
+  run detect_changes "$NOTES_CALLER_PWD/notes"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -103,23 +103,23 @@ setup() {
   i=1
   while [ "$i" -le 40 ]; do
     name=$(printf 'note-%02d.md' "$i")
-    printf '# Note %02d\n' "$i" > "$CALLER_PWD/notes/$name"
+    printf '# Note %02d\n' "$i" > "$NOTES_CALLER_PWD/notes/$name"
     i=$((i + 1))
   done
 
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q -m "add many notes"
-  rename_to_readable "$CALLER_PWD/notes" > /dev/null
-  set_status_suppression "$CALLER_PWD/notes"
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "add many notes"
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
+  set_status_suppression "$NOTES_CALLER_PWD/notes"
 
-  printf '# Note 10 edited\n' > "$CALLER_PWD/notes/note-10.md"
-  printf '# New\n' > "$CALLER_PWD/notes/new.md"
-  rm "$CALLER_PWD/notes/note-20.md"
+  printf '# Note 10 edited\n' > "$NOTES_CALLER_PWD/notes/note-10.md"
+  printf '# New\n' > "$NOTES_CALLER_PWD/notes/new.md"
+  rm "$NOTES_CALLER_PWD/notes/note-20.md"
   delete_id=$(manifest_id_for_name "$MANIFEST" "note-20.md")
-  rm -f "$CALLER_PWD/notes/$delete_id"
+  rm -f "$NOTES_CALLER_PWD/notes/$delete_id"
 
-  run detect_changes "$CALLER_PWD/notes"
+  run detect_changes "$NOTES_CALLER_PWD/notes"
   [ "$status" -eq 0 ]
   [[ "$output" == *"modified"*"note-10.md"* ]]
   [[ "$output" == *"deleted"*"note-20.md"* ]]
@@ -159,7 +159,7 @@ setup() {
 
 @test "set_status_suppression adds exclude entries" {
   local repo_root
-  repo_root=$(git -C "$CALLER_PWD" rev-parse --show-toplevel)
+  repo_root=$(git -C "$NOTES_CALLER_PWD" rev-parse --show-toplevel)
   local exclude="$repo_root/.git/info/exclude"
 
   # Suppression was already set in setup
@@ -172,15 +172,15 @@ setup() {
 
 @test "set_status_suppression gives clean git status" {
   # After setup, git status should be clean
-  run git -C "$CALLER_PWD" status --porcelain
+  run git -C "$NOTES_CALLER_PWD" status --porcelain
   [ -z "$output" ]
 }
 
 @test "clear_status_suppression removes exclude entries" {
-  clear_status_suppression "$CALLER_PWD/notes"
+  clear_status_suppression "$NOTES_CALLER_PWD/notes"
 
   local repo_root
-  repo_root=$(git -C "$CALLER_PWD" rev-parse --show-toplevel)
+  repo_root=$(git -C "$NOTES_CALLER_PWD" rev-parse --show-toplevel)
   local exclude="$repo_root/.git/info/exclude"
 
   # Managed block should be gone
@@ -192,7 +192,7 @@ setup() {
 
 @test "exclude preserves non-managed content" {
   local repo_root
-  repo_root=$(git -C "$CALLER_PWD" rev-parse --show-toplevel)
+  repo_root=$(git -C "$NOTES_CALLER_PWD" rev-parse --show-toplevel)
   local exclude="$repo_root/.git/info/exclude"
 
   # Add custom content before the managed block
@@ -206,8 +206,8 @@ setup() {
   mv "$tmp" "$exclude"
 
   # Re-run suppression (should preserve custom content)
-  clear_status_suppression "$CALLER_PWD/notes"
-  set_status_suppression "$CALLER_PWD/notes"
+  clear_status_suppression "$NOTES_CALLER_PWD/notes"
+  set_status_suppression "$NOTES_CALLER_PWD/notes"
 
   grep -q "# My custom excludes" "$exclude"
   grep -q "build/" "$exclude"
@@ -216,16 +216,16 @@ setup() {
 
 @test "scoped set_status_suppression adds only specified entries" {
   # Clear all first
-  clear_status_suppression "$CALLER_PWD/notes"
+  clear_status_suppression "$NOTES_CALLER_PWD/notes"
 
   local alpha_id
   alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
 
   # Set suppression for just alpha
-  set_status_suppression "$CALLER_PWD/notes" "$alpha_id"
+  set_status_suppression "$NOTES_CALLER_PWD/notes" "$alpha_id"
 
   local repo_root
-  repo_root=$(git -C "$CALLER_PWD" rev-parse --show-toplevel)
+  repo_root=$(git -C "$NOTES_CALLER_PWD" rev-parse --show-toplevel)
   local exclude="$repo_root/.git/info/exclude"
 
   grep -q "notes/alpha.md" "$exclude"
@@ -237,10 +237,10 @@ setup() {
   alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
 
   # Clear just alpha
-  clear_status_suppression "$CALLER_PWD/notes" "$alpha_id"
+  clear_status_suppression "$NOTES_CALLER_PWD/notes" "$alpha_id"
 
   local repo_root
-  repo_root=$(git -C "$CALLER_PWD" rev-parse --show-toplevel)
+  repo_root=$(git -C "$NOTES_CALLER_PWD" rev-parse --show-toplevel)
   local exclude="$repo_root/.git/info/exclude"
 
   ! grep -q "notes/alpha.md" "$exclude"
@@ -250,22 +250,22 @@ setup() {
 # ── stage via git add -f ─────────────────────────────────────
 
 @test "git add -f works despite exclude" {
-  echo "# Alpha modified" > "$CALLER_PWD/notes/alpha.md"
+  echo "# Alpha modified" > "$NOTES_CALLER_PWD/notes/alpha.md"
 
   # Normal git add should fail (file is excluded)
-  git -C "$CALLER_PWD" add "$CALLER_PWD/notes/alpha.md" 2>/dev/null || true
-  run git -C "$CALLER_PWD" diff --cached --name-only
+  git -C "$NOTES_CALLER_PWD" add "$NOTES_CALLER_PWD/notes/alpha.md" 2>/dev/null || true
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
   [[ "$output" != *"alpha.md"* ]]
 
   # Force add should work
-  git -C "$CALLER_PWD" add -f "$CALLER_PWD/notes/alpha.md"
-  run git -C "$CALLER_PWD" diff --cached --name-only
+  git -C "$NOTES_CALLER_PWD" add -f "$NOTES_CALLER_PWD/notes/alpha.md"
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
   [[ "$output" == *"alpha.md"* ]]
 }
 
 @test "notes stage: no args skips new notes but stages modified notes" {
-  echo "# Alpha modified" > "$CALLER_PWD/notes/alpha.md"
-  echo "# Gamma" > "$CALLER_PWD/notes/gamma.md"
+  echo "# Alpha modified" > "$NOTES_CALLER_PWD/notes/alpha.md"
+  echo "# Gamma" > "$NOTES_CALLER_PWD/notes/gamma.md"
 
   run notes stage
   [ "$status" -eq 0 ]
@@ -273,19 +273,19 @@ setup() {
   [[ "$output" == *"Skipped 1 new note(s)"* ]]
   [[ "$output" == *"new: gamma.md"* ]]
 
-  run git -C "$CALLER_PWD" diff --cached --name-only
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
   [[ "$output" == *"notes/alpha.md"* ]]
   [[ "$output" != *"notes/gamma.md"* ]]
 }
 
 @test "notes stage: explicit file stages a new note" {
-  echo "# Gamma" > "$CALLER_PWD/notes/gamma.md"
+  echo "# Gamma" > "$NOTES_CALLER_PWD/notes/gamma.md"
 
   run notes stage gamma.md
   [ "$status" -eq 0 ]
   [[ "$output" == *"staged: gamma.md"* ]]
 
-  run git -C "$CALLER_PWD" diff --cached --name-only
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
   [[ "$output" == *"notes/gamma.md"* ]]
 }
 
@@ -316,7 +316,7 @@ setup() {
   [ -f "$repo/notes/beta.md" ]
   echo "alpha edit" >> "$repo/notes/alpha.md"
 
-  CALLER_PWD="$repo" run notes stage
+  NOTES_CALLER_PWD="$repo" run notes stage
   [ "$status" -eq 0 ]
   [[ "$output" == *"staged: alpha.md"* ]]
   [[ "$output" == *"Skipped 1 new note(s)"* ]]
@@ -332,9 +332,9 @@ setup() {
   install_obfuscation_hook
   install_deobfuscation_hook
 
-  echo "# Gamma" > "$CALLER_PWD/notes/gamma.md"
+  echo "# Gamma" > "$NOTES_CALLER_PWD/notes/gamma.md"
   printf 'cccccccc\tgamma.md\n' >> "$MANIFEST"
-  echo "# Alpha modified" > "$CALLER_PWD/notes/alpha.md"
+  echo "# Alpha modified" > "$NOTES_CALLER_PWD/notes/alpha.md"
 
   run notes stage
   [ "$status" -eq 0 ]
@@ -342,13 +342,13 @@ setup() {
   [[ "$output" == *"Skipped 1 new note(s)"* ]]
   [[ "$output" == *"new: gamma.md"* ]]
 
-  git -C "$CALLER_PWD" commit -q -m "update alpha"
+  git -C "$NOTES_CALLER_PWD" commit -q -m "update alpha"
 
-  run git -C "$CALLER_PWD" cat-file --filters HEAD:notes/.manifest
+  run git -C "$NOTES_CALLER_PWD" cat-file --filters HEAD:notes/.manifest
   [[ "$output" == *"alpha.md"* ]]
   [[ "$output" != *"gamma.md"* ]]
 
-  run git -C "$CALLER_PWD" show --name-only --format= HEAD
+  run git -C "$NOTES_CALLER_PWD" show --name-only --format= HEAD
   [[ "$output" != *"gamma"* ]]
 }
 
@@ -361,35 +361,35 @@ setup() {
   install_deobfuscation_hook
 
   # Verify clean status before edit
-  run git -C "$CALLER_PWD" status --porcelain
+  run git -C "$NOTES_CALLER_PWD" status --porcelain
   [ -z "$output" ]
 
   # Edit a note
-  echo "# Alpha v2" > "$CALLER_PWD/notes/alpha.md"
+  echo "# Alpha v2" > "$NOTES_CALLER_PWD/notes/alpha.md"
 
   # git status should still be clean (exclude hides the change)
-  run git -C "$CALLER_PWD" status --porcelain
+  run git -C "$NOTES_CALLER_PWD" status --porcelain
   [ -z "$output" ]
 
   # But detect_changes should see it
-  run detect_changes "$CALLER_PWD/notes"
+  run detect_changes "$NOTES_CALLER_PWD/notes"
   [[ "$output" == *"modified"*"alpha.md"* ]]
 
   # Stage via notes stage
   notes stage alpha.md
 
   # Commit — hooks handle obfuscation + deobfuscation
-  git -C "$CALLER_PWD" commit -q -m "update alpha"
+  git -C "$NOTES_CALLER_PWD" commit -q -m "update alpha"
 
   # After commit, files should be deobfuscated
-  [ -f "$CALLER_PWD/notes/alpha.md" ]
-  [[ "$(cat "$CALLER_PWD/notes/alpha.md")" == *"Alpha v2"* ]]
+  [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" == *"Alpha v2"* ]]
 
   # Status should be clean again
-  run git -C "$CALLER_PWD" status --porcelain
+  run git -C "$NOTES_CALLER_PWD" status --porcelain
   [ -z "$output" ]
 
   # No changes detected
-  run detect_changes "$CALLER_PWD/notes"
+  run detect_changes "$NOTES_CALLER_PWD/notes"
   [ -z "$output" ]
 }

--- a/test/common.bats
+++ b/test/common.bats
@@ -6,11 +6,58 @@
 load test_helper
 
 setup() {
-  export CALLER_PWD="$BATS_TEST_TMPDIR"
+  export NOTES_CALLER_PWD="$BATS_TEST_TMPDIR"
   source "$REPO_DIR/lib/common.sh"
 
-  mkdir -p "$CALLER_PWD/notes"
-  MANIFEST="$CALLER_PWD/notes/.manifest"
+  mkdir -p "$NOTES_CALLER_PWD/notes"
+  MANIFEST="$NOTES_CALLER_PWD/notes/.manifest"
+}
+
+# ── Caller directory contract ────────────────────────────────
+
+@test "NOTES_CALLER_PWD takes precedence over inherited CALLER_PWD" {
+  local right="$BATS_TEST_TMPDIR/right-repo"
+  local wrong="$BATS_TEST_TMPDIR/wrong-repo"
+  mkdir -p "$right/notes" "$wrong/notes"
+
+  cat > "$right/notes/right.md" <<'EOF'
+---
+title: Right Repo
+tags: []
+---
+EOF
+  cat > "$wrong/notes/wrong.md" <<'EOF'
+---
+title: Wrong Repo
+tags: []
+---
+EOF
+
+  export NOTES_CALLER_PWD="$right"
+  export CALLER_PWD="$wrong"
+  run notes list --json
+  unset CALLER_PWD
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Right Repo"* ]]
+  [[ "$output" != *"Wrong Repo"* ]]
+}
+
+@test "legacy CALLER_PWD fallback still resolves target repo" {
+  local legacy="$BATS_TEST_TMPDIR/legacy-repo"
+  mkdir -p "$legacy/notes"
+  cat > "$legacy/notes/legacy.md" <<'EOF'
+---
+title: Legacy Repo
+tags: []
+---
+EOF
+
+  unset NOTES_CALLER_PWD
+  run bash -c 'cd "$REPO_DIR" && CALLER_PWD="$1" mise run -q list --json' _ "$legacy"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Legacy Repo"* ]]
 }
 
 # ── Confirmation helpers ─────────────────────────────────────

--- a/test/encrypt.bats
+++ b/test/encrypt.bats
@@ -14,8 +14,8 @@ load test_helper
 }
 
 @test "require_git fails on non-git directory" {
-  export CALLER_PWD="$BATS_TEST_TMPDIR/not-a-repo"
-  mkdir -p "$CALLER_PWD"
+  export NOTES_CALLER_PWD="$BATS_TEST_TMPDIR/not-a-repo"
+  mkdir -p "$NOTES_CALLER_PWD"
   source "$REPO_DIR/lib/common.sh"
   run require_git
   [ "$status" -ne 0 ]

--- a/test/git-operations.bats
+++ b/test/git-operations.bats
@@ -34,7 +34,7 @@ setup() {
   git -C "$ORIGIN" add -A
   git -C "$ORIGIN" commit -q -m "initial notes"
 
-  export CALLER_PWD="$ORIGIN"
+  export NOTES_CALLER_PWD="$ORIGIN"
   notes obfuscate
   git -C "$ORIGIN" commit -q -m "obfuscate"
 
@@ -51,7 +51,7 @@ setup() {
   git -C "$LOCAL" config user.name "Test"
 
   # Deobfuscate + install hooks (including merge driver) on local
-  export CALLER_PWD="$LOCAL"
+  export NOTES_CALLER_PWD="$LOCAL"
   notes deobfuscate
   notes install-hooks
 }
@@ -61,7 +61,7 @@ setup() {
 @test "pull: new note from remote appears deobfuscated locally" {
   # Origin adds a new note (hooks auto-obfuscate on commit)
   echo -e "---\ntitle: Gamma\n---\n# Gamma" > "$ORIGIN/notes/gamma.md"
-  CALLER_PWD="$ORIGIN" notes stage gamma.md
+  NOTES_CALLER_PWD="$ORIGIN" notes stage gamma.md
   git -C "$ORIGIN" commit -q -m "add gamma"
   git -C "$ORIGIN" push -q
 
@@ -76,17 +76,17 @@ setup() {
 @test "pull: remote edit to existing note is visible locally" {
   # Origin edits alpha (readable on disk, hooks handle obfuscation)
   echo "Updated content" >> "$ORIGIN/notes/alpha.md"
-  CALLER_PWD="$ORIGIN" notes stage alpha.md
+  NOTES_CALLER_PWD="$ORIGIN" notes stage alpha.md
   git -C "$ORIGIN" commit -q -m "edit alpha"
   git -C "$ORIGIN" push -q
 
   # Local: re-obfuscate before pull so readable files don't conflict
-  CALLER_PWD="$LOCAL" notes obfuscate
+  NOTES_CALLER_PWD="$LOCAL" notes obfuscate
   git -C "$LOCAL" checkout -- .
   git -C "$LOCAL" pull -q
 
   # Deobfuscate to see the updated content
-  CALLER_PWD="$LOCAL" notes deobfuscate
+  NOTES_CALLER_PWD="$LOCAL" notes deobfuscate
   [ -f "$LOCAL/notes/alpha.md" ]
   [[ "$(cat "$LOCAL/notes/alpha.md")" == *"Updated content"* ]]
 }
@@ -98,7 +98,7 @@ setup() {
 
   # Origin adds a completely new note and pushes
   echo -e "---\ntitle: Delta\n---\n# Delta" > "$ORIGIN/notes/delta.md"
-  CALLER_PWD="$ORIGIN" notes stage delta.md
+  NOTES_CALLER_PWD="$ORIGIN" notes stage delta.md
   git -C "$ORIGIN" commit -q -m "add delta"
   git -C "$ORIGIN" push -q
 
@@ -115,7 +115,7 @@ setup() {
 @test "pull: remote edit to existing note works even with readable files on disk" {
   # Origin edits alpha and pushes (hooks auto-obfuscate)
   echo "origin change" >> "$ORIGIN/notes/alpha.md"
-  CALLER_PWD="$ORIGIN" notes stage alpha.md
+  NOTES_CALLER_PWD="$ORIGIN" notes stage alpha.md
   git -C "$ORIGIN" commit -q -m "edit alpha"
   git -C "$ORIGIN" push -q
 
@@ -140,7 +140,7 @@ setup() {
   # Origin edits both notes and pushes. Manifest order is alpha, then beta.
   echo "origin alpha change" >> "$ORIGIN/notes/alpha.md"
   echo "origin beta change" >> "$ORIGIN/notes/beta.md"
-  CALLER_PWD="$ORIGIN" notes stage alpha.md beta.md
+  NOTES_CALLER_PWD="$ORIGIN" notes stage alpha.md beta.md
   git -C "$ORIGIN" commit -q -m "edit alpha and beta"
   git -C "$ORIGIN" push -q
 
@@ -166,19 +166,19 @@ setup() {
 @test "merge: concurrent note additions auto-merge via manifest driver" {
   # With the manifest merge driver installed, concurrent additions to
   # .manifest are union-merged automatically.
-  CALLER_PWD="$LOCAL" notes obfuscate
+  NOTES_CALLER_PWD="$LOCAL" notes obfuscate
   git -C "$LOCAL" checkout -- .
 
   # Branch: add a note
   git -C "$LOCAL" checkout -q -b feature
   echo -e "---\ntitle: Feature Note\n---\n# Feature" > "$LOCAL/notes/feature.md"
-  CALLER_PWD="$LOCAL" notes obfuscate
+  NOTES_CALLER_PWD="$LOCAL" notes obfuscate
   git -C "$LOCAL" commit -q --no-verify -m "add feature note"
 
   # Main: add a different note
   git -C "$LOCAL" checkout -q main
   echo -e "---\ntitle: Main Note\n---\n# Main" > "$LOCAL/notes/main-note.md"
-  CALLER_PWD="$LOCAL" notes obfuscate
+  NOTES_CALLER_PWD="$LOCAL" notes obfuscate
   git -C "$LOCAL" commit -q --no-verify -m "add main note"
 
   # Merge succeeds — driver union-merges the manifest
@@ -194,13 +194,13 @@ setup() {
 @test "merge: single-branch addition merges cleanly" {
   # When only one branch adds notes and the other doesn't touch
   # the manifest, merge succeeds.
-  CALLER_PWD="$LOCAL" notes obfuscate
+  NOTES_CALLER_PWD="$LOCAL" notes obfuscate
   git -C "$LOCAL" checkout -- .
 
   # Branch: add a note
   git -C "$LOCAL" checkout -q -b feature
   echo -e "---\ntitle: Feature\n---\n# Feature" > "$LOCAL/notes/feature.md"
-  CALLER_PWD="$LOCAL" notes obfuscate
+  NOTES_CALLER_PWD="$LOCAL" notes obfuscate
   git -C "$LOCAL" commit -q --no-verify -m "add feature"
 
   # Main: add a non-notes file (no manifest change)
@@ -213,7 +213,7 @@ setup() {
   run git -C "$LOCAL" merge feature -q --no-edit
   [ "$status" -eq 0 ]
 
-  CALLER_PWD="$LOCAL" notes deobfuscate
+  NOTES_CALLER_PWD="$LOCAL" notes deobfuscate
   [ -f "$LOCAL/notes/feature.md" ]
 }
 
@@ -221,7 +221,7 @@ setup() {
   alpha_id=$(grep "alpha.md" "$LOCAL/notes/.manifest" | cut -f1)
 
   # Re-obfuscate for clean branch operations
-  CALLER_PWD="$LOCAL" notes obfuscate
+  NOTES_CALLER_PWD="$LOCAL" notes obfuscate
   git -C "$LOCAL" checkout -- .
 
   # Create a branch, edit alpha's obfuscated file directly
@@ -246,13 +246,13 @@ setup() {
 
 @test "rebase: works when only feature branch adds notes" {
   # Rebase succeeds when main doesn't touch the manifest
-  CALLER_PWD="$LOCAL" notes obfuscate
+  NOTES_CALLER_PWD="$LOCAL" notes obfuscate
   git -C "$LOCAL" checkout -- .
 
   # Create a branch with a new note
   git -C "$LOCAL" checkout -q -b feature
   echo -e "---\ntitle: Feature\n---\n# Feature" > "$LOCAL/notes/feature.md"
-  CALLER_PWD="$LOCAL" notes obfuscate
+  NOTES_CALLER_PWD="$LOCAL" notes obfuscate
   git -C "$LOCAL" commit -q --no-verify -m "add feature"
 
   # Main: non-notes change
@@ -266,25 +266,25 @@ setup() {
   run git -C "$LOCAL" rebase main
   [ "$status" -eq 0 ]
 
-  CALLER_PWD="$LOCAL" notes deobfuscate
+  NOTES_CALLER_PWD="$LOCAL" notes deobfuscate
   [ -f "$LOCAL/notes/feature.md" ]
 }
 
 @test "rebase: concurrent note additions auto-merge via manifest driver" {
   # With the merge driver, concurrent manifest changes are union-merged.
-  CALLER_PWD="$LOCAL" notes obfuscate
+  NOTES_CALLER_PWD="$LOCAL" notes obfuscate
   git -C "$LOCAL" checkout -- .
 
   # Feature branch: add a note
   git -C "$LOCAL" checkout -q -b feature
   echo -e "---\ntitle: Feature\n---\n# Feature" > "$LOCAL/notes/feature.md"
-  CALLER_PWD="$LOCAL" notes obfuscate
+  NOTES_CALLER_PWD="$LOCAL" notes obfuscate
   git -C "$LOCAL" commit -q --no-verify -m "add feature"
 
   # Main: add a different note
   git -C "$LOCAL" checkout -q main
   echo -e "---\ntitle: Other\n---\n# Other" > "$LOCAL/notes/other.md"
-  CALLER_PWD="$LOCAL" notes obfuscate
+  NOTES_CALLER_PWD="$LOCAL" notes obfuscate
   git -C "$LOCAL" commit -q --no-verify -m "add other"
 
   # Rebase succeeds — driver union-merges the manifest
@@ -320,7 +320,7 @@ EOT
   git -C "$repo" add .gitattributes notes/.manifest notes/aaa00001
   git -C "$repo" commit -q -m "init"
 
-  CALLER_PWD="$repo" notes install-hooks >/dev/null
+  NOTES_CALLER_PWD="$repo" notes install-hooks >/dev/null
 
   git -C "$repo" switch -q -c feature
   cat > "$repo/notes/.manifest" <<'EOT'

--- a/test/graph.bats
+++ b/test/graph.bats
@@ -3,8 +3,8 @@
 load test_helper
 
 setup() {
-  export CALLER_PWD="$BATS_TEST_TMPDIR"
-  mkdir -p "$CALLER_PWD/notes"
+  export NOTES_CALLER_PWD="$BATS_TEST_TMPDIR"
+  mkdir -p "$NOTES_CALLER_PWD/notes"
 }
 
 @test "graph generates graph.md" {
@@ -12,7 +12,7 @@ setup() {
 
   run notes graph
   [ "$status" -eq 0 ]
-  [ -f "$CALLER_PWD/notes/graph.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/graph.md" ]
 }
 
 @test "graph detects outgoing wikilinks" {
@@ -22,7 +22,7 @@ setup() {
   run notes graph
   [ "$status" -eq 0 ]
 
-  grep -q "note-a.*note-b" "$CALLER_PWD/notes/graph.md"
+  grep -q "note-a.*note-b" "$NOTES_CALLER_PWD/notes/graph.md"
 }
 
 @test "graph detects backlinks" {
@@ -32,8 +32,8 @@ setup() {
   run notes graph
   [ "$status" -eq 0 ]
 
-  grep -q "Backlinks" "$CALLER_PWD/notes/graph.md"
-  grep -q "note-b.*note-a" "$CALLER_PWD/notes/graph.md"
+  grep -q "Backlinks" "$NOTES_CALLER_PWD/notes/graph.md"
+  grep -q "note-b.*note-a" "$NOTES_CALLER_PWD/notes/graph.md"
 }
 
 @test "graph detects explicit relations" {
@@ -43,8 +43,8 @@ setup() {
   run notes graph
   [ "$status" -eq 0 ]
 
-  grep -q "Explicit Relations" "$CALLER_PWD/notes/graph.md"
-  grep -q "note-x.*note-y" "$CALLER_PWD/notes/graph.md"
+  grep -q "Explicit Relations" "$NOTES_CALLER_PWD/notes/graph.md"
+  grep -q "note-x.*note-y" "$NOTES_CALLER_PWD/notes/graph.md"
 }
 
 @test "graph detects orphaned notes" {
@@ -53,14 +53,14 @@ setup() {
   run notes graph
   [ "$status" -eq 0 ]
 
-  grep -q "Orphaned Notes" "$CALLER_PWD/notes/graph.md"
-  grep -q "Lonely Note" "$CALLER_PWD/notes/graph.md"
+  grep -q "Orphaned Notes" "$NOTES_CALLER_PWD/notes/graph.md"
+  grep -q "Lonely Note" "$NOTES_CALLER_PWD/notes/graph.md"
 }
 
 @test "graph empty directory generates valid output" {
   run notes graph
   [ "$status" -eq 0 ]
 
-  [ -f "$CALLER_PWD/notes/graph.md" ]
-  grep -q "No outgoing links yet" "$CALLER_PWD/notes/graph.md"
+  [ -f "$NOTES_CALLER_PWD/notes/graph.md" ]
+  grep -q "No outgoing links yet" "$NOTES_CALLER_PWD/notes/graph.md"
 }

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -15,7 +15,7 @@ setup() {
   git -C "$TARGET_DIR" config user.name "notes-test"
   git -C "$TARGET_DIR" config commit.gpgsign false
 
-  export CALLER_PWD="$TARGET_DIR"
+  export NOTES_CALLER_PWD="$TARGET_DIR"
   source "$REPO_DIR/lib/common.sh"
 
   # Isolated GPG home

--- a/test/list.bats
+++ b/test/list.bats
@@ -3,8 +3,8 @@
 load test_helper
 
 setup() {
-  export CALLER_PWD="$BATS_TEST_TMPDIR"
-  mkdir -p "$CALLER_PWD/notes"
+  export NOTES_CALLER_PWD="$BATS_TEST_TMPDIR"
+  mkdir -p "$NOTES_CALLER_PWD/notes"
 }
 
 @test "list shows notes with frontmatter" {
@@ -17,7 +17,7 @@ setup() {
 
 @test "list skips files without frontmatter" {
   notes new -- --slug real --title "Real Note" --tags "test" --updated "2026-03-14"
-  echo "# No frontmatter" > "$CALLER_PWD/notes/plain.md"
+  echo "# No frontmatter" > "$NOTES_CALLER_PWD/notes/plain.md"
 
   run notes list
   [ "$status" -eq 0 ]
@@ -73,7 +73,7 @@ setup() {
 }
 
 @test "list --json parses block-list tags" {
-  cat > "$CALLER_PWD/notes/block-tags.md" <<'EOF'
+  cat > "$NOTES_CALLER_PWD/notes/block-tags.md" <<'EOF'
 ---
 title: Block Tag Note
 tags:
@@ -92,7 +92,7 @@ EOF
 }
 
 @test "list --tag matches block-list tags" {
-  cat > "$CALLER_PWD/notes/block-tags.md" <<'EOF'
+  cat > "$NOTES_CALLER_PWD/notes/block-tags.md" <<'EOF'
 ---
 title: Block Tag Note
 tags:

--- a/test/merge-driver.bats
+++ b/test/merge-driver.bats
@@ -34,7 +34,7 @@ setup() {
   export TARGET_DIR="$BATS_TEST_TMPDIR/test-repo"
   mkdir -p "$TARGET_DIR"
   git -C "$TARGET_DIR" init -q
-  export CALLER_PWD="$TARGET_DIR"
+  export NOTES_CALLER_PWD="$TARGET_DIR"
   source "$REPO_DIR/lib/common.sh"
 
   # Temp files for ancestor/ours/theirs

--- a/test/new.bats
+++ b/test/new.bats
@@ -3,8 +3,8 @@
 load test_helper
 
 setup() {
-  export CALLER_PWD="$BATS_TEST_TMPDIR"
-  mkdir -p "$CALLER_PWD/notes"
+  export NOTES_CALLER_PWD="$BATS_TEST_TMPDIR"
+  mkdir -p "$NOTES_CALLER_PWD/notes"
 }
 
 @test "new creates note with frontmatter" {
@@ -19,21 +19,21 @@ setup() {
 @test "new sets tags and dates" {
   notes new -- --slug beta --title "Beta" --tags "a, b" --created "2026-01-01" --updated "2026-03-20"
 
-  run farts get tags "$CALLER_PWD/notes/beta.md"
+  run farts get tags "$NOTES_CALLER_PWD/notes/beta.md"
   [ "${lines[0]}" = "a" ]
   [ "${lines[1]}" = "b" ]
 
-  run farts get created "$CALLER_PWD/notes/beta.md"
+  run farts get created "$NOTES_CALLER_PWD/notes/beta.md"
   [ "$output" = "2026-01-01" ]
 
-  run farts get updated "$CALLER_PWD/notes/beta.md"
+  run farts get updated "$NOTES_CALLER_PWD/notes/beta.md"
   [ "$output" = "2026-03-20" ]
 }
 
 @test "new appends body text" {
   notes new -- --slug with-body --title "Body Note" --body "Some content here."
 
-  run farts body "$CALLER_PWD/notes/with-body.md"
+  run farts body "$NOTES_CALLER_PWD/notes/with-body.md"
   [[ "$output" == *"Some content here."* ]]
 }
 
@@ -49,6 +49,6 @@ setup() {
   notes new -- --slug today-note --title "Today"
   today=$(date +%Y-%m-%d)
 
-  run farts get created "$CALLER_PWD/notes/today-note.md"
+  run farts get created "$NOTES_CALLER_PWD/notes/today-note.md"
   [ "$output" = "$today" ]
 }

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -3,18 +3,18 @@
 load test_helper
 
 setup() {
-  export CALLER_PWD="$BATS_TEST_TMPDIR"
-  mkdir -p "$CALLER_PWD/notes"
+  export NOTES_CALLER_PWD="$BATS_TEST_TMPDIR"
+  mkdir -p "$NOTES_CALLER_PWD/notes"
 
   # Create test notes
-  echo -e "---\ntitle: Alpha\ntags: [test]\n---\n# Alpha" > "$CALLER_PWD/notes/alpha.md"
-  echo -e "---\ntitle: Beta\ntags: [test]\n---\n# Beta" > "$CALLER_PWD/notes/beta.md"
-  echo -e "---\ntitle: Gamma\ntags: [test]\n---\n# Gamma" > "$CALLER_PWD/notes/gamma.txt"
+  echo -e "---\ntitle: Alpha\ntags: [test]\n---\n# Alpha" > "$NOTES_CALLER_PWD/notes/alpha.md"
+  echo -e "---\ntitle: Beta\ntags: [test]\n---\n# Beta" > "$NOTES_CALLER_PWD/notes/beta.md"
+  echo -e "---\ntitle: Gamma\ntags: [test]\n---\n# Gamma" > "$NOTES_CALLER_PWD/notes/gamma.txt"
 
   # git init and commit so git mv works
-  git -C "$CALLER_PWD" init -q
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q -m "init"
+  git -C "$NOTES_CALLER_PWD" init -q
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "init"
 }
 
 # --- Core obfuscation ---
@@ -25,19 +25,19 @@ setup() {
   [[ "$output" == *"Obfuscated 3 file(s)"* ]]
 
   # Original files should be gone
-  [ ! -f "$CALLER_PWD/notes/alpha.md" ]
-  [ ! -f "$CALLER_PWD/notes/beta.md" ]
-  [ ! -f "$CALLER_PWD/notes/gamma.txt" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/beta.md" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/gamma.txt" ]
 
   # Manifest should exist with 3 entries
-  [ -f "$CALLER_PWD/notes/.manifest" ]
-  [ "$(wc -l < "$CALLER_PWD/notes/.manifest" | tr -d ' ')" -eq 3 ]
+  [ -f "$NOTES_CALLER_PWD/notes/.manifest" ]
+  [ "$(wc -l < "$NOTES_CALLER_PWD/notes/.manifest" | tr -d ' ')" -eq 3 ]
 }
 
 @test "obfuscate creates extensionless files" {
   notes obfuscate
 
-  for f in "$CALLER_PWD/notes/"*; do
+  for f in "$NOTES_CALLER_PWD/notes/"*; do
     [ ! -f "$f" ] && continue
     base=$(basename "$f")
     [[ "$base" != *.* ]]
@@ -49,28 +49,28 @@ setup() {
 
   while IFS=$'\t' read -r id name; do
     [[ "$id" =~ ^[0-9a-f]{8}$ ]]
-  done < "$CALLER_PWD/notes/.manifest"
+  done < "$NOTES_CALLER_PWD/notes/.manifest"
 }
 
 @test "obfuscate preserves file content" {
   notes obfuscate
 
-  id=$(grep "alpha.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
-  [[ "$(cat "$CALLER_PWD/notes/$id")" == *"# Alpha"* ]]
+  id=$(grep "alpha.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/$id")" == *"# Alpha"* ]]
 }
 
 @test "obfuscate is idempotent" {
   notes obfuscate
 
-  manifest_before=$(cat "$CALLER_PWD/notes/.manifest")
-  files_before=$(ls "$CALLER_PWD/notes/" | sort)
+  manifest_before=$(cat "$NOTES_CALLER_PWD/notes/.manifest")
+  files_before=$(ls "$NOTES_CALLER_PWD/notes/" | sort)
 
   run notes obfuscate
   [ "$status" -eq 0 ]
   [[ "$output" == *"Nothing to obfuscate"* ]]
 
-  [ "$(cat "$CALLER_PWD/notes/.manifest")" = "$manifest_before" ]
-  [ "$(ls "$CALLER_PWD/notes/" | sort)" = "$files_before" ]
+  [ "$(cat "$NOTES_CALLER_PWD/notes/.manifest")" = "$manifest_before" ]
+  [ "$(ls "$NOTES_CALLER_PWD/notes/" | sort)" = "$files_before" ]
 }
 
 @test "obfuscate dry-run shows plan without renaming" {
@@ -78,13 +78,13 @@ setup() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"alpha.md"* ]]
 
-  [ -f "$CALLER_PWD/notes/alpha.md" ]
-  [ ! -f "$CALLER_PWD/notes/.manifest" ]
+  [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/.manifest" ]
 }
 
 @test "scoped obfuscate dry-run shows existing manifest ID for readable file" {
   notes obfuscate
-  alpha_id=$(grep $'\talpha\.md$' "$CALLER_PWD/notes/.manifest" | cut -f1)
+  alpha_id=$(grep $'\talpha\.md$' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
 
   notes deobfuscate
 
@@ -93,36 +93,36 @@ setup() {
   [[ "$output" == *"alpha.md → $alpha_id"* ]]
   [[ "$output" != *"alpha.md → (will be assigned)"* ]]
 
-  [ -f "$CALLER_PWD/notes/alpha.md" ]
-  [ ! -f "$CALLER_PWD/notes/$alpha_id" ]
+  [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/$alpha_id" ]
 }
 
 @test "scoped obfuscate dry-run skips already-obfuscated IDs" {
   notes obfuscate
-  alpha_id=$(grep $'\talpha\.md$' "$CALLER_PWD/notes/.manifest" | cut -f1)
+  alpha_id=$(grep $'\talpha\.md$' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
 
   run notes obfuscate --dry-run "$alpha_id"
   [ "$status" -eq 0 ]
   [[ "$output" != *"$alpha_id"* ]]
   [[ "$output" != *"will be assigned"* ]]
 
-  [ -f "$CALLER_PWD/notes/$alpha_id" ]
+  [ -f "$NOTES_CALLER_PWD/notes/$alpha_id" ]
 }
 
 @test "obfuscate handles new files added after initial obfuscation" {
   notes obfuscate
 
-  echo -e "---\ntitle: Delta\n---\n# Delta" > "$CALLER_PWD/notes/delta.md"
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q -m "add delta"
+  echo -e "---\ntitle: Delta\n---\n# Delta" > "$NOTES_CALLER_PWD/notes/delta.md"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "add delta"
 
   run notes obfuscate
   [ "$status" -eq 0 ]
   [[ "$output" == *"delta.md"* ]]
   [[ "$output" == *"Obfuscated 1 file(s)"* ]]
 
-  [ "$(wc -l < "$CALLER_PWD/notes/.manifest" | tr -d ' ')" -eq 4 ]
-  [ ! -f "$CALLER_PWD/notes/delta.md" ]
+  [ "$(wc -l < "$NOTES_CALLER_PWD/notes/.manifest" | tr -d ' ')" -eq 4 ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/delta.md" ]
 }
 
 # --- Scoped obfuscation from deobfuscated state ---
@@ -136,9 +136,9 @@ setup() {
 
 @test "scoped obfuscate from deobfuscated state preserves manifest entries" {
   notes obfuscate
-  [ "$(wc -l < "$CALLER_PWD/notes/.manifest" | tr -d ' ')" -eq 3 ]
-  beta_id=$(grep $'\tbeta\.md$' "$CALLER_PWD/notes/.manifest" | cut -f1)
-  gamma_id=$(grep $'\tgamma\.txt$' "$CALLER_PWD/notes/.manifest" | cut -f1)
+  [ "$(wc -l < "$NOTES_CALLER_PWD/notes/.manifest" | tr -d ' ')" -eq 3 ]
+  beta_id=$(grep $'\tbeta\.md$' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  gamma_id=$(grep $'\tgamma\.txt$' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
 
   # Drop to deobfuscated state — all files at readable names, none at IDs.
   notes deobfuscate
@@ -149,164 +149,164 @@ setup() {
 
   # Manifest must still have all three entries, and beta/gamma must keep their
   # original IDs (stable across the scoped op).
-  [ "$(wc -l < "$CALLER_PWD/notes/.manifest" | tr -d ' ')" -eq 3 ]
-  grep -q $'\talpha\.md$' "$CALLER_PWD/notes/.manifest"
-  grep -q "^${beta_id}"$'\t''beta\.md$' "$CALLER_PWD/notes/.manifest"
-  grep -q "^${gamma_id}"$'\t''gamma\.txt$' "$CALLER_PWD/notes/.manifest"
+  [ "$(wc -l < "$NOTES_CALLER_PWD/notes/.manifest" | tr -d ' ')" -eq 3 ]
+  grep -q $'\talpha\.md$' "$NOTES_CALLER_PWD/notes/.manifest"
+  grep -q "^${beta_id}"$'\t''beta\.md$' "$NOTES_CALLER_PWD/notes/.manifest"
+  grep -q "^${gamma_id}"$'\t''gamma\.txt$' "$NOTES_CALLER_PWD/notes/.manifest"
 
   # beta and gamma stay on disk under readable names (scoped op must not touch
   # them).
-  [ -f "$CALLER_PWD/notes/beta.md" ]
-  [ -f "$CALLER_PWD/notes/gamma.txt" ]
+  [ -f "$NOTES_CALLER_PWD/notes/beta.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/gamma.txt" ]
 }
 
 @test "full obfuscate from fully-deobfuscated state preserves manifest entries" {
   notes obfuscate
-  [ "$(wc -l < "$CALLER_PWD/notes/.manifest" | tr -d ' ')" -eq 3 ]
-  alpha_id=$(grep $'\talpha\.md$' "$CALLER_PWD/notes/.manifest" | cut -f1)
+  [ "$(wc -l < "$NOTES_CALLER_PWD/notes/.manifest" | tr -d ' ')" -eq 3 ]
+  alpha_id=$(grep $'\talpha\.md$' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
 
   notes deobfuscate
   # Full obfuscate with no args — should find all three readable files and
   # restore them to their known IDs without dropping manifest entries.
   run notes obfuscate
   [ "$status" -eq 0 ]
-  [ "$(wc -l < "$CALLER_PWD/notes/.manifest" | tr -d ' ')" -eq 3 ]
-  [ -f "$CALLER_PWD/notes/$alpha_id" ]
+  [ "$(wc -l < "$NOTES_CALLER_PWD/notes/.manifest" | tr -d ' ')" -eq 3 ]
+  [ -f "$NOTES_CALLER_PWD/notes/$alpha_id" ]
 }
 
 # --- Stale manifest cleanup ---
 
 @test "obfuscate removes stale entries for deleted files" {
   notes obfuscate
-  [ "$(wc -l < "$CALLER_PWD/notes/.manifest" | tr -d ' ')" -eq 3 ]
+  [ "$(wc -l < "$NOTES_CALLER_PWD/notes/.manifest" | tr -d ' ')" -eq 3 ]
 
   # Delete a file while deobfuscated
   notes deobfuscate
-  rm "$CALLER_PWD/notes/alpha.md"
+  rm "$NOTES_CALLER_PWD/notes/alpha.md"
 
   notes obfuscate
 
   # Manifest should have 2 entries, not 3
-  [ "$(wc -l < "$CALLER_PWD/notes/.manifest" | tr -d ' ')" -eq 2 ]
-  ! grep -q "alpha.md" "$CALLER_PWD/notes/.manifest"
+  [ "$(wc -l < "$NOTES_CALLER_PWD/notes/.manifest" | tr -d ' ')" -eq 2 ]
+  ! grep -q "alpha.md" "$NOTES_CALLER_PWD/notes/.manifest"
 }
 
 @test "obfuscate handles renamed files as delete + new" {
   notes obfuscate
-  alpha_id=$(grep "alpha.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
+  alpha_id=$(grep "alpha.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
 
   notes deobfuscate
-  mv "$CALLER_PWD/notes/alpha.md" "$CALLER_PWD/notes/alpha-v2.md"
+  mv "$NOTES_CALLER_PWD/notes/alpha.md" "$NOTES_CALLER_PWD/notes/alpha-v2.md"
 
   notes obfuscate
 
   # Old entry gone, new entry present
-  ! grep -q "alpha.md" "$CALLER_PWD/notes/.manifest"
-  grep -q "alpha-v2.md" "$CALLER_PWD/notes/.manifest"
+  ! grep -q "alpha.md" "$NOTES_CALLER_PWD/notes/.manifest"
+  grep -q "alpha-v2.md" "$NOTES_CALLER_PWD/notes/.manifest"
 
   # New file gets a different ID (old one freed)
-  new_id=$(grep "alpha-v2.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
-  [ -f "$CALLER_PWD/notes/$new_id" ]
+  new_id=$(grep "alpha-v2.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  [ -f "$NOTES_CALLER_PWD/notes/$new_id" ]
 }
 
 # --- Same filename in different subdirectories ---
 
 @test "obfuscate handles same filename in different subdirectories" {
-  mkdir -p "$CALLER_PWD/notes/a" "$CALLER_PWD/notes/b"
-  echo -e "---\ntitle: Foo A\n---" > "$CALLER_PWD/notes/a/foo.md"
-  echo -e "---\ntitle: Foo B\n---" > "$CALLER_PWD/notes/b/foo.md"
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q -m "add same-name files in subdirs"
+  mkdir -p "$NOTES_CALLER_PWD/notes/a" "$NOTES_CALLER_PWD/notes/b"
+  echo -e "---\ntitle: Foo A\n---" > "$NOTES_CALLER_PWD/notes/a/foo.md"
+  echo -e "---\ntitle: Foo B\n---" > "$NOTES_CALLER_PWD/notes/b/foo.md"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "add same-name files in subdirs"
 
   notes obfuscate
 
   # Both should be in manifest with different IDs
-  grep -q "a/foo.md" "$CALLER_PWD/notes/.manifest"
-  grep -q "b/foo.md" "$CALLER_PWD/notes/.manifest"
+  grep -q "a/foo.md" "$NOTES_CALLER_PWD/notes/.manifest"
+  grep -q "b/foo.md" "$NOTES_CALLER_PWD/notes/.manifest"
 
-  id_a=$(grep "a/foo.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
-  id_b=$(grep "b/foo.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
+  id_a=$(grep "a/foo.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  id_b=$(grep "b/foo.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
   [ "$id_a" != "$id_b" ]
 
   # Both files exist in notes root
-  [ -f "$CALLER_PWD/notes/$id_a" ]
-  [ -f "$CALLER_PWD/notes/$id_b" ]
+  [ -f "$NOTES_CALLER_PWD/notes/$id_a" ]
+  [ -f "$NOTES_CALLER_PWD/notes/$id_b" ]
 
   # Subdirectories should be gone
-  [ ! -d "$CALLER_PWD/notes/a" ]
-  [ ! -d "$CALLER_PWD/notes/b" ]
+  [ ! -d "$NOTES_CALLER_PWD/notes/a" ]
+  [ ! -d "$NOTES_CALLER_PWD/notes/b" ]
 
   # Content preserved
-  [[ "$(cat "$CALLER_PWD/notes/$id_a")" == *"Foo A"* ]]
-  [[ "$(cat "$CALLER_PWD/notes/$id_b")" == *"Foo B"* ]]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/$id_a")" == *"Foo A"* ]]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/$id_b")" == *"Foo B"* ]]
 }
 
 # --- Stable IDs across cycles ---
 
 @test "obfuscate reuses IDs from preserved manifest" {
   notes obfuscate
-  manifest_first=$(cat "$CALLER_PWD/notes/.manifest")
+  manifest_first=$(cat "$NOTES_CALLER_PWD/notes/.manifest")
 
   notes deobfuscate
   notes obfuscate
 
-  manifest_second=$(cat "$CALLER_PWD/notes/.manifest")
+  manifest_second=$(cat "$NOTES_CALLER_PWD/notes/.manifest")
   [ "$manifest_first" = "$manifest_second" ]
 
   # Verify files are actually obfuscated, not just manifest match
-  [ ! -f "$CALLER_PWD/notes/alpha.md" ]
-  [ ! -f "$CALLER_PWD/notes/beta.md" ]
-  [ ! -f "$CALLER_PWD/notes/gamma.txt" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/beta.md" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/gamma.txt" ]
 }
 
 @test "obfuscate after deobfuscate renames files to their known IDs" {
   notes obfuscate
-  alpha_id=$(grep "alpha.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
+  alpha_id=$(grep "alpha.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
 
   notes deobfuscate
-  [ -f "$CALLER_PWD/notes/alpha.md" ]
-  [ ! -f "$CALLER_PWD/notes/$alpha_id" ]
+  [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/$alpha_id" ]
 
   notes obfuscate
-  [ ! -f "$CALLER_PWD/notes/alpha.md" ]
-  [ -f "$CALLER_PWD/notes/$alpha_id" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/$alpha_id" ]
 
   # Content survived the round-trip
-  [[ "$(cat "$CALLER_PWD/notes/$alpha_id")" == *"# Alpha"* ]]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/$alpha_id")" == *"# Alpha"* ]]
 }
 
 # --- Flatten + recurse ---
 
 @test "obfuscate flattens subdirectory files into notes root" {
-  mkdir -p "$CALLER_PWD/notes/sub"
-  echo -e "---\ntitle: Deep\n---\n# Deep" > "$CALLER_PWD/notes/sub/deep.md"
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q -m "add subdir note"
+  mkdir -p "$NOTES_CALLER_PWD/notes/sub"
+  echo -e "---\ntitle: Deep\n---\n# Deep" > "$NOTES_CALLER_PWD/notes/sub/deep.md"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "add subdir note"
 
   notes obfuscate
 
   # Subdirectory should be gone (emptied and cleaned up)
-  [ ! -d "$CALLER_PWD/notes/sub" ]
+  [ ! -d "$NOTES_CALLER_PWD/notes/sub" ]
 
   # Manifest should have relative path
-  grep -q "sub/deep.md" "$CALLER_PWD/notes/.manifest"
+  grep -q "sub/deep.md" "$NOTES_CALLER_PWD/notes/.manifest"
 
   # All files should be in notes root
   while IFS=$'\t' read -r id name; do
-    [ -f "$CALLER_PWD/notes/$id" ]
-  done < "$CALLER_PWD/notes/.manifest"
+    [ -f "$NOTES_CALLER_PWD/notes/$id" ]
+  done < "$NOTES_CALLER_PWD/notes/.manifest"
 }
 
 @test "obfuscate flattens nested subdirectories" {
-  mkdir -p "$CALLER_PWD/notes/a/b/c"
-  echo -e "---\ntitle: Nested\n---" > "$CALLER_PWD/notes/a/b/c/nested.md"
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q -m "add nested note"
+  mkdir -p "$NOTES_CALLER_PWD/notes/a/b/c"
+  echo -e "---\ntitle: Nested\n---" > "$NOTES_CALLER_PWD/notes/a/b/c/nested.md"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "add nested note"
 
   notes obfuscate
 
-  [ ! -d "$CALLER_PWD/notes/a" ]
-  grep -q "a/b/c/nested.md" "$CALLER_PWD/notes/.manifest"
+  [ ! -d "$NOTES_CALLER_PWD/notes/a" ]
+  grep -q "a/b/c/nested.md" "$NOTES_CALLER_PWD/notes/.manifest"
 }
 
 # --- Deobfuscate ---
@@ -317,38 +317,38 @@ setup() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"Restored 3 file(s)"* ]]
 
-  [ -f "$CALLER_PWD/notes/alpha.md" ]
-  [ -f "$CALLER_PWD/notes/beta.md" ]
-  [ -f "$CALLER_PWD/notes/gamma.txt" ]
+  [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/beta.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/gamma.txt" ]
 }
 
 @test "deobfuscate preserves manifest for stable IDs" {
   notes obfuscate
   notes deobfuscate
 
-  [ -f "$CALLER_PWD/notes/.manifest" ]
+  [ -f "$NOTES_CALLER_PWD/notes/.manifest" ]
 }
 
 @test "deobfuscate recreates subdirectories" {
-  mkdir -p "$CALLER_PWD/notes/sub"
-  echo -e "---\ntitle: Deep\n---\n# Deep" > "$CALLER_PWD/notes/sub/deep.md"
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q -m "add subdir note"
+  mkdir -p "$NOTES_CALLER_PWD/notes/sub"
+  echo -e "---\ntitle: Deep\n---\n# Deep" > "$NOTES_CALLER_PWD/notes/sub/deep.md"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "add subdir note"
 
   notes obfuscate
-  [ ! -d "$CALLER_PWD/notes/sub" ]
+  [ ! -d "$NOTES_CALLER_PWD/notes/sub" ]
 
   notes deobfuscate
-  [ -f "$CALLER_PWD/notes/sub/deep.md" ]
-  [[ "$(cat "$CALLER_PWD/notes/sub/deep.md")" == *"# Deep"* ]]
+  [ -f "$NOTES_CALLER_PWD/notes/sub/deep.md" ]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/sub/deep.md")" == *"# Deep"* ]]
 }
 
 @test "deobfuscate preserves file content" {
   notes obfuscate
   notes deobfuscate
 
-  [[ "$(cat "$CALLER_PWD/notes/alpha.md")" == *"# Alpha"* ]]
-  [[ "$(cat "$CALLER_PWD/notes/gamma.txt")" == *"# Gamma"* ]]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" == *"# Alpha"* ]]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/gamma.txt")" == *"# Gamma"* ]]
 }
 
 @test "deobfuscate fails without manifest" {
@@ -359,23 +359,23 @@ setup() {
 
 @test "deobfuscate dry-run shows plan without renaming" {
   notes obfuscate
-  id=$(grep "alpha.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
+  id=$(grep "alpha.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
 
   run notes deobfuscate -- --dry-run
   [ "$status" -eq 0 ]
   [[ "$output" == *"alpha.md"* ]]
 
-  [ -f "$CALLER_PWD/notes/$id" ]
+  [ -f "$NOTES_CALLER_PWD/notes/$id" ]
 }
 
 @test "round-trip preserves all content and metadata" {
   notes obfuscate
   notes deobfuscate
 
-  run farts get title "$CALLER_PWD/notes/alpha.md"
+  run farts get title "$NOTES_CALLER_PWD/notes/alpha.md"
   [ "$output" = "Alpha" ]
 
-  run farts get title "$CALLER_PWD/notes/beta.md"
+  run farts get title "$NOTES_CALLER_PWD/notes/beta.md"
   [ "$output" = "Beta" ]
 }
 
@@ -386,12 +386,12 @@ setup() {
 @test "install-hooks installs pre-commit hooks" {
   notes install-hooks
 
-  [ -x "$CALLER_PWD/.git/hooks/pre-commit" ]
-  grep -q "Generic hook dispatcher" "$CALLER_PWD/.git/hooks/pre-commit"
-  [ -x "$CALLER_PWD/.git/hooks/pre-commit.d/encryption" ]
-  grep -q "git-crypt status" "$CALLER_PWD/.git/hooks/pre-commit.d/encryption"
-  [ -x "$CALLER_PWD/.git/hooks/pre-commit.d/obfuscation" ]
-  grep -q "manifest" "$CALLER_PWD/.git/hooks/pre-commit.d/obfuscation"
+  [ -x "$NOTES_CALLER_PWD/.git/hooks/pre-commit" ]
+  grep -q "Generic hook dispatcher" "$NOTES_CALLER_PWD/.git/hooks/pre-commit"
+  [ -x "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d/encryption" ]
+  grep -q "git-crypt status" "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d/encryption"
+  [ -x "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d/obfuscation" ]
+  grep -q "manifest" "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d/obfuscation"
 }
 
 @test "encryption pre-commit hook rejects plaintext staged encrypted blobs" {
@@ -399,18 +399,18 @@ setup() {
     skip "git-crypt not installed"
   fi
 
-  ( cd "$CALLER_PWD" && git-crypt init >/dev/null 2>&1 ) || skip "git-crypt init failed"
-  echo "notes/** filter=git-crypt diff=git-crypt" > "$CALLER_PWD/.gitattributes"
-  git -C "$CALLER_PWD" add .gitattributes
-  git -C "$CALLER_PWD" commit -q --no-verify -m "enable encryption"
+  ( cd "$NOTES_CALLER_PWD" && git-crypt init >/dev/null 2>&1 ) || skip "git-crypt init failed"
+  echo "notes/** filter=git-crypt diff=git-crypt" > "$NOTES_CALLER_PWD/.gitattributes"
+  git -C "$NOTES_CALLER_PWD" add .gitattributes
+  git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "enable encryption"
 
   notes install-hooks
 
   local blob
-  blob=$(printf 'aaa00001\talpha.md\n' | git -C "$CALLER_PWD" hash-object -w --stdin)
-  git -C "$CALLER_PWD" update-index --add --cacheinfo 100644 "$blob" notes/.manifest
+  blob=$(printf 'aaa00001\talpha.md\n' | git -C "$NOTES_CALLER_PWD" hash-object -w --stdin)
+  git -C "$NOTES_CALLER_PWD" update-index --add --cacheinfo 100644 "$blob" notes/.manifest
 
-  run git -C "$CALLER_PWD" commit -m "force plaintext manifest"
+  run git -C "$NOTES_CALLER_PWD" commit -m "force plaintext manifest"
   [ "$status" -ne 0 ]
   [[ "$output" == *"Staged files should be encrypted but are plaintext"* ]]
   [[ "$output" == *"notes/.manifest"* ]]
@@ -418,28 +418,28 @@ setup() {
 
 @test "deobfuscate does not install hooks" {
   notes obfuscate
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q --no-verify -m "obfuscate"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscate"
 
   notes deobfuscate
 
-  [ ! -d "$CALLER_PWD/.git/hooks/pre-commit.d" ]
+  [ ! -d "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d" ]
 }
 
 @test "deobfuscate dry-run does not install hook" {
   notes obfuscate
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q --no-verify -m "obfuscate"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscate"
 
   notes deobfuscate -- --dry-run
 
-  [ ! -d "$CALLER_PWD/.git/hooks/pre-commit.d" ]
+  [ ! -d "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d" ]
 }
 
 @test "dispatcher runs all hooks in pre-commit.d" {
   # Set up dispatcher with two hooks — one passes, one would fail
-  mkdir -p "$CALLER_PWD/.git/hooks/pre-commit.d"
-  cat > "$CALLER_PWD/.git/hooks/pre-commit" <<'EOF'
+  mkdir -p "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d"
+  cat > "$NOTES_CALLER_PWD/.git/hooks/pre-commit" <<'EOF'
 #!/usr/bin/env bash
 set -eo pipefail
 HOOK_DIR="$(dirname "$0")/pre-commit.d"
@@ -447,22 +447,22 @@ for hook in "$HOOK_DIR"/*; do
   [ -x "$hook" ] && "$hook" || exit $?
 done
 EOF
-  chmod +x "$CALLER_PWD/.git/hooks/pre-commit"
+  chmod +x "$NOTES_CALLER_PWD/.git/hooks/pre-commit"
 
   # Hook that passes
-  echo '#!/usr/bin/env bash' > "$CALLER_PWD/.git/hooks/pre-commit.d/pass"
-  echo 'exit 0' >> "$CALLER_PWD/.git/hooks/pre-commit.d/pass"
-  chmod +x "$CALLER_PWD/.git/hooks/pre-commit.d/pass"
+  echo '#!/usr/bin/env bash' > "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d/pass"
+  echo 'exit 0' >> "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d/pass"
+  chmod +x "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d/pass"
 
   # Hook that fails
-  echo '#!/usr/bin/env bash' > "$CALLER_PWD/.git/hooks/pre-commit.d/fail"
-  echo 'echo "blocked" >&2; exit 1' >> "$CALLER_PWD/.git/hooks/pre-commit.d/fail"
-  chmod +x "$CALLER_PWD/.git/hooks/pre-commit.d/fail"
+  echo '#!/usr/bin/env bash' > "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d/fail"
+  echo 'echo "blocked" >&2; exit 1' >> "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d/fail"
+  chmod +x "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d/fail"
 
-  echo "test" > "$CALLER_PWD/notes/test-file.md"
-  git -C "$CALLER_PWD" add notes/test-file.md
+  echo "test" > "$NOTES_CALLER_PWD/notes/test-file.md"
+  git -C "$NOTES_CALLER_PWD" add notes/test-file.md
 
-  run git -C "$CALLER_PWD" commit -m "should fail"
+  run git -C "$NOTES_CALLER_PWD" commit -m "should fail"
   [ "$status" -ne 0 ]
   [[ "$output" == *"blocked"* ]]
 }
@@ -477,17 +477,17 @@ EOF
 
 @test "pre-commit hook rejects un-obfuscated files in guard mode" {
   notes setup --yes
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit --no-verify -q -m "setup"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit --no-verify -q -m "setup"
 
   notes obfuscate
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit --no-verify -q -m "obfuscated"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit --no-verify -q -m "obfuscated"
 
-  echo -e "---\ntitle: Sneaky\n---\n# Sneaky" > "$CALLER_PWD/notes/sneaky.md"
-  git -C "$CALLER_PWD" add notes/sneaky.md
+  echo -e "---\ntitle: Sneaky\n---\n# Sneaky" > "$NOTES_CALLER_PWD/notes/sneaky.md"
+  git -C "$NOTES_CALLER_PWD" add notes/sneaky.md
 
-  NOTES_OBFUSCATE_HOOK=guard run git -C "$CALLER_PWD" commit -m "should fail"
+  NOTES_OBFUSCATE_HOOK=guard run git -C "$NOTES_CALLER_PWD" commit -m "should fail"
   [ "$status" -ne 0 ]
   [[ "$output" == *"non-obfuscated filenames"* ]]
   [[ "$output" == *"sneaky.md"* ]]
@@ -495,34 +495,34 @@ EOF
 
 @test "pre-commit hook allows obfuscated files" {
   notes setup --yes
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit --no-verify -q -m "setup"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit --no-verify -q -m "setup"
 
   notes obfuscate
-  git -C "$CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" add -A
 
-  run git -C "$CALLER_PWD" commit -m "should succeed"
+  run git -C "$NOTES_CALLER_PWD" commit -m "should succeed"
   [ "$status" -eq 0 ]
 }
 
 @test "pre-commit hook rejects staged renames in guard mode" {
   notes setup --yes
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit --no-verify -q -m "setup"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit --no-verify -q -m "setup"
 
   notes obfuscate
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit --no-verify -q -m "obfuscated"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit --no-verify -q -m "obfuscated"
 
   # After committing the obfuscated state, the post-commit hook
   # deobfuscates the working tree and adds readable names to
   # .git/info/exclude (clean-status mechanism from notes#43). A plain
   # `git add notes/` now no-ops. To simulate someone trying to stage a
   # deobfuscated rename anyway, we force-add the readable name.
-  git -C "$CALLER_PWD" add -f notes/alpha.md
+  git -C "$NOTES_CALLER_PWD" add -f notes/alpha.md
 
   # The hook should reject this in guard mode
-  NOTES_OBFUSCATE_HOOK=guard run git -C "$CALLER_PWD" commit -m "should fail"
+  NOTES_OBFUSCATE_HOOK=guard run git -C "$NOTES_CALLER_PWD" commit -m "should fail"
   [ "$status" -ne 0 ]
   [[ "$output" == *"non-obfuscated filenames"* ]]
   [[ "$output" == *"alpha.md"* ]]
@@ -531,31 +531,31 @@ EOF
 @test "pre-commit hook auto-obfuscates by default" {
   # Obfuscate and commit the obfuscated state
   notes obfuscate
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q --no-verify -m "obfuscated"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscated"
 
   # Deobfuscate + install hooks explicitly
   notes deobfuscate
   notes install-hooks
 
   # Add a new deobfuscated file + stage everything
-  echo -e "---\ntitle: Sneaky\n---\n# Sneaky" > "$CALLER_PWD/notes/sneaky.md"
-  git -C "$CALLER_PWD" add -A
+  echo -e "---\ntitle: Sneaky\n---\n# Sneaky" > "$NOTES_CALLER_PWD/notes/sneaky.md"
+  git -C "$NOTES_CALLER_PWD" add -A
 
   # Should succeed — hook auto-obfuscates before commit
-  run git -C "$CALLER_PWD" commit -m "should succeed"
+  run git -C "$NOTES_CALLER_PWD" commit -m "should succeed"
   [ "$status" -eq 0 ]
 
   # The committed tree should have obfuscated filenames
   # (post-commit hook deobfuscates the working tree, so check git not disk)
   local committed_files
-  committed_files=$(git -C "$CALLER_PWD" show --name-only --format='' HEAD -- notes/)
+  committed_files=$(git -C "$NOTES_CALLER_PWD" show --name-only --format='' HEAD -- notes/)
   ! echo "$committed_files" | grep -q "alpha.md"
   ! echo "$committed_files" | grep -q "sneaky.md"
 
   # Manifest should have all entries
-  grep -q "sneaky.md" "$CALLER_PWD/notes/.manifest"
-  grep -q "alpha.md" "$CALLER_PWD/notes/.manifest"
+  grep -q "sneaky.md" "$NOTES_CALLER_PWD/notes/.manifest"
+  grep -q "alpha.md" "$NOTES_CALLER_PWD/notes/.manifest"
 }
 
 # --- Post-commit hook ---
@@ -563,55 +563,55 @@ EOF
 @test "install-hooks installs post-commit deobfuscation hook" {
   notes install-hooks
 
-  [ -x "$CALLER_PWD/.git/hooks/post-commit" ]
-  grep -q "Generic hook dispatcher" "$CALLER_PWD/.git/hooks/post-commit"
-  [ -x "$CALLER_PWD/.git/hooks/post-commit.d/deobfuscation" ]
-  grep -q "manifest" "$CALLER_PWD/.git/hooks/post-commit.d/deobfuscation"
+  [ -x "$NOTES_CALLER_PWD/.git/hooks/post-commit" ]
+  grep -q "Generic hook dispatcher" "$NOTES_CALLER_PWD/.git/hooks/post-commit"
+  [ -x "$NOTES_CALLER_PWD/.git/hooks/post-commit.d/deobfuscation" ]
+  grep -q "manifest" "$NOTES_CALLER_PWD/.git/hooks/post-commit.d/deobfuscation"
 }
 
 @test "post-commit hook deobfuscates working tree after commit" {
   # Obfuscate and commit initial state
   notes obfuscate
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q --no-verify -m "obfuscated"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscated"
 
   # Deobfuscate + install hooks explicitly
   notes deobfuscate
   notes install-hooks
 
   # Add a new file and commit — hooks should handle the round-trip
-  echo -e "---\ntitle: New Note\n---\n# New" > "$CALLER_PWD/notes/new-note.md"
-  git -C "$CALLER_PWD" add notes/new-note.md
-  git -C "$CALLER_PWD" commit -m "add new note"
+  echo -e "---\ntitle: New Note\n---\n# New" > "$NOTES_CALLER_PWD/notes/new-note.md"
+  git -C "$NOTES_CALLER_PWD" add notes/new-note.md
+  git -C "$NOTES_CALLER_PWD" commit -m "add new note"
 
   # Working tree should have readable filenames (post-commit deobfuscated)
-  [ -f "$CALLER_PWD/notes/alpha.md" ]
-  [ -f "$CALLER_PWD/notes/beta.md" ]
-  [ -f "$CALLER_PWD/notes/gamma.txt" ]
-  [ -f "$CALLER_PWD/notes/new-note.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/beta.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/gamma.txt" ]
+  [ -f "$NOTES_CALLER_PWD/notes/new-note.md" ]
 
   # Committed tree should have obfuscated filenames
   local committed_files
-  committed_files=$(git -C "$CALLER_PWD" show --name-only --format='' HEAD -- notes/)
+  committed_files=$(git -C "$NOTES_CALLER_PWD" show --name-only --format='' HEAD -- notes/)
   ! echo "$committed_files" | grep -q "alpha.md"
   ! echo "$committed_files" | grep -q "new-note.md"
 }
 
 @test "post-commit hook preserves file content after round-trip" {
   notes obfuscate
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q --no-verify -m "obfuscated"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscated"
 
   notes deobfuscate
   notes install-hooks
 
-  echo -e "---\ntitle: Fresh\n---\n# Fresh content" > "$CALLER_PWD/notes/fresh.md"
-  git -C "$CALLER_PWD" add notes/fresh.md
-  git -C "$CALLER_PWD" commit -m "add fresh"
+  echo -e "---\ntitle: Fresh\n---\n# Fresh content" > "$NOTES_CALLER_PWD/notes/fresh.md"
+  git -C "$NOTES_CALLER_PWD" add notes/fresh.md
+  git -C "$NOTES_CALLER_PWD" commit -m "add fresh"
 
   # Content should survive the obfuscate→deobfuscate round-trip
-  [[ "$(cat "$CALLER_PWD/notes/alpha.md")" == *"# Alpha"* ]]
-  [[ "$(cat "$CALLER_PWD/notes/fresh.md")" == *"# Fresh content"* ]]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" == *"# Alpha"* ]]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/fresh.md")" == *"# Fresh content"* ]]
 }
 
 @test "post-commit hook is no-op when files are not obfuscated" {
@@ -619,9 +619,9 @@ EOF
   notes install-hooks
 
   # Commit should succeed even though post-commit hook exists
-  echo "change" >> "$CALLER_PWD/notes/alpha.md"
-  git -C "$CALLER_PWD" add -A
-  run git -C "$CALLER_PWD" commit -m "should work fine"
+  echo "change" >> "$NOTES_CALLER_PWD/notes/alpha.md"
+  git -C "$NOTES_CALLER_PWD" add -A
+  run git -C "$NOTES_CALLER_PWD" commit -m "should work fine"
   [ "$status" -eq 0 ]
 }
 
@@ -637,9 +637,9 @@ EOF
 
 @test "obfuscate succeeds with single file" {
   # Minimal case — catches set -e failures in manifest lookups
-  rm "$CALLER_PWD/notes/beta.md" "$CALLER_PWD/notes/gamma.txt"
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q -m "remove extras"
+  rm "$NOTES_CALLER_PWD/notes/beta.md" "$NOTES_CALLER_PWD/notes/gamma.txt"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "remove extras"
 
   run notes obfuscate
   [ "$status" -eq 0 ]
@@ -648,13 +648,13 @@ EOF
 
 @test "pre-commit hook allows commits when no manifest exists" {
   notes setup --yes
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q -m "setup"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "setup"
 
-  echo -e "---\ntitle: Normal\n---" > "$CALLER_PWD/notes/normal.md"
-  git -C "$CALLER_PWD" add notes/normal.md
+  echo -e "---\ntitle: Normal\n---" > "$NOTES_CALLER_PWD/notes/normal.md"
+  git -C "$NOTES_CALLER_PWD" add notes/normal.md
 
-  run git -C "$CALLER_PWD" commit -m "should succeed"
+  run git -C "$NOTES_CALLER_PWD" commit -m "should succeed"
   [ "$status" -eq 0 ]
 }
 
@@ -662,26 +662,26 @@ EOF
 
 @test "deobfuscate restores names without staging" {
   notes obfuscate
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q --no-verify -m "obfuscated"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscated"
 
   notes deobfuscate
 
   # Working tree has readable names
-  [ -f "$CALLER_PWD/notes/alpha.md" ]
-  [ -f "$CALLER_PWD/notes/beta.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/beta.md" ]
 
   # Index is clean (no staged changes)
   local staged
-  staged=$(git -C "$CALLER_PWD" diff --cached --name-status)
+  staged=$(git -C "$NOTES_CALLER_PWD" diff --cached --name-status)
   [ -z "$staged" ]
 }
 
 @test "obfuscate works when working tree is deobfuscated but index has obfuscated names" {
   # This is the state after deobfuscate
   notes obfuscate
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q --no-verify -m "obfuscated"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscated"
   notes deobfuscate
 
   # Now obfuscate should restore obfuscated names and stage them
@@ -689,43 +689,43 @@ EOF
   [ "$status" -eq 0 ]
 
   # All files should be obfuscated on disk
-  [ ! -f "$CALLER_PWD/notes/alpha.md" ]
-  [ ! -f "$CALLER_PWD/notes/beta.md" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/beta.md" ]
 
   # Manifest entries should use the same IDs (stable)
   local id_alpha id_beta
-  id_alpha=$(grep 'alpha.md' "$CALLER_PWD/notes/.manifest" | cut -f1)
-  id_beta=$(grep 'beta.md' "$CALLER_PWD/notes/.manifest" | cut -f1)
-  [ -f "$CALLER_PWD/notes/$id_alpha" ]
-  [ -f "$CALLER_PWD/notes/$id_beta" ]
+  id_alpha=$(grep 'alpha.md' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  id_beta=$(grep 'beta.md' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  [ -f "$NOTES_CALLER_PWD/notes/$id_alpha" ]
+  [ -f "$NOTES_CALLER_PWD/notes/$id_beta" ]
 }
 
 @test "full commit cycle: deobfuscated working tree stays clean" {
   # Set up obfuscated repo with hooks
   notes obfuscate
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q --no-verify -m "obfuscated"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscated"
   notes deobfuscate
   notes install-hooks
 
   # Edit a file and commit via hooks
-  echo "edited" >> "$CALLER_PWD/notes/alpha.md"
+  echo "edited" >> "$NOTES_CALLER_PWD/notes/alpha.md"
   notes stage alpha.md
-  run git -C "$CALLER_PWD" commit -m "edit alpha"
+  run git -C "$NOTES_CALLER_PWD" commit -m "edit alpha"
   [ "$status" -eq 0 ]
 
   # Committed tree should have obfuscated names
   local committed_files
-  committed_files=$(git -C "$CALLER_PWD" show --name-only --format='' HEAD -- notes/)
+  committed_files=$(git -C "$NOTES_CALLER_PWD" show --name-only --format='' HEAD -- notes/)
   ! echo "$committed_files" | grep -q "alpha.md"
 
   # Working tree should have readable names (post-commit deobfuscated)
-  [ -f "$CALLER_PWD/notes/alpha.md" ]
-  [[ "$(cat "$CALLER_PWD/notes/alpha.md")" == *"edited"* ]]
+  [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" == *"edited"* ]]
 
   # Index should be clean
   local staged
-  staged=$(git -C "$CALLER_PWD" diff --cached --name-status)
+  staged=$(git -C "$NOTES_CALLER_PWD" diff --cached --name-status)
   [ -z "$staged" ]
 }
 
@@ -734,10 +734,10 @@ EOF
 @test "install-hooks installs post-merge deobfuscation hook" {
   notes install-hooks
 
-  [ -x "$CALLER_PWD/.git/hooks/post-merge" ]
-  grep -q "Generic hook dispatcher" "$CALLER_PWD/.git/hooks/post-merge"
-  [ -x "$CALLER_PWD/.git/hooks/post-merge.d/deobfuscation" ]
-  grep -q "manifest" "$CALLER_PWD/.git/hooks/post-merge.d/deobfuscation"
+  [ -x "$NOTES_CALLER_PWD/.git/hooks/post-merge" ]
+  grep -q "Generic hook dispatcher" "$NOTES_CALLER_PWD/.git/hooks/post-merge"
+  [ -x "$NOTES_CALLER_PWD/.git/hooks/post-merge.d/deobfuscation" ]
+  grep -q "manifest" "$NOTES_CALLER_PWD/.git/hooks/post-merge.d/deobfuscation"
 }
 
 # --- Scoped obfuscation (variadic args) ---
@@ -746,61 +746,61 @@ EOF
   notes obfuscate alpha.md beta.md
 
   # Specified files should be obfuscated
-  [ ! -f "$CALLER_PWD/notes/alpha.md" ]
-  [ ! -f "$CALLER_PWD/notes/beta.md" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/beta.md" ]
 
   # Unspecified file should remain
-  [ -f "$CALLER_PWD/notes/gamma.txt" ]
+  [ -f "$NOTES_CALLER_PWD/notes/gamma.txt" ]
 
   # Manifest should have entries for obfuscated files
-  grep -q "alpha.md" "$CALLER_PWD/notes/.manifest"
-  grep -q "beta.md" "$CALLER_PWD/notes/.manifest"
+  grep -q "alpha.md" "$NOTES_CALLER_PWD/notes/.manifest"
+  grep -q "beta.md" "$NOTES_CALLER_PWD/notes/.manifest"
 }
 
 @test "obfuscate with args handles notes-dir prefix" {
   notes obfuscate notes/alpha.md
 
-  [ ! -f "$CALLER_PWD/notes/alpha.md" ]
-  [ -f "$CALLER_PWD/notes/beta.md" ]
-  [ -f "$CALLER_PWD/notes/gamma.txt" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/beta.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/gamma.txt" ]
 }
 
 @test "obfuscate with args re-obfuscates known files" {
   # First obfuscate all, then deobfuscate
   notes obfuscate
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q --no-verify -m "obfuscated"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscated"
   notes deobfuscate
 
   # Re-obfuscate only one file
   notes obfuscate alpha.md
 
   # alpha should be obfuscated, others still readable
-  [ ! -f "$CALLER_PWD/notes/alpha.md" ]
-  [ -f "$CALLER_PWD/notes/beta.md" ]
-  [ -f "$CALLER_PWD/notes/gamma.txt" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/beta.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/gamma.txt" ]
 
   # ID should be stable (same as manifest)
   local id_alpha
-  id_alpha=$(grep 'alpha.md' "$CALLER_PWD/notes/.manifest" | cut -f1)
-  [ -f "$CALLER_PWD/notes/$id_alpha" ]
+  id_alpha=$(grep 'alpha.md' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  [ -f "$NOTES_CALLER_PWD/notes/$id_alpha" ]
 }
 
 @test "deobfuscate with args only processes specified IDs" {
   notes obfuscate
 
   local id_alpha
-  id_alpha=$(grep 'alpha.md' "$CALLER_PWD/notes/.manifest" | cut -f1)
+  id_alpha=$(grep 'alpha.md' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
 
   notes deobfuscate "$id_alpha"
 
   # alpha should be restored
-  [ -f "$CALLER_PWD/notes/alpha.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
 
   # Others should remain obfuscated
   local id_beta
-  id_beta=$(grep 'beta.md' "$CALLER_PWD/notes/.manifest" | cut -f1)
-  [ -f "$CALLER_PWD/notes/$id_beta" ]
+  id_beta=$(grep 'beta.md' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  [ -f "$NOTES_CALLER_PWD/notes/$id_beta" ]
 }
 
 @test "deobfuscate with args warns on unknown ID" {
@@ -813,41 +813,41 @@ EOF
 
 @test "deobfuscate scoped sets assume-unchanged only on deobfuscated IDs" {
   notes obfuscate
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q --no-verify -m "obfuscated"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscated"
 
   local alpha_id beta_id
-  alpha_id=$(grep "alpha.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
-  beta_id=$(grep "beta.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
+  alpha_id=$(grep "alpha.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  beta_id=$(grep "beta.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
 
   # Deobfuscate only alpha
   notes deobfuscate "$alpha_id"
 
   # alpha's obfuscated ID should be assume-unchanged
-  run git -C "$CALLER_PWD" ls-files -v "notes/$alpha_id"
+  run git -C "$NOTES_CALLER_PWD" ls-files -v "notes/$alpha_id"
   [[ "$output" == h* ]]
 
   # beta's obfuscated ID should NOT be assume-unchanged (still tracked normally)
-  run git -C "$CALLER_PWD" ls-files -v "notes/$beta_id"
+  run git -C "$NOTES_CALLER_PWD" ls-files -v "notes/$beta_id"
   [[ "$output" == H* ]]
 }
 
 @test "pre-commit hook only obfuscates staged files" {
   # Set up: obfuscate, commit, then deobfuscate + install hooks
   notes obfuscate
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q --no-verify -m "obfuscated"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscated"
   notes deobfuscate
   notes install-hooks
   # Working tree: readable names. Index: obfuscated names matching HEAD.
 
   # Edit one file, stage only that one
-  echo "change" >> "$CALLER_PWD/notes/alpha.md"
-  git -C "$CALLER_PWD" add -f notes/alpha.md
+  echo "change" >> "$NOTES_CALLER_PWD/notes/alpha.md"
+  git -C "$NOTES_CALLER_PWD" add -f notes/alpha.md
 
   # Capture stderr from commit (hooks print rename operations there)
   local stderr_log="$BATS_TEST_TMPDIR/commit-stderr"
-  git -C "$CALLER_PWD" commit -m "edit one file" 2>"$stderr_log"
+  git -C "$NOTES_CALLER_PWD" commit -m "edit one file" 2>"$stderr_log"
 
   cat "$stderr_log" >&2
 
@@ -870,75 +870,75 @@ EOF
   # run, training them to bypass the protection forever.
   notes obfuscate
   local alpha_id
-  alpha_id=$(grep "alpha.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
-  [ -f "$CALLER_PWD/notes/$alpha_id" ]
+  alpha_id=$(grep "alpha.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  [ -f "$NOTES_CALLER_PWD/notes/$alpha_id" ]
 
   # Simulate a pre-fix clone: a stale readable on disk, no state file.
-  echo "stale readable from before the upgrade" > "$CALLER_PWD/notes/alpha.md"
-  rm -f "$CALLER_PWD/.git/info/notes-obfuscation-state"
+  echo "stale readable from before the upgrade" > "$NOTES_CALLER_PWD/notes/alpha.md"
+  rm -f "$NOTES_CALLER_PWD/.git/info/notes-obfuscation-state"
 
   run notes deobfuscate
   [ "$status" -eq 0 ]
   # The readable was overwritten with the obfuscated content (the protection
   # is opt-in only after the state file exists; on the upgrade run we trust
   # the existing readable so users don't get force-prompted on every file).
-  [[ "$(cat "$CALLER_PWD/notes/alpha.md")" == *"# Alpha"* ]]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" == *"# Alpha"* ]]
   # And the very next deobfuscate is now protected -- the state file got
   # written on this run.
-  [ -f "$CALLER_PWD/.git/info/notes-obfuscation-state" ]
-  grep -q "^${alpha_id}"$'\t' "$CALLER_PWD/.git/info/notes-obfuscation-state"
+  [ -f "$NOTES_CALLER_PWD/.git/info/notes-obfuscation-state" ]
+  grep -q "^${alpha_id}"$'\t' "$NOTES_CALLER_PWD/.git/info/notes-obfuscation-state"
 }
 
 @test "deobfuscate refuses dirty readable note with recorded base hash" {
   notes obfuscate
   local alpha_id
-  alpha_id=$(grep "alpha.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
-  git -C "$CALLER_PWD" add -A notes
-  git -C "$CALLER_PWD" commit -q -m "obfuscate"
+  alpha_id=$(grep "alpha.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  git -C "$NOTES_CALLER_PWD" add -A notes
+  git -C "$NOTES_CALLER_PWD" commit -q -m "obfuscate"
 
   notes deobfuscate
-  echo "local edit" >> "$CALLER_PWD/notes/alpha.md"
+  echo "local edit" >> "$NOTES_CALLER_PWD/notes/alpha.md"
 
   # Simulate unlock/pull restoring the obfuscated source while the readable
   # file still exists with local edits.
-  git -C "$CALLER_PWD" update-index --no-assume-unchanged "notes/$alpha_id" 2>/dev/null || true
-  git -C "$CALLER_PWD" checkout -- "notes/$alpha_id"
+  git -C "$NOTES_CALLER_PWD" update-index --no-assume-unchanged "notes/$alpha_id" 2>/dev/null || true
+  git -C "$NOTES_CALLER_PWD" checkout -- "notes/$alpha_id"
 
   run notes deobfuscate
   [ "$status" -ne 0 ]
   [[ "$output" == *"refusing to overwrite dirty readable note"* ]]
-  [[ "$(cat "$CALLER_PWD/notes/alpha.md")" == *"local edit"* ]]
-  [ -f "$CALLER_PWD/notes/$alpha_id" ]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" == *"local edit"* ]]
+  [ -f "$NOTES_CALLER_PWD/notes/$alpha_id" ]
 }
 
 @test "deobfuscate --force intentionally overwrites dirty readable note" {
   notes obfuscate
   local alpha_id
-  alpha_id=$(grep "alpha.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
-  [ -f "$CALLER_PWD/notes/$alpha_id" ]
+  alpha_id=$(grep "alpha.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  [ -f "$NOTES_CALLER_PWD/notes/$alpha_id" ]
 
-  echo "local edit" > "$CALLER_PWD/notes/alpha.md"
+  echo "local edit" > "$NOTES_CALLER_PWD/notes/alpha.md"
 
   run notes deobfuscate -- --force
   [ "$status" -eq 0 ]
 
-  [ -f "$CALLER_PWD/notes/alpha.md" ]
-  [[ "$(cat "$CALLER_PWD/notes/alpha.md")" == *"# Alpha"* ]]
-  [[ "$(cat "$CALLER_PWD/notes/alpha.md")" != *"local edit"* ]]
+  [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" == *"# Alpha"* ]]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" != *"local edit"* ]]
 }
 
 @test "deobfuscate allows identical readable note copy" {
   notes obfuscate
   local alpha_id
-  alpha_id=$(grep "alpha.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
-  [ -f "$CALLER_PWD/notes/$alpha_id" ]
+  alpha_id=$(grep "alpha.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  [ -f "$NOTES_CALLER_PWD/notes/$alpha_id" ]
 
-  cp "$CALLER_PWD/notes/$alpha_id" "$CALLER_PWD/notes/alpha.md"
+  cp "$NOTES_CALLER_PWD/notes/$alpha_id" "$NOTES_CALLER_PWD/notes/alpha.md"
 
   run notes deobfuscate
   [ "$status" -eq 0 ]
-  [ -f "$CALLER_PWD/notes/alpha.md" ]
-  [[ "$(cat "$CALLER_PWD/notes/alpha.md")" == *"# Alpha"* ]]
+  [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" == *"# Alpha"* ]]
 }
 
 @test "deobfuscate records state for files renamed before mid-batch refusal" {
@@ -950,14 +950,14 @@ EOF
   # without --force, even though the user did nothing wrong.
   notes obfuscate
   local alpha_id beta_id
-  alpha_id=$(grep "alpha.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
-  beta_id=$(grep "beta.md"  "$CALLER_PWD/notes/.manifest" | cut -f1)
-  git -C "$CALLER_PWD" add -A notes
-  git -C "$CALLER_PWD" commit -q -m "obfuscate"
+  alpha_id=$(grep "alpha.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  beta_id=$(grep "beta.md"  "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  git -C "$NOTES_CALLER_PWD" add -A notes
+  git -C "$NOTES_CALLER_PWD" commit -q -m "obfuscate"
 
   # Establish state-file invariant for both files.
   notes deobfuscate
-  local state="$CALLER_PWD/.git/info/notes-obfuscation-state"
+  local state="$NOTES_CALLER_PWD/.git/info/notes-obfuscation-state"
   [ -f "$state" ]
 
   # Snapshot the count of rows for alpha_id BEFORE the partial-failure run.
@@ -971,21 +971,21 @@ EOF
 
   # Dirty beta and restore the obfuscated source for both, simulating a pull
   # that brings back the obfuscated form alongside the dirty readable.
-  echo "local edit on beta" > "$CALLER_PWD/notes/beta.md"
-  git -C "$CALLER_PWD" update-index --no-assume-unchanged "notes/$alpha_id" "notes/$beta_id" 2>/dev/null || true
-  git -C "$CALLER_PWD" checkout -- "notes/$alpha_id" "notes/$beta_id"
+  echo "local edit on beta" > "$NOTES_CALLER_PWD/notes/beta.md"
+  git -C "$NOTES_CALLER_PWD" update-index --no-assume-unchanged "notes/$alpha_id" "notes/$beta_id" 2>/dev/null || true
+  git -C "$NOTES_CALLER_PWD" checkout -- "notes/$alpha_id" "notes/$beta_id"
   # Now alpha.md is up-to-date but the obfuscated source has been re-restored;
   # beta has a dirty readable that should refuse.
 
   # Remove the alpha readable so the rename re-creates it from scratch (cmp -s
   # mismatch triggers the rename path); beta refuses on the dirty check.
-  rm -f "$CALLER_PWD/notes/alpha.md"
+  rm -f "$NOTES_CALLER_PWD/notes/alpha.md"
 
   run notes deobfuscate
   [ "$status" -ne 0 ]
   [[ "$output" == *"refusing to overwrite dirty readable note"* ]]
   # Alpha was renamed despite beta's failure...
-  [ -f "$CALLER_PWD/notes/alpha.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
   # ...and the state file recorded its base hash again (the actual regression
   # under test). Pre-fix the task exit'd before _record_deobfuscation_base_hashes
   # was called, so alpha_rows_after == alpha_rows_before. Post-fix the recording
@@ -1004,12 +1004,12 @@ EOF
   #       shadow older ones (which is what makes append-only safe).
   notes obfuscate
   local alpha_id
-  alpha_id=$(grep "alpha.md" "$CALLER_PWD/notes/.manifest" | cut -f1)
-  git -C "$CALLER_PWD" add -A notes
-  git -C "$CALLER_PWD" commit -q -m "obfuscate"
+  alpha_id=$(grep "alpha.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  git -C "$NOTES_CALLER_PWD" add -A notes
+  git -C "$NOTES_CALLER_PWD" commit -q -m "obfuscate"
 
   notes deobfuscate
-  local state="$CALLER_PWD/.git/info/notes-obfuscation-state"
+  local state="$NOTES_CALLER_PWD/.git/info/notes-obfuscation-state"
   [ -f "$state" ]
 
   local rows_before alpha_rows_before
@@ -1021,9 +1021,9 @@ EOF
   # obfuscated source from the commit (simulating a pull), then force.
   # Pre-fix this rewrote the state file (rows_after == rows_before);
   # post-fix it appends (rows_after > rows_before).
-  echo "local edit" >> "$CALLER_PWD/notes/alpha.md"
-  git -C "$CALLER_PWD" update-index --no-assume-unchanged "notes/$alpha_id" 2>/dev/null || true
-  git -C "$CALLER_PWD" checkout -- "notes/$alpha_id"
+  echo "local edit" >> "$NOTES_CALLER_PWD/notes/alpha.md"
+  git -C "$NOTES_CALLER_PWD" update-index --no-assume-unchanged "notes/$alpha_id" 2>/dev/null || true
+  git -C "$NOTES_CALLER_PWD" checkout -- "notes/$alpha_id"
   notes deobfuscate -- --force
 
   local rows_after alpha_rows_after
@@ -1043,7 +1043,7 @@ EOF
   # rewrite of _deobfuscation_base_hash_for_id (different awk, perl, etc.)
   # that silently broke last-entry-wins would then fail this test.
   local last
-  last=$(_deobfuscation_base_hash_for_id "$CALLER_PWD/notes" "$alpha_id")
+  last=$(_deobfuscation_base_hash_for_id "$NOTES_CALLER_PWD/notes" "$alpha_id")
   [ "$last" = "$stale_hash" ]
 }
 
@@ -1054,9 +1054,9 @@ EOF
   # an obfuscated file exists on disk, but the manifest has lost its entry.
   # Without this guard, `notes obfuscate` would treat the hex file as
   # unobfuscated, generate a fresh random id, and create a duplicate blob.
-  mkdir -p "$CALLER_PWD/notes"
+  mkdir -p "$NOTES_CALLER_PWD/notes"
   echo "---
-title: orphan" > "$CALLER_PWD/notes/deadbeef"
+title: orphan" > "$NOTES_CALLER_PWD/notes/deadbeef"
   # No manifest entry for deadbeef — simulates the lost-mapping case
 
   run notes obfuscate "deadbeef"
@@ -1065,19 +1065,19 @@ title: orphan" > "$CALLER_PWD/notes/deadbeef"
   [[ "$output" == *"deadbeef"* ]]
 
   # File must not have been renamed
-  [ -f "$CALLER_PWD/notes/deadbeef" ]
+  [ -f "$NOTES_CALLER_PWD/notes/deadbeef" ]
 }
 
 @test "obfuscate refuses hex-named file in full scan mode" {
   # Same guard, but via unscoped `notes obfuscate` (scans all files)
-  mkdir -p "$CALLER_PWD/notes"
-  cat > "$CALLER_PWD/notes/alpha.md" <<EOT
+  mkdir -p "$NOTES_CALLER_PWD/notes"
+  cat > "$NOTES_CALLER_PWD/notes/alpha.md" <<EOT
 ---
 title: Alpha
 ---
 alpha
 EOT
-  echo "orphan" > "$CALLER_PWD/notes/cafebabe"
+  echo "orphan" > "$NOTES_CALLER_PWD/notes/cafebabe"
 
   run notes obfuscate
   [ "$status" -ne 0 ]
@@ -1085,13 +1085,13 @@ EOT
   [[ "$output" == *"cafebabe"* ]]
 
   # alpha.md also shouldn't have been renamed (the guard aborts the operation)
-  [ -f "$CALLER_PWD/notes/alpha.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
 }
 
 @test "obfuscate allows files with hex prefix but non-hex tail" {
   # Don't false-positive on names that happen to start with hex
-  mkdir -p "$CALLER_PWD/notes"
-  cat > "$CALLER_PWD/notes/abc123xy.md" <<EOT
+  mkdir -p "$NOTES_CALLER_PWD/notes"
+  cat > "$NOTES_CALLER_PWD/notes/abc123xy.md" <<EOT
 ---
 title: abc
 ---
@@ -1101,14 +1101,14 @@ EOT
   run notes obfuscate
   [ "$status" -eq 0 ]
   # File was renamed to a real hex id (manifest has entry)
-  [ -f "$CALLER_PWD/notes/.manifest" ]
-  grep -q "abc123xy.md" "$CALLER_PWD/notes/.manifest"
+  [ -f "$NOTES_CALLER_PWD/notes/.manifest" ]
+  grep -q "abc123xy.md" "$NOTES_CALLER_PWD/notes/.manifest"
 }
 
 @test "obfuscate allows files whose basename is hex but has an extension" {
   # `deadbeef.md` is a valid readable filename; guard only fires on bare 8-hex
-  mkdir -p "$CALLER_PWD/notes"
-  cat > "$CALLER_PWD/notes/deadbeef.md" <<EOT
+  mkdir -p "$NOTES_CALLER_PWD/notes"
+  cat > "$NOTES_CALLER_PWD/notes/deadbeef.md" <<EOT
 ---
 title: Dead Beef
 ---
@@ -1117,13 +1117,13 @@ EOT
 
   run notes obfuscate
   [ "$status" -eq 0 ]
-  grep -q "deadbeef.md" "$CALLER_PWD/notes/.manifest"
+  grep -q "deadbeef.md" "$NOTES_CALLER_PWD/notes/.manifest"
 }
 
 @test "obfuscate refuses hex-named file in a subdirectory" {
   # The guard uses basename(), so nested paths must still be caught.
-  mkdir -p "$CALLER_PWD/notes/sub"
-  echo "orphan" > "$CALLER_PWD/notes/sub/cafebabe"
+  mkdir -p "$NOTES_CALLER_PWD/notes/sub"
+  echo "orphan" > "$NOTES_CALLER_PWD/notes/sub/cafebabe"
 
   run notes obfuscate "sub/cafebabe"
   [ "$status" -ne 0 ]
@@ -1131,7 +1131,7 @@ EOT
   [[ "$output" == *"cafebabe"* ]]
 
   # File must not have been renamed
-  [ -f "$CALLER_PWD/notes/sub/cafebabe" ]
+  [ -f "$NOTES_CALLER_PWD/notes/sub/cafebabe" ]
 }
 
 @test "obfuscate hex guard: uppercase basename behavior" {
@@ -1145,12 +1145,12 @@ EOT
   # This test documents the contract: the guard fires only on lowercase
   # hex. If the ID generator ever produces uppercase, or if we want to
   # catch the case-insensitive-FS collision, the regex must change.
-  mkdir -p "$CALLER_PWD/notes"
-  echo "uppercase" > "$CALLER_PWD/notes/DEADBEEF"
+  mkdir -p "$NOTES_CALLER_PWD/notes"
+  echo "uppercase" > "$NOTES_CALLER_PWD/notes/DEADBEEF"
   # No .md extension; basename is 8 chars of uppercase hex
   # Note: the note has no title in frontmatter, which is fine — we're testing
   # the guard path, not frontmatter parsing.
-  cat > "$CALLER_PWD/notes/DEADBEEF" <<'EOT'
+  cat > "$NOTES_CALLER_PWD/notes/DEADBEEF" <<'EOT'
 ---
 title: deadbeef
 ---
@@ -1162,22 +1162,22 @@ EOT
   # gets a fresh random obfuscated ID.
   [ "$status" -eq 0 ]
   # The original uppercase file is renamed (disappeared)
-  [ ! -f "$CALLER_PWD/notes/DEADBEEF" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/DEADBEEF" ]
   # A new obfuscated entry exists in the manifest
-  grep -q "DEADBEEF" "$CALLER_PWD/notes/.manifest" || fail "expected manifest entry for DEADBEEF"
+  grep -q "DEADBEEF" "$NOTES_CALLER_PWD/notes/.manifest" || fail "expected manifest entry for DEADBEEF"
 }
 
 @test "obfuscate hex guard: 7-char and 9-char hex pass through" {
   # The guard is {8}, not {7,} or {8,}. Files whose basenames are hex but
   # the wrong length are treated as normal readable filenames. This locks
   # in the boundary in case anyone 'improves' the regex without thinking.
-  mkdir -p "$CALLER_PWD/notes"
-  cat > "$CALLER_PWD/notes/abcdef0" <<'EOT'
+  mkdir -p "$NOTES_CALLER_PWD/notes"
+  cat > "$NOTES_CALLER_PWD/notes/abcdef0" <<'EOT'
 ---
 title: seven-char
 ---
 EOT
-  cat > "$CALLER_PWD/notes/abcdef012" <<'EOT'
+  cat > "$NOTES_CALLER_PWD/notes/abcdef012" <<'EOT'
 ---
 title: nine-char
 ---
@@ -1186,10 +1186,10 @@ EOT
   run notes obfuscate
   [ "$status" -eq 0 ]
   # Both files got renamed to obfuscated IDs (guard didn't fire)
-  [ ! -f "$CALLER_PWD/notes/abcdef0" ]
-  [ ! -f "$CALLER_PWD/notes/abcdef012" ]
-  grep -q "abcdef0$" "$CALLER_PWD/notes/.manifest" || fail "expected 7-char entry in manifest"
-  grep -q "abcdef012$" "$CALLER_PWD/notes/.manifest" || fail "expected 9-char entry in manifest"
+  [ ! -f "$NOTES_CALLER_PWD/notes/abcdef0" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/abcdef012" ]
+  grep -q "abcdef0$" "$NOTES_CALLER_PWD/notes/.manifest" || fail "expected 7-char entry in manifest"
+  grep -q "abcdef012$" "$NOTES_CALLER_PWD/notes/.manifest" || fail "expected 9-char entry in manifest"
 }
 
 @test "obfuscate hex guard: multiple hex-named orphans in full-scan mode (first-hit-only)" {
@@ -1198,10 +1198,10 @@ EOT
   # behavior: the error message only names ONE of the orphans — the user
   # must iterate. If that changes (e.g., we collect all violations before
   # failing), this test will notice.
-  mkdir -p "$CALLER_PWD/notes"
-  echo "orphan1" > "$CALLER_PWD/notes/deadbeef"
-  echo "orphan2" > "$CALLER_PWD/notes/cafebabe"
-  cat > "$CALLER_PWD/notes/real.md" <<'EOT'
+  mkdir -p "$NOTES_CALLER_PWD/notes"
+  echo "orphan1" > "$NOTES_CALLER_PWD/notes/deadbeef"
+  echo "orphan2" > "$NOTES_CALLER_PWD/notes/cafebabe"
+  cat > "$NOTES_CALLER_PWD/notes/real.md" <<'EOT'
 ---
 title: real
 ---
@@ -1215,8 +1215,8 @@ EOT
     fail "expected at least one orphan name in error: $output"
   fi
   # Neither orphan was renamed — the operation aborted
-  [ -f "$CALLER_PWD/notes/deadbeef" ]
-  [ -f "$CALLER_PWD/notes/cafebabe" ]
+  [ -f "$NOTES_CALLER_PWD/notes/deadbeef" ]
+  [ -f "$NOTES_CALLER_PWD/notes/cafebabe" ]
   # And real.md wasn't obfuscated either (fail-fast = no partial state)
-  [ -f "$CALLER_PWD/notes/real.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/real.md" ]
 }

--- a/test/rename.bats
+++ b/test/rename.bats
@@ -7,27 +7,27 @@
 load test_helper
 
 setup() {
-  export CALLER_PWD="$BATS_TEST_TMPDIR"
+  export NOTES_CALLER_PWD="$BATS_TEST_TMPDIR"
   source "$REPO_DIR/lib/common.sh"
   source "$REPO_DIR/lib/obfuscate.sh"
 
-  mkdir -p "$CALLER_PWD/notes"
-  echo "# Alpha" > "$CALLER_PWD/notes/alpha.md"
-  echo "# Beta" > "$CALLER_PWD/notes/beta.md"
-  echo "# Gamma" > "$CALLER_PWD/notes/gamma.txt"
+  mkdir -p "$NOTES_CALLER_PWD/notes"
+  echo "# Alpha" > "$NOTES_CALLER_PWD/notes/alpha.md"
+  echo "# Beta" > "$NOTES_CALLER_PWD/notes/beta.md"
+  echo "# Gamma" > "$NOTES_CALLER_PWD/notes/gamma.txt"
 
-  MANIFEST="$CALLER_PWD/notes/.manifest"
+  MANIFEST="$NOTES_CALLER_PWD/notes/.manifest"
 }
 
 # ── rename_to_obfuscated ─────────────────────────────────────
 
 @test "rename_to_obfuscated renames all files and creates manifest" {
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
 
   # Original files should be gone
-  [ ! -f "$CALLER_PWD/notes/alpha.md" ]
-  [ ! -f "$CALLER_PWD/notes/beta.md" ]
-  [ ! -f "$CALLER_PWD/notes/gamma.txt" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/beta.md" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/gamma.txt" ]
 
   # Manifest should have 3 entries
   [ -f "$MANIFEST" ]
@@ -35,7 +35,7 @@ setup() {
 }
 
 @test "rename_to_obfuscated generates 8-char hex IDs" {
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
 
   while IFS=$'\t' read -r id name; do
     [[ "$id" =~ ^[0-9a-f]{8}$ ]]
@@ -43,16 +43,16 @@ setup() {
 }
 
 @test "rename_to_obfuscated preserves file content" {
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
 
   local id
   id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
-  [[ "$(cat "$CALLER_PWD/notes/$id")" == *"# Alpha"* ]]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/$id")" == *"# Alpha"* ]]
 }
 
 @test "rename_to_obfuscated outputs relpath-tab-id per file" {
   local output
-  output=$(rename_to_obfuscated "$CALLER_PWD/notes")
+  output=$(rename_to_obfuscated "$NOTES_CALLER_PWD/notes")
 
   # Should have 3 lines
   [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 3 ]
@@ -65,27 +65,27 @@ setup() {
 }
 
 @test "rename_to_obfuscated returns 2 when nothing to do" {
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
-  run rename_to_obfuscated "$CALLER_PWD/notes"
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
+  run rename_to_obfuscated "$NOTES_CALLER_PWD/notes"
   [ "$status" -eq 2 ]
 }
 
 @test "rename_to_obfuscated skips .manifest" {
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
   ! grep -q ".manifest" "$MANIFEST"
 }
 
 @test "rename_to_obfuscated scoped: only renames specified files" {
-  rename_to_obfuscated "$CALLER_PWD/notes" "alpha.md" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" "alpha.md" > /dev/null
 
-  [ ! -f "$CALLER_PWD/notes/alpha.md" ]
-  [ -f "$CALLER_PWD/notes/beta.md" ]
-  [ -f "$CALLER_PWD/notes/gamma.txt" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/beta.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/gamma.txt" ]
 }
 
 @test "rename_to_obfuscated scoped: preserves existing manifest entries" {
   # First obfuscate all
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
   [ "$(wc -l < "$MANIFEST" | tr -d ' ')" -eq 3 ]
 
   local beta_id gamma_id
@@ -93,10 +93,10 @@ setup() {
   gamma_id=$(manifest_id_for_name "$MANIFEST" "gamma.txt")
 
   # Deobfuscate all
-  rename_to_readable "$CALLER_PWD/notes" > /dev/null
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
 
   # Scoped obfuscate just alpha
-  rename_to_obfuscated "$CALLER_PWD/notes" "alpha.md" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" "alpha.md" > /dev/null
 
   # Manifest still has all 3 entries with stable IDs
   [ "$(wc -l < "$MANIFEST" | tr -d ' ')" -eq 3 ]
@@ -105,80 +105,80 @@ setup() {
 }
 
 @test "rename_to_obfuscated restores known IDs after deobfuscation" {
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
   local alpha_id
   alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
 
-  rename_to_readable "$CALLER_PWD/notes" > /dev/null
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
 
   # Same ID reused
   [ "$(manifest_id_for_name "$MANIFEST" "alpha.md")" = "$alpha_id" ]
-  [ -f "$CALLER_PWD/notes/$alpha_id" ]
+  [ -f "$NOTES_CALLER_PWD/notes/$alpha_id" ]
 }
 
 @test "rename_to_obfuscated flattens subdirectories" {
-  mkdir -p "$CALLER_PWD/notes/sub"
-  echo "# Deep" > "$CALLER_PWD/notes/sub/deep.md"
+  mkdir -p "$NOTES_CALLER_PWD/notes/sub"
+  echo "# Deep" > "$NOTES_CALLER_PWD/notes/sub/deep.md"
 
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
 
-  [ ! -d "$CALLER_PWD/notes/sub" ]
+  [ ! -d "$NOTES_CALLER_PWD/notes/sub" ]
   grep -q "sub/deep.md" "$MANIFEST"
 }
 
 @test "rename_to_obfuscated removes stale manifest entries during rename" {
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
   [ "$(wc -l < "$MANIFEST" | tr -d ' ')" -eq 3 ]
 
   # Delete alpha's obfuscated file and add a new file
   local alpha_id
   alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
-  rm "$CALLER_PWD/notes/$alpha_id"
-  echo "# Delta" > "$CALLER_PWD/notes/delta.md"
+  rm "$NOTES_CALLER_PWD/notes/$alpha_id"
+  echo "# Delta" > "$NOTES_CALLER_PWD/notes/delta.md"
 
   # Re-obfuscate — the new file triggers a pass, stale alpha gets dropped
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
   [ "$(wc -l < "$MANIFEST" | tr -d ' ')" -eq 3 ]  # beta, gamma, delta
   ! grep -q "alpha.md" "$MANIFEST"
   grep -q "delta.md" "$MANIFEST"
 }
 
 @test "rename_to_obfuscated does not touch git index" {
-  git -C "$CALLER_PWD" init -q
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q -m "init"
+  git -C "$NOTES_CALLER_PWD" init -q
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "init"
 
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
 
   # Index should not have obfuscated names staged
   local staged
-  staged=$(git -C "$CALLER_PWD" diff --cached --name-only)
+  staged=$(git -C "$NOTES_CALLER_PWD" diff --cached --name-only)
   [ -z "$staged" ]
 }
 
 # ── rename_to_readable ───────────────────────────────────────
 
 @test "rename_to_readable restores all files" {
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
-  rename_to_readable "$CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
 
-  [ -f "$CALLER_PWD/notes/alpha.md" ]
-  [ -f "$CALLER_PWD/notes/beta.md" ]
-  [ -f "$CALLER_PWD/notes/gamma.txt" ]
+  [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/beta.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/gamma.txt" ]
 }
 
 @test "rename_to_readable preserves content" {
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
-  rename_to_readable "$CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
 
-  [[ "$(cat "$CALLER_PWD/notes/alpha.md")" == *"# Alpha"* ]]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" == *"# Alpha"* ]]
 }
 
 @test "rename_to_readable outputs id-tab-relpath per file" {
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
   local output
-  output=$(rename_to_readable "$CALLER_PWD/notes")
+  output=$(rename_to_readable "$NOTES_CALLER_PWD/notes")
 
   [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 3 ]
 
@@ -189,97 +189,97 @@ setup() {
 }
 
 @test "rename_to_readable returns 2 when nothing to do" {
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
-  rename_to_readable "$CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
 
-  run rename_to_readable "$CALLER_PWD/notes"
+  run rename_to_readable "$NOTES_CALLER_PWD/notes"
   [ "$status" -eq 2 ]
 }
 
 @test "rename_to_readable returns 1 without manifest" {
-  run rename_to_readable "$CALLER_PWD/notes"
+  run rename_to_readable "$NOTES_CALLER_PWD/notes"
   [ "$status" -eq 1 ]
 }
 
 @test "rename_to_readable scoped: only deobfuscates specified IDs" {
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
 
   local alpha_id beta_id
   alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
   beta_id=$(manifest_id_for_name "$MANIFEST" "beta.md")
 
-  rename_to_readable "$CALLER_PWD/notes" "$alpha_id" > /dev/null
+  rename_to_readable "$NOTES_CALLER_PWD/notes" "$alpha_id" > /dev/null
 
-  [ -f "$CALLER_PWD/notes/alpha.md" ]
-  [ -f "$CALLER_PWD/notes/$beta_id" ]
-  [ ! -f "$CALLER_PWD/notes/beta.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/$beta_id" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/beta.md" ]
 }
 
 @test "rename_to_readable recreates subdirectories" {
-  mkdir -p "$CALLER_PWD/notes/sub"
-  echo "# Deep" > "$CALLER_PWD/notes/sub/deep.md"
+  mkdir -p "$NOTES_CALLER_PWD/notes/sub"
+  echo "# Deep" > "$NOTES_CALLER_PWD/notes/sub/deep.md"
 
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
-  [ ! -d "$CALLER_PWD/notes/sub" ]
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
+  [ ! -d "$NOTES_CALLER_PWD/notes/sub" ]
 
-  rename_to_readable "$CALLER_PWD/notes" > /dev/null
-  [ -f "$CALLER_PWD/notes/sub/deep.md" ]
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
+  [ -f "$NOTES_CALLER_PWD/notes/sub/deep.md" ]
 }
 
 @test "rename_to_readable preserves manifest" {
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
   local manifest_before
   manifest_before=$(cat "$MANIFEST")
 
-  rename_to_readable "$CALLER_PWD/notes" > /dev/null
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
 
   [ "$(cat "$MANIFEST")" = "$manifest_before" ]
 }
 
 @test "rename_to_readable does not touch git index" {
-  git -C "$CALLER_PWD" init -q
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
-  git -C "$CALLER_PWD" add -A
-  git -C "$CALLER_PWD" commit -q -m "obfuscated"
+  git -C "$NOTES_CALLER_PWD" init -q
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "obfuscated"
 
-  rename_to_readable "$CALLER_PWD/notes" > /dev/null
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
 
   # Index should not have renames staged
   local staged
-  staged=$(git -C "$CALLER_PWD" diff --cached --name-only)
+  staged=$(git -C "$NOTES_CALLER_PWD" diff --cached --name-only)
   [ -z "$staged" ]
 }
 
 # ── Round-trip ────────────────────────────────────────────────
 
 @test "round-trip obfuscate→deobfuscate preserves all content" {
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
-  rename_to_readable "$CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
 
-  [[ "$(cat "$CALLER_PWD/notes/alpha.md")" == *"# Alpha"* ]]
-  [[ "$(cat "$CALLER_PWD/notes/beta.md")" == *"# Beta"* ]]
-  [[ "$(cat "$CALLER_PWD/notes/gamma.txt")" == *"# Gamma"* ]]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" == *"# Alpha"* ]]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/beta.md")" == *"# Beta"* ]]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/gamma.txt")" == *"# Gamma"* ]]
 }
 
 @test "round-trip preserves stable IDs" {
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
   local manifest_first
   manifest_first=$(cat "$MANIFEST")
 
-  rename_to_readable "$CALLER_PWD/notes" > /dev/null
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
 
   [ "$(cat "$MANIFEST")" = "$manifest_first" ]
 }
 
 @test "multiple round-trips are stable" {
-  rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
   local manifest_first
   manifest_first=$(cat "$MANIFEST")
 
   for i in 1 2 3; do
-    rename_to_readable "$CALLER_PWD/notes" > /dev/null
-    rename_to_obfuscated "$CALLER_PWD/notes" > /dev/null
+    rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
+    rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
   done
 
   [ "$(cat "$MANIFEST")" = "$manifest_first" ]

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -8,7 +8,7 @@ export REPO_DIR
 eval "$(cd "$REPO_DIR" && mise env)"
 
 # Source lib files at file-load time, not inside setup(). Most .bats files in
-# this suite override setup() to set their own CALLER_PWD/fixtures, which
+# this suite override setup() to set their own NOTES_CALLER_PWD/fixtures, which
 # shadows the helper's setup() and silently drops the lib sources. Sourcing
 # at top level makes the helper functions available in every test body
 # regardless of which setup wins.
@@ -20,11 +20,11 @@ source "$REPO_DIR/lib/hooks.sh"
 # notes() wrapper — calls tasks via mise, just like real usage
 # Exported so subshells (e.g. bash -c pipes) can use it too.
 notes() {
-  if [ -z "${CALLER_PWD:-}" ]; then
-    echo "CALLER_PWD not set" >&2
+  if [ -z "${NOTES_CALLER_PWD:-}" ]; then
+    echo "NOTES_CALLER_PWD not set" >&2
     return 1
   fi
-  cd "$REPO_DIR" && CALLER_PWD="$CALLER_PWD" mise run -q "$@"
+  cd "$REPO_DIR" && NOTES_CALLER_PWD="$NOTES_CALLER_PWD" mise run -q "$@"
 }
 export -f notes
 
@@ -38,13 +38,14 @@ without_confirmation() (
 )
 export -f without_confirmation
 
-# rudi() wrapper — calls rudi with CALLER_PWD set
+# rudi() wrapper — calls rudi against the same target repo. rudi still uses
+# the legacy generic caller-dir contract, so translate at the boundary.
 rudi() {
-  if [ -z "${CALLER_PWD:-}" ]; then
-    echo "CALLER_PWD not set" >&2
+  if [ -z "${NOTES_CALLER_PWD:-}" ]; then
+    echo "NOTES_CALLER_PWD not set" >&2
     return 1
   fi
-  CALLER_PWD="$CALLER_PWD" command rudi "$@"
+  CALLER_PWD="$NOTES_CALLER_PWD" command rudi "$@"
 }
 export -f rudi
 
@@ -52,5 +53,5 @@ setup() {
   export TARGET_DIR="$BATS_TEST_TMPDIR/test-repo"
   mkdir -p "$TARGET_DIR"
   git -C "$TARGET_DIR" init -q
-  export CALLER_PWD="$TARGET_DIR"
+  export NOTES_CALLER_PWD="$TARGET_DIR"
 }


### PR DESCRIPTION
## Summary

- prefer `NOTES_CALLER_PWD` for notes target repo resolution, with temporary `CALLER_PWD` fallback
- update hook templates and test wrappers/fixtures to set `NOTES_CALLER_PWD`
- add regressions for `NOTES_CALLER_PWD` precedence over inherited generic `CALLER_PWD` and legacy fallback behavior

Fixes #92

## Verification

- `bash -n lib/common.sh hooks/obfuscation.template hooks/post-commit-deobfuscate.template hooks/post-merge-deobfuscate.template .mise/tasks/list .mise/tasks/new .mise/tasks/setup .mise/tasks/unlock .mise/tasks/lock .mise/tasks/test test/test_helper.bash`
- `python3 -m py_compile .mise/tasks/graph`
- `mise run test test/common.bats`
- `mise run test test/obfuscate.bats test/git-operations.bats`
- `mise run test`
- `git diff --check`
