### PR TITLE
Guard incomplete deobfuscation conflicts

### DIFF
--- a/.mise/tasks/deobfuscate
+++ b/.mise/tasks/deobfuscate
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #MISE description="Restore obfuscated filenames to their original names"
-#USAGE flag "--dir <dir>" help="Notes directory relative to repo root (default: notes)"
-#USAGE flag "--dry-run" help="Show what would be renamed without doing it"
-#USAGE flag "--force" help="Overwrite existing readable files intentionally"
-#USAGE arg "[files]..." help="Specific obfuscated IDs to deobfuscate. Omit for all."
+#USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root (default: notes)"
+#USAGE flag "--dry-run" default=#false help="Show what would be renamed without doing it"
+#USAGE flag "--force" default=#false help="Overwrite existing readable files intentionally"
+#USAGE arg "[files]..." default="" help="Specific obfuscated IDs to deobfuscate. Omit for all."
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"

--- a/.mise/tasks/deobfuscate
+++ b/.mise/tasks/deobfuscate
@@ -3,7 +3,7 @@
 #USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root (default: notes)"
 #USAGE flag "--dry-run" default=#false help="Show what would be renamed without doing it"
 #USAGE flag "--force" default=#false help="Overwrite existing readable files intentionally"
-#USAGE arg "[files]..." default="" help="Specific obfuscated IDs to deobfuscate. Omit for all."
+#USAGE arg "[files]" var=#true default="" help="Specific obfuscated IDs to deobfuscate. Omit for all."
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"

--- a/.mise/tasks/deobfuscate
+++ b/.mise/tasks/deobfuscate
@@ -26,6 +26,8 @@ if [ -n "${usage_files:-}" ]; then
   while IFS= read -r arg; do
     # Strip notes_dir prefix if provided (e.g. "notes/abc123" → "abc123")
     arg="${arg#"${notes_dir}/"}"
+    # Skip empty variadic defaults after xargs unquotes "''".
+    [ -z "$arg" ] && continue
     arg=$(basename "$arg")
     ARGS+=("$arg")
   done < <(printf '%s' "${usage_files}" | xargs printf '%s\n')

--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -23,6 +23,8 @@ ARGS=()
 if [ -n "${usage_files:-}" ]; then
   while IFS= read -r arg; do
     arg="${arg#"${notes_dir}/"}"
+    # Skip empty variadic defaults after xargs unquotes "''".
+    [ -z "$arg" ] && continue
     ARGS+=("$arg")
   done < <(printf '%s' "${usage_files}" | xargs printf '%s\n')
 fi

--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -2,7 +2,7 @@
 #MISE description="Stage notes for commit (bypasses exclude)"
 #USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root (default: notes)"
 #USAGE flag "--dry-run" default=#false help="Show what would be staged without doing it"
-#USAGE arg "[files]..." default="" help="Specific notes to stage (readable names, relative to notes dir). Omit to stage modified/deleted only; new notes require explicit files."
+#USAGE arg "[files]" var=#true default="" help="Specific notes to stage (readable names, relative to notes dir). Omit to stage modified/deleted only; new notes require explicit files."
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"

--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #MISE description="Stage notes for commit (bypasses exclude)"
-#USAGE flag "--dir <dir>" help="Notes directory relative to repo root (default: notes)"
-#USAGE flag "--dry-run" help="Show what would be staged without doing it"
-#USAGE arg "[files]..." help="Specific notes to stage (readable names, relative to notes dir). Omit to stage modified/deleted only; new notes require explicit files."
+#USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root (default: notes)"
+#USAGE flag "--dry-run" default=#false help="Show what would be staged without doing it"
+#USAGE arg "[files]..." default="" help="Specific notes to stage (readable names, relative to notes dir). Omit to stage modified/deleted only; new notes require explicit files."
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
@@ -46,6 +46,38 @@ fi
 
 to_stage=()
 skipped_new=()
+
+conflicting_notes=$(detect_dual_present_conflicts "$abs_notes_dir") || true
+if [ -n "$conflicting_notes" ]; then
+  blocked_conflicts=()
+  while IFS=$'\t' read -r conflict_id conflict_relpath; do
+    [ -z "$conflict_id" ] && continue
+    if $explicit_files; then
+      match=false
+      for f in "${ARGS[@]}"; do
+        [ "$f" = "$conflict_relpath" ] && match=true && break
+      done
+      $match || continue
+    fi
+    blocked_conflicts+=("$conflict_id"$'\t'"$conflict_relpath")
+  done <<< "$conflicting_notes"
+
+  if [ ${#blocked_conflicts[@]} -gt 0 ]; then
+    echo "Error: incomplete deobfuscation detected; refusing to stage conflicting note(s)." >&2
+    echo "A readable note and its obfuscated source both exist with different content:" >&2
+    for conflict in "${blocked_conflicts[@]}"; do
+      IFS=$'\t' read -r conflict_id conflict_relpath <<< "$conflict"
+      echo "  $conflict_relpath (also present as $notes_dir/$conflict_id)" >&2
+    done
+    echo "" >&2
+    echo "Run 'notes deobfuscate' after resolving local edits, or inspect with:" >&2
+    for conflict in "${blocked_conflicts[@]}"; do
+      IFS=$'\t' read -r _conflict_id conflict_relpath <<< "$conflict"
+      echo "  notes changes $conflict_relpath" >&2
+    done
+    exit 1
+  fi
+fi
 
 print_skipped_new() {
   [ ${#skipped_new[@]} -eq 0 ] && return 0

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Show encryption and obfuscation status"
-#USAGE flag "--json" help="Output as JSON"
-#USAGE flag "--dir <dir>" help="Notes directory name (default: notes)"
+#USAGE flag "--json" default=#false help="Output as JSON"
+#USAGE flag "--dir <dir>" default="notes" help="Notes directory name (default: notes)"
 set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
@@ -50,7 +50,16 @@ if [ "$enc_status" != "locked" ] && [ -f "$NOTES_DIR/.manifest" ]; then
   fi
 fi
 
-# --- Output ---
+# --- Incomplete deobfuscation detection ---
+
+incomplete_deobfuscation=""
+incomplete_conflicts=0
+if [ "$enc_status" != "locked" ] && [ -f "$NOTES_DIR/.manifest" ]; then
+  incomplete_deobfuscation=$(detect_dual_present_conflicts "$TARGET_DIR/$NOTES_DIR" 2>/dev/null) || true
+  if [ -n "$incomplete_deobfuscation" ]; then
+    incomplete_conflicts=$(printf '%s\n' "$incomplete_deobfuscation" | wc -l | tr -d ' ')
+  fi
+fi
 
 # --- Changes (only when deobfuscated) ---
 
@@ -83,6 +92,7 @@ if [ "$JSON" = "true" ]; then
       '{
         encryption: { status: $enc, unlocked: $enc_unlocked },
         obfuscation: { status: "unknown", notes: null },
+        incomplete_deobfuscation: { conflicts: 0 },
         changes: null
       }'
   else
@@ -95,9 +105,11 @@ if [ "$JSON" = "true" ]; then
       --argjson chg_new "$changes_new" \
       --argjson chg_deleted "$changes_deleted" \
       --argjson chg_total "$changes_total" \
+      --argjson incomplete_conflicts "$incomplete_conflicts" \
       '{
         encryption: { status: $enc, unlocked: $enc_unlocked },
         obfuscation: { status: $obf, notes: $total_notes },
+        incomplete_deobfuscation: { conflicts: $incomplete_conflicts },
         changes: { total: $chg_total, modified: $chg_modified, new: $chg_new, deleted: $chg_deleted }
       }'
   fi
@@ -113,6 +125,15 @@ else
     echo "Run 'notes unlock' to decrypt files and see obfuscation status."
   else
     echo "Obfuscation: $obf_status ($total_notes notes)"
+    if [ "$incomplete_conflicts" -gt 0 ]; then
+      echo ""
+      echo "Incomplete deobfuscation: $incomplete_conflicts conflict(s)"
+      while IFS=$'\t' read -r conflict_id conflict_relpath; do
+        [ -z "$conflict_id" ] && continue
+        echo "  $conflict_relpath (also present as $NOTES_DIR/$conflict_id)"
+      done <<< "$incomplete_deobfuscation"
+      echo "Run 'notes deobfuscate' after resolving local edits; use 'notes changes <file>' to inspect."
+    fi
     if [ "$obf_status" = "deobfuscated" ]; then
       if [ "$changes_total" -gt 0 ]; then
         echo "Changes:     $changes_total ($changes_modified modified, $changes_new new, $changes_deleted deleted)"

--- a/hooks/post-merge-deobfuscate.template
+++ b/hooks/post-merge-deobfuscate.template
@@ -20,6 +20,16 @@ if [ -f "$NOTES_ROOT/.manifest" ]; then
   # Run the notes package version that installed this hook, not whichever
   # `notes` command happens to appear first on PATH. Suppress stdout (rename
   # output) but let stderr through so dirty-readable refusals and hard failures
-  # are visible to the user/agent.
-  run_notes deobfuscate >/dev/null
+  # are visible to the user/agent. ORIG_HEAD lets deobfuscate prove a missing
+  # state-row readable is clean stale pre-merge content before refreshing it.
+  if NOTES_DEOBFUSCATE_BASE_REF=ORIG_HEAD run_notes deobfuscate >/dev/null; then
+    :
+  else
+    rc=$?
+    cat >&2 <<EOF
+Warning: git completed, but notes deobfuscation is incomplete.
+Run 'notes status' to see conflicts, and 'notes changes <file>' before staging.
+EOF
+    exit "$rc"
+  fi
 fi

--- a/lib/changes.sh
+++ b/lib/changes.sh
@@ -5,6 +5,27 @@
 # (obfuscated IDs in the index). This library compares readable content against
 # committed content to detect modifications, additions, and deletions.
 
+# Detect manifest entries where both the obfuscated ID and readable path exist
+# on disk with different content. This is the dangerous state left behind when
+# post-merge/post-rebase deobfuscation preserves a dirty readable note while the
+# incoming obfuscated source remains present.
+#
+# Outputs one line per conflict: "<id>\t<readable_name>"
+# Usage: detect_dual_present_conflicts <abs_notes_dir>
+detect_dual_present_conflicts() {
+  local abs_notes_dir="${1:?usage: detect_dual_present_conflicts <abs_notes_dir>}"
+  local manifest="$abs_notes_dir/.manifest"
+  [ ! -f "$manifest" ] && return 0
+
+  while IFS=$'\t' read -r id relpath; do
+    [ -z "$id" ] && continue
+    [ -f "$abs_notes_dir/$id" ] || continue
+    [ -f "$abs_notes_dir/$relpath" ] || continue
+    cmp -s "$abs_notes_dir/$id" "$abs_notes_dir/$relpath" && continue
+    printf '%s\t%s\n' "$id" "$relpath"
+  done < "$manifest"
+}
+
 # Detect changed notes relative to HEAD.
 # Outputs one line per change: "<status>\t<readable_name>"
 # Status values: modified, new, deleted

--- a/lib/obfuscate.sh
+++ b/lib/obfuscate.sh
@@ -204,6 +204,31 @@ _deobfuscation_base_hash_for_id() {
   awk -F '\t' -v wanted="$id" '$1 == wanted { found=$2 } END { if (found != "") print found }' "$state"
 }
 
+_deobfuscation_readable_matches_base_ref() {
+  local notes_dir="$1" id="$2" relpath="$3" base_ref="$4"
+  [ -n "$base_ref" ] || return 1
+  [ -f "$notes_dir/$relpath" ] || return 1
+
+  resolve_notes_dir "$notes_dir" || return 1
+  local repo_root="$RESOLVED_REPO_ROOT"
+  local notes_rel="$RESOLVED_NOTES_DIR"
+  local tmp
+  tmp=$(mktemp) || return 1
+
+  if ! git -C "$repo_root" cat-file --filters "$base_ref:$notes_rel/$id" > "$tmp" 2>/dev/null; then
+    rm -f "$tmp"
+    return 1
+  fi
+
+  if cmp -s "$tmp" "$notes_dir/$relpath"; then
+    rm -f "$tmp"
+    return 0
+  fi
+
+  rm -f "$tmp"
+  return 1
+}
+
 _record_deobfuscation_base_hashes() {
   local notes_dir="$1"
   shift
@@ -247,7 +272,7 @@ _rename_one_to_readable() {
   [ ! -d "$target_dir" ] && mkdir -p "$target_dir"
 
   if [ -e "$notes_dir/$relpath" ] && ! cmp -s "$notes_dir/$id" "$notes_dir/$relpath"; then
-    local current_hash base_hash state_file
+    local current_hash base_hash state_file dirty_readable=false
     state_file=$(_deobfuscation_state_file "$notes_dir" 2>/dev/null) || state_file=""
     current_hash=$(git -C "$notes_dir" hash-object -- "$notes_dir/$relpath" 2>/dev/null || true)
     base_hash=$(_deobfuscation_base_hash_for_id "$notes_dir" "$id")
@@ -255,9 +280,15 @@ _rename_one_to_readable() {
     # No state file (fresh clone or pre-safety upgrade) -> trust the readable
     # and let the rename proceed. Force-prompting on every file would train
     # users into --force-as-default, which is worse than the one-time window.
-    if [ -n "$state_file" ] && [ -f "$state_file" ] \
-      && { [ -z "$base_hash" ] || [ "$current_hash" != "$base_hash" ]; }; then
-      if [ "${NOTES_DEOBFUSCATE_FORCE:-false}" != "true" ]; then
+    if [ -n "$state_file" ] && [ -f "$state_file" ]; then
+      if [ -n "$base_hash" ]; then
+        [ "$current_hash" != "$base_hash" ] && dirty_readable=true
+      elif ! _deobfuscation_readable_matches_base_ref \
+        "$notes_dir" "$id" "$relpath" "${NOTES_DEOBFUSCATE_BASE_REF:-}"; then
+        dirty_readable=true
+      fi
+
+      if $dirty_readable && [ "${NOTES_DEOBFUSCATE_FORCE:-false}" != "true" ]; then
         echo "Error: refusing to overwrite dirty readable note: $relpath" >&2
         echo "This may be a real local edit, or a cosmetic editor re-save (trailing-newline trim, BOM, line-ending change)." >&2
         echo "Run 'notes changes $relpath' to inspect; rerun with --force to overwrite intentionally." >&2

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,5 @@
+min_version = "2026.5.5"
+
 [settings]
 quiet = true
 task_output = "interleave"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,3 @@
-min_version = "2026.5.5"
-
 [settings]
 quiet = true
 task_output = "interleave"

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 bats = "1.13.0"
 gum = "0.17.0"
 "aqua:shenwei356/rush" = "0.9.0"
-"shiv:rudi" = "0.5.4"
+"shiv:rudi" = "0.5"
 # git-crypt has no macOS binary on GitHub releases.
 # macOS: brew install git-crypt
 # Linux: downloaded from GitHub releases by rudi install

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -278,6 +278,17 @@ setup() {
   [[ "$output" != *"notes/gamma.md"* ]]
 }
 
+@test "notes stage: no args ignores inherited usage_files" {
+  echo "# Alpha modified" > "$NOTES_CALLER_PWD/notes/alpha.md"
+
+  usage_files="gamma.md" run notes stage
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"staged: alpha.md"* ]]
+
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
+  [[ "$output" == *"notes/alpha.md"* ]]
+}
+
 @test "notes stage: explicit file stages a new note" {
   echo "# Gamma" > "$NOTES_CALLER_PWD/notes/gamma.md"
 

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -289,6 +289,24 @@ setup() {
   [[ "$output" == *"notes/gamma.md"* ]]
 }
 
+@test "notes stage: refuses dual-present differing readable and obfuscated pair" {
+  local alpha_id
+  alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
+
+  echo "# Alpha local edit" > "$NOTES_CALLER_PWD/notes/alpha.md"
+  echo "# Alpha incoming upstream" > "$NOTES_CALLER_PWD/notes/$alpha_id"
+
+  run notes stage alpha.md
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"incomplete deobfuscation"* ]]
+  [[ "$output" == *"alpha.md"* ]]
+  [[ "$output" == *"notes deobfuscate"* ]]
+  [[ "$output" == *"notes changes alpha.md"* ]]
+
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
+  [[ "$output" != *"notes/alpha.md"* ]]
+}
+
 @test "notes stage: no args skips readable files left from another branch" {
   local repo="$BATS_TEST_TMPDIR/branch-repo"
   mkdir -p "$repo/notes"

--- a/test/git-operations.bats
+++ b/test/git-operations.bats
@@ -158,7 +158,18 @@ setup() {
   [ ! -f "$LOCAL/notes/$beta_id" ]
 
   [[ "$output" == *"refusing to overwrite dirty readable note: alpha.md"* ]]
+  [[ "$output" == *"git completed, but notes deobfuscation is incomplete"* ]]
   [[ "$output" == *"post-merge hook failed"* ]]
+
+  NOTES_CALLER_PWD="$LOCAL" run notes status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Incomplete deobfuscation"* ]]
+  [[ "$output" == *"alpha.md"* ]]
+
+  NOTES_CALLER_PWD="$LOCAL" run notes stage alpha.md
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"incomplete deobfuscation"* ]]
+  [[ "$output" == *"notes changes alpha.md"* ]]
 }
 
 # ── Merge ─────────────────────────────────────────────────────

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -368,6 +368,20 @@ setup() {
   [ -f "$NOTES_CALLER_PWD/notes/$id" ]
 }
 
+@test "deobfuscate ignores inherited usage_files without explicit IDs" {
+  notes obfuscate
+  local alpha_id beta_id gamma_id
+  alpha_id=$(grep "alpha.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  beta_id=$(grep "beta.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  gamma_id=$(grep "gamma.txt" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+
+  usage_files="$alpha_id" run notes deobfuscate -- --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$alpha_id → alpha.md"* ]]
+  [[ "$output" == *"$beta_id → beta.md"* ]]
+  [[ "$output" == *"$gamma_id → gamma.txt"* ]]
+}
+
 @test "round-trip preserves all content and metadata" {
   notes obfuscate
   notes deobfuscate

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -811,6 +811,7 @@ EOT
   grep -q "Generic hook dispatcher" "$NOTES_CALLER_PWD/.git/hooks/post-merge"
   [ -x "$NOTES_CALLER_PWD/.git/hooks/post-merge.d/deobfuscation" ]
   grep -q "manifest" "$NOTES_CALLER_PWD/.git/hooks/post-merge.d/deobfuscation"
+  grep -q "NOTES_DEOBFUSCATE_BASE_REF=ORIG_HEAD" "$NOTES_CALLER_PWD/.git/hooks/post-merge.d/deobfuscation"
 }
 
 # --- Scoped obfuscation (variadic args) ---
@@ -984,6 +985,37 @@ EOT
   [ -f "$NOTES_CALLER_PWD/notes/$alpha_id" ]
 }
 
+@test "deobfuscate refreshes clean stale readable when state row is missing but base ref matches" {
+  notes obfuscate
+  local alpha_id base_ref state
+  alpha_id=$(grep "alpha.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  git -C "$NOTES_CALLER_PWD" add -A notes
+  git -C "$NOTES_CALLER_PWD" commit -q -m "obfuscate v1"
+  base_ref=$(git -C "$NOTES_CALLER_PWD" rev-parse HEAD)
+
+  notes deobfuscate
+  state="$NOTES_CALLER_PWD/.git/info/notes-obfuscation-state"
+  [ -f "$state" ]
+
+  echo "# Alpha v2" > "$NOTES_CALLER_PWD/notes/alpha.md"
+  notes obfuscate alpha.md
+  git -C "$NOTES_CALLER_PWD" commit -q -m "obfuscate v2"
+
+  # Simulate a partial/old state file after pull: alpha.md is still the clean
+  # pre-merge readable, the new obfuscated source is present, but alpha's state
+  # row is missing. ORIG_HEAD/base-ref should prove the readable is safe to
+  # refresh instead of treating it as a local edit.
+  git -C "$NOTES_CALLER_PWD" cat-file --filters "$base_ref:notes/$alpha_id" > "$NOTES_CALLER_PWD/notes/alpha.md"
+  grep -v "^${alpha_id}"$'\t' "$state" > "$state.tmp"
+  mv "$state.tmp" "$state"
+
+  NOTES_DEOBFUSCATE_BASE_REF="$base_ref" run notes deobfuscate
+  [ "$status" -eq 0 ]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" == *"# Alpha v2"* ]]
+  [ ! -f "$NOTES_CALLER_PWD/notes/$alpha_id" ]
+  grep -q "^${alpha_id}"$'\t' "$state"
+}
+
 @test "deobfuscate --force intentionally overwrites dirty readable note" {
   notes obfuscate
   local alpha_id
@@ -998,6 +1030,24 @@ EOT
   [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
   [[ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" == *"# Alpha"* ]]
   [[ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" != *"local edit"* ]]
+}
+
+@test "deobfuscate ignores inherited usage_force without explicit --force" {
+  notes obfuscate
+  local alpha_id
+  alpha_id=$(grep "alpha.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  git -C "$NOTES_CALLER_PWD" add -A notes
+  git -C "$NOTES_CALLER_PWD" commit -q -m "obfuscate"
+
+  notes deobfuscate
+  echo "local edit" >> "$NOTES_CALLER_PWD/notes/alpha.md"
+  git -C "$NOTES_CALLER_PWD" update-index --no-assume-unchanged "notes/$alpha_id" 2>/dev/null || true
+  git -C "$NOTES_CALLER_PWD" checkout -- "notes/$alpha_id"
+
+  usage_force=true run notes deobfuscate
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"refusing to overwrite dirty readable note"* ]]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" == *"local edit"* ]]
 }
 
 @test "deobfuscate allows identical readable note copy" {

--- a/test/status.bats
+++ b/test/status.bats
@@ -49,6 +49,19 @@ load test_helper
   echo "$output" | grep -q "1 notes"
 }
 
+@test "status reports incomplete deobfuscation for dual-present differing pair" {
+  mkdir -p "$TARGET_DIR/notes"
+  printf 'aaaaaaaa\talpha.md\n' > "$TARGET_DIR/notes/.manifest"
+  echo "# Alpha local edit" > "$TARGET_DIR/notes/alpha.md"
+  echo "# Alpha incoming upstream" > "$TARGET_DIR/notes/aaaaaaaa"
+
+  run notes status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Incomplete deobfuscation"* ]]
+  [[ "$output" == *"alpha.md"* ]]
+  [[ "$output" == *"notes/aaaaaaaa"* ]]
+}
+
 # --- JSON output ---
 
 @test "status --json outputs valid JSON" {

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -7,6 +7,29 @@ export REPO_DIR
 # directly instead of going through `mise run test`.
 eval "$(cd "$REPO_DIR" && mise env)"
 
+# Agent sessions inject command-scope git config so real workspace commits are
+# signed. That command-scope config outranks a throwaway test repo's local
+# `commit.gpgsign=false`, so integration tests can fail when the agent's signing
+# key is unavailable. Tests should exercise git behavior, not the launcher's
+# ambient signing policy; keep commits/tags unsigned while preserving normal
+# global/local user identity resolution.
+_disable_git_signing_for_tests() {
+  local name _value
+  unset GIT_CONFIG_COUNT GIT_CONFIG_PARAMETERS
+  while IFS='=' read -r name _value; do
+    case "$name" in
+      GIT_CONFIG_KEY_*|GIT_CONFIG_VALUE_*) unset "$name" ;;
+    esac
+  done < <(env)
+
+  export GIT_CONFIG_COUNT=2
+  export GIT_CONFIG_KEY_0=commit.gpgsign
+  export GIT_CONFIG_VALUE_0=false
+  export GIT_CONFIG_KEY_1=tag.gpgsign
+  export GIT_CONFIG_VALUE_1=false
+}
+_disable_git_signing_for_tests
+
 # Source lib files at file-load time, not inside setup(). Most .bats files in
 # this suite override setup() to set their own NOTES_CALLER_PWD/fixtures, which
 # shadows the helper's setup() and silently drops the lib sources. Sourcing


### PR DESCRIPTION
## Summary

- refresh clean stale readables when a state row is missing but `ORIG_HEAD` proves the readable matches the pre-merge blob
- report dual-present readable/obfuscated conflicts in `notes status`
- refuse `notes stage` for dual-present differing pairs so local stale readables cannot overwrite upstream content
- make the post-merge hook pass `ORIG_HEAD` and warn clearly when Git completed but deobfuscation did not
- keep explicit `#USAGE` defaults to prevent inherited `usage_*` leakage; use the canonical variadic form `arg "[files]" var=#true default=""` for file arguments
- neutralize ambient agent Git signing config in BATS so local agent sessions can run integration tests without the agent signing key inside isolated `GNUPGHOME`

Closes #99.

## Verification

- `mise run test test/obfuscate.bats --filter 'base ref|post-merge deobfuscation hook'`
- `mise run test test/changes.bats --filter 'dual-present differing'`
- `mise run test test/status.bats --filter 'incomplete deobfuscation'`
- `mise run test test/git-operations.bats --filter 'dirty readable does not block safe remote updates later in manifest'`
- `mise run test test/obfuscate.bats --filter 'inherited usage_files|deobfuscate dry-run'`
- `mise run test test/changes.bats --filter 'inherited usage_files|dual-present differing'`
- `mise run test test/obfuscate.bats`
- `mise run test test/git-operations.bats`
- `mise run test` — 240/240 incl. expected skips
- `bash -n .mise/tasks/deobfuscate .mise/tasks/stage .mise/tasks/status hooks/post-merge-deobfuscate.template lib/changes.sh lib/obfuscate.sh test/test_helper.bash test/changes.bats test/git-operations.bats test/obfuscate.bats test/status.bats`
- `git diff --check`
- compatibility probe: `#USAGE arg "[files]" var=#true default=""` clears inherited `usage_files` and preserves flags on mise `2026.3.0`
