### PR TITLE
Fix variadic usage defaults for notes#102

### DIFF
--- a/.mise/tasks/deobfuscate
+++ b/.mise/tasks/deobfuscate
@@ -3,7 +3,7 @@
 #USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root (default: notes)"
 #USAGE flag "--dry-run" default=#false help="Show what would be renamed without doing it"
 #USAGE flag "--force" default=#false help="Overwrite existing readable files intentionally"
-#USAGE arg "[files]..." default="" help="Specific obfuscated IDs to deobfuscate. Omit for all."
+#USAGE arg "[files]..." help="Specific obfuscated IDs to deobfuscate. Omit for all."
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"

--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -2,7 +2,7 @@
 #MISE description="Stage notes for commit (bypasses exclude)"
 #USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root (default: notes)"
 #USAGE flag "--dry-run" default=#false help="Show what would be staged without doing it"
-#USAGE arg "[files]..." default="" help="Specific notes to stage (readable names, relative to notes dir). Omit to stage modified/deleted only; new notes require explicit files."
+#USAGE arg "[files]..." help="Specific notes to stage (readable names, relative to notes dir). Omit to stage modified/deleted only; new notes require explicit files."
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"


### PR DESCRIPTION
## Summary

- remove `default=""` from variadic `#USAGE arg` lines in `deobfuscate` and `stage`
- keeps flag parsing working on the repo's current mise/usage path while preserving the explicit flag defaults that neutralize inherited `usage_force`

## Verification

- `mise run test test/obfuscate.bats --filter 'deobfuscate dry-run|inherited usage_force'`
- `mise run test test/changes.bats --filter 'dual-present differing'`
- `mise run test`
- `bash -n .mise/tasks/deobfuscate .mise/tasks/stage`
- `git diff --check`
