### PR TITLE
fix: pass package caller cwd to rudi lock

### DIFF
--- a/.mise/tasks/lock
+++ b/.mise/tasks/lock
@@ -30,9 +30,9 @@ if [ -f "$TARGET_DIR/notes/.manifest" ]; then
 fi
 
 if [ -n "${usage_key:-}" ]; then
-  CALLER_PWD="$TARGET_DIR" rudi lock --key "$usage_key"
+  RUDI_CALLER_PWD="$TARGET_DIR" rudi lock --key "$usage_key" # codebase:ignore caller-pwd-contract -- invoking rudi requires rudi's package-scoped caller var
 else
-  CALLER_PWD="$TARGET_DIR" rudi lock
+  RUDI_CALLER_PWD="$TARGET_DIR" rudi lock # codebase:ignore caller-pwd-contract -- invoking rudi requires rudi's package-scoped caller var
   # Known limitation: rudi lock without --key locks ALL git-crypt-encrypted
   # files, not just notes. Tracked in KnickKnackLabs/rudi#5.
   echo "Note: lock re-encrypts all encrypted files in this repo (rudi#5)."

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -38,14 +38,13 @@ without_confirmation() (
 )
 export -f without_confirmation
 
-# rudi() wrapper — calls rudi against the same target repo. rudi still uses
-# the legacy generic caller-dir contract, so translate at the boundary.
+# rudi() wrapper — calls rudi against the same target repo.
 rudi() {
   if [ -z "${NOTES_CALLER_PWD:-}" ]; then
     echo "NOTES_CALLER_PWD not set" >&2
     return 1
   fi
-  CALLER_PWD="$NOTES_CALLER_PWD" command rudi "$@"
+  RUDI_CALLER_PWD="$NOTES_CALLER_PWD" command rudi "$@"
 }
 export -f rudi
 


### PR DESCRIPTION
## Summary

- pass `RUDI_CALLER_PWD` when `notes lock` delegates to `rudi lock`
- update the BATS helper's rudi wrapper to use the package-scoped caller variable
- mark the cross-tool caller var in `notes lock` as an intentional `caller-pwd-contract` exception

## Verification

- `bash -n .mise/tasks/lock test/test_helper.bash lib/common.sh`
- from `KnickKnackLabs/codebase@v0.3.0`: `mise run lint:caller-pwd-contract ~/agents/quick/notes`
- `mise run test test/common.bats --filter 'NOTES_CALLER_PWD takes precedence'`
- `mise run test`

## Note

This is not the CI-unblock release. `notes#93` is already on main and provides the critical `NOTES_CALLER_PWD` target resolution fix for `notes unlock`; this PR just cleans up remaining caller-contract findings around the `notes lock` → `rudi lock` boundary.
