### PR TITLE
fix: skip hooks in uninitialized repos

### DIFF
--- a/.mise/tasks/install-hooks
+++ b/.mise/tasks/install-hooks
@@ -8,6 +8,13 @@ source "$MISE_CONFIG_ROOT/lib/hooks.sh"
 require_git
 
 notes_dir="${usage_dir:-notes}"
+manifest="$TARGET_DIR/$notes_dir/.manifest"
+
+if ! is_initialized && [ ! -f "$manifest" ]; then
+  echo "No notes manifest found and git-crypt is not initialized; not installing hooks."
+  echo "Run 'notes setup --yes' to initialize notes in this repo."
+  exit 0
+fi
 
 install_encryption_hook
 install_obfuscation_hook "$notes_dir"

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -383,7 +383,20 @@ setup() {
 
 # --- Hook installation ---
 
+@test "install-hooks no-ops for uninitialized plain notes directories" {
+  run notes install-hooks
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No notes manifest found"* ]]
+  [[ "$output" == *"notes setup --yes"* ]]
+
+  [ ! -e "$NOTES_CALLER_PWD/.gitattributes" ]
+  [ ! -e "$NOTES_CALLER_PWD/.git/hooks/pre-commit" ]
+  [ ! -d "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d" ]
+  [ -z "$(git -C "$NOTES_CALLER_PWD" config --get merge.manifest.driver || true)" ]
+}
+
 @test "install-hooks installs pre-commit hooks" {
+  notes obfuscate
   notes install-hooks
 
   [ -x "$NOTES_CALLER_PWD/.git/hooks/pre-commit" ]
@@ -561,6 +574,7 @@ EOF
 # --- Post-commit hook ---
 
 @test "install-hooks installs post-commit deobfuscation hook" {
+  notes obfuscate
   notes install-hooks
 
   [ -x "$NOTES_CALLER_PWD/.git/hooks/post-commit" ]
@@ -732,6 +746,7 @@ EOF
 # --- Post-merge hook ---
 
 @test "install-hooks installs post-merge deobfuscation hook" {
+  notes obfuscate
   notes install-hooks
 
   [ -x "$NOTES_CALLER_PWD/.git/hooks/post-merge" ]


### PR DESCRIPTION
## Summary

- Make `notes install-hooks` exit successfully without mutation when the target repo is not initialized for notes: no git-crypt state and no notes manifest.
- Tell users to run `notes setup --yes` when they intended to initialize notes.
- Keep hook installation behavior unchanged for repos that already have a notes manifest, including obfuscation-only test fixtures.

Closes #78.

## Verification

```text
elapsed: 0.006 seconds  bash -n .mise/tasks/install-hooks test/obfuscate.bats
elapsed: 2.148 seconds  mise run test test/obfuscate.bats --filter 'install-hooks no-ops|install-hooks installs pre-commit hooks|post-commit hook is no-op when files are not obfuscated'
elapsed: 3.326 seconds  mise run test test/obfuscate.bats --filter 'install-hooks no-ops|install-hooks installs pre-commit hooks|install-hooks installs post-commit|install-hooks installs post-merge'
elapsed: 68.138 seconds mise run test test/obfuscate.bats        # 67/67
elapsed: 0.013 seconds  bash -n .mise/tasks/install-hooks test/obfuscate.bats
elapsed: 0.023 seconds  git diff --check
elapsed: 61.345 seconds mise run test                            # 232/232, including expected skips
```

Note: the first full `test/obfuscate.bats` pass exposed two stale hook-installation tests that still assumed mutation without a manifest. I updated those fixtures to create a manifest before asserting hooks are installed, then reran the targeted and full suites above.
