### PR TITLE
fix: keep notes hooks and manifests stable

### DIFF
--- a/hooks/obfuscation.template
+++ b/hooks/obfuscation.template
@@ -5,7 +5,16 @@
 set -eo pipefail
 
 NOTES_ROOT="__NOTES_DIR__"
+NOTES_TOOL_ROOT="__NOTES_TOOL_ROOT__"
+MISE_BIN="__MISE_BIN__"
 MODE="${NOTES_OBFUSCATE_HOOK:-auto}"
+
+run_notes() {
+  local repo_root
+  repo_root="$(git rev-parse --show-toplevel)"
+  export NOTES_CALLER_PWD="$repo_root"
+  (cd "$NOTES_TOOL_ROOT" && "$MISE_BIN" run -q "$@")
+}
 
 if [ -f "$NOTES_ROOT/.manifest" ]; then
   unobfuscated=()
@@ -22,11 +31,10 @@ if [ -f "$NOTES_ROOT/.manifest" ]; then
   if [ "${#unobfuscated[@]}" -gt 0 ]; then
     if [ "$MODE" = "auto" ]; then
       echo "Auto-obfuscating ${#unobfuscated[@]} file(s)..." >&2
-      # Set NOTES_CALLER_PWD so the notes shim resolves to this repo
-      export NOTES_CALLER_PWD
-      NOTES_CALLER_PWD="$(git rev-parse --show-toplevel)"
-      # Pass only the staged unobfuscated files
-      notes obfuscate "${unobfuscated[@]}" >&2
+      # Run the notes package version that installed this hook, not whichever
+      # `notes` command happens to appear first on PATH.
+      # Pass only the staged unobfuscated files.
+      run_notes obfuscate "${unobfuscated[@]}" >&2
     else
       echo "ERROR: Staged notes have non-obfuscated filenames:" >&2
       printf '  %s\n' "${unobfuscated[@]}" >&2

--- a/hooks/post-commit-deobfuscate.template
+++ b/hooks/post-commit-deobfuscate.template
@@ -5,6 +5,15 @@
 set -eo pipefail
 
 NOTES_ROOT="__NOTES_DIR__"
+NOTES_TOOL_ROOT="__NOTES_TOOL_ROOT__"
+MISE_BIN="__MISE_BIN__"
+
+run_notes() {
+  local repo_root
+  repo_root="$(git rev-parse --show-toplevel)"
+  export NOTES_CALLER_PWD="$repo_root"
+  (cd "$NOTES_TOOL_ROOT" && "$MISE_BIN" run -q "$@")
+}
 
 if [ -f "$NOTES_ROOT/.manifest" ]; then
   # Only deobfuscate if files are currently obfuscated
@@ -21,11 +30,9 @@ if [ -f "$NOTES_ROOT/.manifest" ]; then
   done
 
   if [ "$obfuscated" -eq 1 ]; then
-    # Set NOTES_CALLER_PWD so the notes shim resolves to this repo
-    export NOTES_CALLER_PWD
-    NOTES_CALLER_PWD="$(git rev-parse --show-toplevel)"
-    # Suppress stdout (rename output) but let stderr through so errors
-    # from Layer 1 (mv failures, permission issues) are visible.
-    notes deobfuscate >/dev/null
+    # Run the notes package version that installed this hook, not whichever
+    # `notes` command happens to appear first on PATH. Suppress stdout (rename
+    # output) but let stderr through so errors from Layer 1 are visible.
+    run_notes deobfuscate >/dev/null
   fi
 fi

--- a/hooks/post-merge-deobfuscate.template
+++ b/hooks/post-merge-deobfuscate.template
@@ -6,12 +6,20 @@
 set -eo pipefail
 
 NOTES_ROOT="__NOTES_DIR__"
+NOTES_TOOL_ROOT="__NOTES_TOOL_ROOT__"
+MISE_BIN="__MISE_BIN__"
+
+run_notes() {
+  local repo_root
+  repo_root="$(git rev-parse --show-toplevel)"
+  export NOTES_CALLER_PWD="$repo_root"
+  (cd "$NOTES_TOOL_ROOT" && "$MISE_BIN" run -q "$@")
+}
 
 if [ -f "$NOTES_ROOT/.manifest" ]; then
-  # Set NOTES_CALLER_PWD so the notes shim resolves to this repo.
-  export NOTES_CALLER_PWD
-  NOTES_CALLER_PWD="$(git rev-parse --show-toplevel)"
-  # Suppress stdout (rename output) but let stderr through so dirty-readable
-  # refusals and hard failures are visible to the user/agent.
-  notes deobfuscate >/dev/null
+  # Run the notes package version that installed this hook, not whichever
+  # `notes` command happens to appear first on PATH. Suppress stdout (rename
+  # output) but let stderr through so dirty-readable refusals and hard failures
+  # are visible to the user/agent.
+  run_notes deobfuscate >/dev/null
 fi

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -4,6 +4,26 @@
 HOOKS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOOKS_REPO_DIR="$(cd "$HOOKS_LIB_DIR/.." && pwd)"
 
+_hook_template_value() {
+  printf '%s' "$1" | sed 's/[&|\\]/\\&/g'
+}
+
+_render_notes_hook_template() {
+  local template="${1:?usage: _render_notes_hook_template <template> <notes-dir>}"
+  local notes_dir="${2:?usage: _render_notes_hook_template <template> <notes-dir>}"
+  local mise_bin
+  mise_bin=$(command -v mise) || {
+    echo "Error: mise not found; cannot install notes hooks" >&2
+    return 1
+  }
+
+  sed \
+    -e "s|__NOTES_DIR__|$(_hook_template_value "$notes_dir")|g" \
+    -e "s|__NOTES_TOOL_ROOT__|$(_hook_template_value "$HOOKS_REPO_DIR")|g" \
+    -e "s|__MISE_BIN__|$(_hook_template_value "$mise_bin")|g" \
+    "$template"
+}
+
 # Ensure a hook dispatcher is installed for the given hook type.
 # Usage: ensure_hook_dispatcher <pre-commit|post-commit|post-merge>
 ensure_hook_dispatcher() {
@@ -34,7 +54,7 @@ install_obfuscation_hook() {
   local notes_dir="${1:-notes}"
   ensure_hook_dispatcher pre-commit
   local target="$TARGET_DIR/.git/hooks/pre-commit.d/obfuscation"
-  sed "s|__NOTES_DIR__|$notes_dir|g" "$HOOKS_DIR/obfuscation.template" > "$target"
+  _render_notes_hook_template "$HOOKS_DIR/obfuscation.template" "$notes_dir" > "$target"
   chmod +x "$target"
 }
 
@@ -67,12 +87,12 @@ install_deobfuscation_hook() {
   # Install for post-commit (deobfuscate after committing)
   ensure_hook_dispatcher post-commit
   local target="$TARGET_DIR/.git/hooks/post-commit.d/deobfuscation"
-  sed "s|__NOTES_DIR__|$notes_dir|g" "$commit_template" > "$target"
+  _render_notes_hook_template "$commit_template" "$notes_dir" > "$target"
   chmod +x "$target"
 
   # Install for post-merge (deobfuscate after pulling)
   ensure_hook_dispatcher post-merge
   local merge_target="$TARGET_DIR/.git/hooks/post-merge.d/deobfuscation"
-  sed "s|__NOTES_DIR__|$notes_dir|g" "$merge_template" > "$merge_target"
+  _render_notes_hook_template "$merge_template" "$notes_dir" > "$merge_target"
   chmod +x "$merge_target"
 }

--- a/lib/obfuscate.sh
+++ b/lib/obfuscate.sh
@@ -49,8 +49,10 @@ rename_to_obfuscated() {
   local manifest="$notes_dir/.manifest"
 
   local to_rename=() to_restore=()
+  local scoped_mode=false
 
   if [ ${#scoped_files[@]} -gt 0 ] && [ -n "${scoped_files[0]}" ]; then
+    scoped_mode=true
     for relpath in "${scoped_files[@]}"; do
       [[ "$relpath" == ".manifest" ]] && continue
       [ ! -f "$notes_dir/$relpath" ] && continue
@@ -143,6 +145,15 @@ rename_to_obfuscated() {
 
   # Clean up empty directories after flattening
   find "$notes_dir" -mindepth 1 -type d -empty -delete 2>/dev/null || true
+
+  # Scoped re-obfuscation of existing manifest entries should not rewrite the
+  # manifest at all. Re-sorting a valid but differently-ordered manifest creates
+  # an order-only dirty worktree after the pre-commit hook, because scoped
+  # obfuscation intentionally does not stage unchanged manifest mappings.
+  if $scoped_mode && [ ${#to_rename[@]} -eq 0 ]; then
+    rm -f "$new_entries"
+    return 0
+  fi
 
   # Update manifest: merge existing + new entries, sorted by name.
   # An entry is live if either its obfuscated id or readable name is on disk.

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -558,6 +558,34 @@ EOF
   grep -q "alpha.md" "$NOTES_CALLER_PWD/notes/.manifest"
 }
 
+@test "installed hooks run notes from installer, not PATH" {
+  notes obfuscate
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscated"
+
+  notes deobfuscate
+  notes install-hooks
+  git -C "$NOTES_CALLER_PWD" add .gitattributes
+  git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "install hook attributes"
+
+  local fake_bin
+  fake_bin="$BATS_TEST_TMPDIR/fake-bin"
+  mkdir -p "$fake_bin"
+  cat > "$fake_bin/notes" <<'EOT'
+#!/usr/bin/env bash
+echo "fake notes invoked: $*" >&2
+exit 99
+EOT
+  chmod +x "$fake_bin/notes"
+
+  echo "change" >> "$NOTES_CALLER_PWD/notes/alpha.md"
+  git -C "$NOTES_CALLER_PWD" add -f notes/alpha.md
+
+  run bash -c 'unset -f notes; PATH="$1:$PATH" git -C "$2" commit -m "edit alpha"' _ "$fake_bin" "$NOTES_CALLER_PWD"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"fake notes invoked"* ]]
+}
+
 # --- Post-commit hook ---
 
 @test "install-hooks installs post-commit deobfuscation hook" {
@@ -727,6 +755,36 @@ EOF
   local staged
   staged=$(git -C "$NOTES_CALLER_PWD" diff --cached --name-status)
   [ -z "$staged" ]
+}
+
+@test "post-commit hook preserves valid manifest order during scoped obfuscation" {
+  notes obfuscate
+
+  local alpha_id beta_id gamma_id
+  alpha_id=$(grep $'\talpha\.md$' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  beta_id=$(grep $'\tbeta\.md$' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  gamma_id=$(grep $'\tgamma\.txt$' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+
+  # Simulate a historical valid manifest whose order differs from the current
+  # name sort. Scoped pre-commit obfuscation should not create an order-only
+  # dirty worktree by normalizing unrelated manifest order.
+  printf '%s\tgamma.txt\n%s\talpha.md\n%s\tbeta.md\n' \
+    "$gamma_id" "$alpha_id" "$beta_id" > "$NOTES_CALLER_PWD/notes/.manifest"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscated unsorted manifest"
+
+  notes deobfuscate
+  notes install-hooks
+  git -C "$NOTES_CALLER_PWD" add .gitattributes
+  git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "install hook attributes"
+  [ -z "$(git -C "$NOTES_CALLER_PWD" status --short)" ]
+
+  echo "edited" >> "$NOTES_CALLER_PWD/notes/alpha.md"
+  notes stage alpha.md
+  run git -C "$NOTES_CALLER_PWD" commit -m "edit alpha"
+  [ "$status" -eq 0 ]
+
+  [ -z "$(git -C "$NOTES_CALLER_PWD" status --short)" ]
 }
 
 # --- Post-merge hook ---


### PR DESCRIPTION
## Summary

- Make installed obfuscation/deobfuscation hooks run the notes package root that installed them via absolute `mise`, instead of resolving bare `notes` from PATH.
- Preserve `notes/.manifest` bytes during scoped re-obfuscation of existing manifest entries, so the pre-commit hook does not leave an order-only dirty manifest after a successful commit.
- Add regressions for PATH shadowing and valid-but-unsorted manifest order during the hook commit cycle.

Closes #76.
Closes #33.

## Notes

This intentionally does not change the manifest merge-driver config path; that is tracked separately as #50.

## Verification

```text
elapsed: 0.011 seconds  bash -n lib/hooks.sh lib/obfuscate.sh hooks/obfuscation.template hooks/post-commit-deobfuscate.template hooks/post-merge-deobfuscate.template .mise/tasks/install-hooks .mise/tasks/obfuscate .mise/tasks/deobfuscate test/obfuscate.bats
elapsed: 5.879 seconds  mise run test test/obfuscate.bats --filter 'installed hooks run notes from installer|post-commit hook preserves valid manifest order'
elapsed: 74.493 seconds mise run test test/obfuscate.bats        # 68/68
elapsed: 44.076 seconds mise run test test/git-operations.bats   # 11/11
elapsed: 0.031 seconds  git diff --check
elapsed: 69.021 seconds mise run test                            # 233/233, including expected skips
```
