### PR TITLE
fix(audit): harden edge cases (dedupe broken, validate --top, BOM-tolerant frontmatter)

### DIFF
--- a/.mise/tasks/audit
+++ b/.mise/tasks/audit
@@ -53,9 +53,18 @@ from collections import defaultdict
 from pathlib import Path
 
 notes_dir = Path(sys.argv[1])
-# Clamp at zero so `--top -5` doesn't slice off rows from the end of
-# the sorted list (which would silently return a weird subset).
-top_n = max(0, int(sys.argv[2]))
+# Reject non-integer / non-positive --top values up front. Clamping
+# silently to zero (an earlier iteration) produced a confusing
+# "no notes have any links yet" empty-rows message even on link-rich
+# corpora; an explicit error is friendlier than a misleading success.
+try:
+    top_n = int(sys.argv[2])
+except ValueError:
+    print(f"Error: --top must be an integer (got {sys.argv[2]!r})", file=sys.stderr)
+    sys.exit(2)
+if top_n < 1:
+    print(f"Error: --top must be >= 1 (got {top_n})", file=sys.stderr)
+    sys.exit(2)
 as_json = sys.argv[3] == "true"
 
 # Wikilinks anywhere in body text. [[target]] or [[target|display]].
@@ -69,7 +78,9 @@ fence_re = re.compile(r"```.*?```", re.S)
 inline_code_re = re.compile(r"`[^`]*`")
 # Strip a leading YAML frontmatter block so wiki-shaped strings inside
 # frontmatter values (e.g. a `description:` field) don't pollute counts.
-frontmatter_re = re.compile(r"\A---\n.*?\n---\n", re.S)
+# Tolerate an optional UTF-8 BOM so files saved by Windows tooling don't
+# silently leak their frontmatter wikilinks into the body scan.
+frontmatter_re = re.compile(r"\A\ufeff?---\n.*?\n---\n", re.S)
 
 
 def is_external(target: str) -> bool:
@@ -97,7 +108,11 @@ stems = {p.stem for p in notes}
 
 inbound: dict[str, int] = defaultdict(int)
 outbound: dict[str, int] = defaultdict(int)
-broken: dict[str, list[str]] = defaultdict(list)
+# Per-source set of broken target stems. We use a set so a note that
+# references the same missing target three times shows up as one broken
+# link, not three identical lines in the report. The aggregate
+# multiplicity is still visible via the source note's `outbound` count.
+broken: dict[str, set[str]] = defaultdict(set)
 
 for path in notes:
     stem = path.stem
@@ -117,7 +132,7 @@ for path in notes:
         if target in stems:
             inbound[target] += 1
         else:
-            broken[stem].append(target)
+            broken[stem].add(target)
 
 # Ensure every note has a row in the count maps even if it's a
 # zero-link island; makes the JSON output complete and avoids

--- a/test/audit.bats
+++ b/test/audit.bats
@@ -291,6 +291,101 @@ assert data['notes']['src']['broken_targets'] == []
 "
 }
 
+@test "audit deduplicates a repeated broken target within a single source" {
+  cat > "$NOTES_CALLER_PWD/notes/dup.md" <<'EOF'
+---
+title: Dup
+---
+First [[ghost]] then [[ghost]] then [[ghost]] again.
+EOF
+
+  run notes audit
+  [ "$status" -eq 0 ]
+  # The source's outbound count still reflects all three references
+  # (multiplicity preserved at the aggregate level)...
+  echo "$output" | grep -E "^  dup .* outbound:.*3" >/dev/null
+  # ...but the broken-targets report shows the unique missing stem once,
+  # not three identical rows.
+  [[ "$output" == *"Broken wikilink targets (1):"* ]]
+  [ "$(echo "$output" | grep -c "\[\[ghost\]\]")" -eq 1 ]
+
+  run notes audit -- --json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+assert data['notes']['dup']['outbound'] == 3, data['notes']['dup']
+assert data['notes']['dup']['broken_targets'] == ['ghost'], data['notes']['dup']
+"
+}
+
+@test "audit ignores empty-target / empty-alias wikilink shapes" {
+  cat > "$NOTES_CALLER_PWD/notes/shapes.md" <<'EOF'
+---
+title: Shapes
+---
+Empty target with alias only: [[|alias-only]].
+Target with empty alias: [[real|]].
+Whitespace-only target: [[ ]].
+EOF
+  cat > "$NOTES_CALLER_PWD/notes/real.md" <<'EOF'
+---
+title: Real
+---
+Real.
+EOF
+
+  run notes audit -- --json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+# [[|alias]] and [[ ]] produce no link; [[real|]] resolves to 'real'.
+assert data['notes']['shapes']['outbound'] == 1, data['notes']['shapes']
+assert data['notes']['shapes']['broken_targets'] == [], data['notes']['shapes']
+assert data['notes']['real']['inbound'] == 1, data['notes']['real']
+"
+}
+
+@test "audit tolerates a UTF-8 BOM at the start of a note" {
+  printf '\xef\xbb\xbf---\ntitle: BOM\ndescription: "See [[some-other-note]]"\n---\n\nBody has [[real]] only.\n' \
+    > "$NOTES_CALLER_PWD/notes/bom.md"
+  cat > "$NOTES_CALLER_PWD/notes/real.md" <<'EOF'
+---
+title: Real
+---
+Real.
+EOF
+
+  run notes audit -- --json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+# Frontmatter must be stripped even with a BOM prefix; only the body
+# wikilink counts and there are no broken targets.
+assert data['notes']['bom']['outbound'] == 1, data['notes']['bom']
+assert data['notes']['bom']['broken_targets'] == [], data['notes']['bom']
+assert data['notes']['real']['inbound'] == 1, data['notes']['real']
+"
+}
+
+@test "audit rejects non-positive and non-integer --top values" {
+  seed_corpus
+
+  run notes audit -- --top 0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--top must be >= 1"* ]]
+
+  run notes audit -- --top -5
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--top must be >= 1"* ]]
+
+  run notes audit -- --top abc
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--top must be an integer"* ]]
+}
+
 @test "audit errors when notes directory is missing" {
   rm -rf "$NOTES_CALLER_PWD/notes"
 


### PR DESCRIPTION
Fix-it PR for #97 — second-round review follow-ups.

Three behavioral tightenings and one BOM-robustness fix, all scoped to `notes audit`. Each is small enough to revert independently; bundled because they're all the same kind of work (edge cases the existing tests didn't pin).

## Changes

### 1. Dedupe broken targets within a source

Before, `dup.md` referencing `[[ghost]]` three times produced:

```
Broken wikilink targets (3):
  dup  → [[ghost]]
  dup  → [[ghost]]
  dup  → [[ghost]]
```

…and `"broken_targets": ["ghost", "ghost", "ghost"]` in JSON. Now it produces one row and `["ghost"]`. The source's `outbound: 3` still preserves the multiplicity at the aggregate level, so no information is lost — the broken-target listing just stops shouting the same name in triplicate.

Implementation: `defaultdict(list)` → `defaultdict(set)`; `.append` → `.add`. Iteration / sorting / JSON serialization all still work as-is.

### 2. Validate `--top` instead of silently clamping to 0

`--top 0` and `--top -5` previously hit the clamp added in the first-round review and then rendered the misleading message `"(no notes have any links yet)"` even on link-rich corpora (the label said "Top 0 by inbound links" but the body sounded like "you have no links"). `--top abc` raised a raw `ValueError` and dumped a Python traceback at the user.

Now all three exit 2 with `Error: --top must be >= 1 (got ...)` or `Error: --top must be an integer (got ...)`.

If the friendlier behavior is "best-effort: just clamp to 1," that's a one-line tweak — happy to switch on request. The current proposal errors out because it matches what `--dir` already does when given a nonexistent path (exit + message, no silent fallback).

### 3. Tolerate a UTF-8 BOM at the head of a note

`\A---\n.*?\n---\n` doesn't match `\ufeff---\n...` , so a BOM-prefixed file silently leaked its frontmatter wikilinks into the outbound + broken counts. Files saved by some Windows tooling include BOMs. Patch is one character: `\A\ufeff?---\n...`.

### 4. Test coverage for shapes zeke called out

`[[|alias]]` (empty target), `[[target|]]` (empty alias), and `[[ ]]` (whitespace target) were all mentioned in the PR description's worries but not pinned by a test. They work correctly today; the new test locks that behavior so a future regex tweak can't quietly change it.

## Validation

```
$ mise run test
249/249 passing
  (15 audit tests — 11 existing + 4 new — and 234 existing)
```

Smoke run against the den corpus (`NOTES_CALLER_PWD=~/agents/zeke/home/modules/den mise run audit`) produces the same top-N as zeke's pre-fix smoke; broken-target count drops slightly because of dedupe (notes that referenced the same missing stem multiple times now show it once).

## What this does NOT change

- Slash-detection external rule (out of scope; zeke's choice from round 1).
- Layer-agnostic framing in the README and code.
- The JSON schema's outer shape (only `broken_targets` semantics shift from "list of occurrences" to "sorted unique stems").
- The bash wrapper or USAGE flags.
- `notes graph` (out of scope per #83).

Happy to split into smaller PRs if you'd rather review them piecewise.
