### PR TITLE
Fix notes#102 variadic usage inheritance

### DIFF
--- a/.mise/tasks/deobfuscate
+++ b/.mise/tasks/deobfuscate
@@ -3,7 +3,7 @@
 #USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root (default: notes)"
 #USAGE flag "--dry-run" default=#false help="Show what would be renamed without doing it"
 #USAGE flag "--force" default=#false help="Overwrite existing readable files intentionally"
-#USAGE arg "[files]..." default="" help="Specific obfuscated IDs to deobfuscate. Omit for all."
+#USAGE arg "[files]..." help="Specific obfuscated IDs to deobfuscate. Omit for all."
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
@@ -21,6 +21,33 @@ fi
 # Parse variadic args safely (mise wraps multi-word args in single quotes).
 # xargs respects shell quoting so spaces in filenames work correctly.
 # Limitation: backslashes in filenames are treated as escape characters by xargs.
+#
+# Do not add a #USAGE default to variadic args: mise versions through at least
+# 2026.5.15 stop exporting flag env correctly when a file task combines flags
+# with a variadic default. Instead, clear inherited usage_files by checking the
+# raw task argv that mise also forwards to file tasks.
+raw_has_file_args=false
+skip_next=false
+for raw_arg in "$@"; do
+  if $skip_next; then
+    skip_next=false
+    continue
+  fi
+  case "$raw_arg" in
+    --dir)
+      skip_next=true
+      ;;
+    --dir=*|--dry-run|--force|--)
+      ;;
+    *)
+      raw_has_file_args=true
+      ;;
+  esac
+done
+if ! $raw_has_file_args; then
+  usage_files=""
+fi
+
 ARGS=()
 if [ -n "${usage_files:-}" ]; then
   while IFS= read -r arg; do

--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -2,7 +2,7 @@
 #MISE description="Stage notes for commit (bypasses exclude)"
 #USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root (default: notes)"
 #USAGE flag "--dry-run" default=#false help="Show what would be staged without doing it"
-#USAGE arg "[files]..." default="" help="Specific notes to stage (readable names, relative to notes dir). Omit to stage modified/deleted only; new notes require explicit files."
+#USAGE arg "[files]..." help="Specific notes to stage (readable names, relative to notes dir). Omit to stage modified/deleted only; new notes require explicit files."
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
@@ -18,7 +18,33 @@ if [ ! -f "$manifest" ]; then
   exit 1
 fi
 
-# Parse variadic args
+# Parse variadic args. Do not add a #USAGE default to variadic args: mise
+# versions through at least 2026.5.15 stop exporting flag env correctly when a
+# file task combines flags with a variadic default. Instead, clear inherited
+# usage_files by checking the raw task argv that mise also forwards to file
+# tasks.
+raw_has_file_args=false
+skip_next=false
+for raw_arg in "$@"; do
+  if $skip_next; then
+    skip_next=false
+    continue
+  fi
+  case "$raw_arg" in
+    --dir|--dry-run)
+      [ "$raw_arg" = "--dir" ] && skip_next=true
+      ;;
+    --dir=*|--)
+      ;;
+    *)
+      raw_has_file_args=true
+      ;;
+  esac
+done
+if ! $raw_has_file_args; then
+  usage_files=""
+fi
+
 ARGS=()
 if [ -n "${usage_files:-}" ]; then
   while IFS= read -r arg; do


### PR DESCRIPTION
Fix-it for #102 after re-review of 9970e21.

`default=""` on variadic file-task args still breaks flag env export on mise 2026.5.5 and 2026.5.15 in my runner, so the dry-run tests enter the real deobfuscation path. This keeps variadic defaults off, but explicitly clears inherited `usage_files` when the raw task argv contains no file arguments.

Verification:

- `mise run test test/obfuscate.bats --filter 'inherited usage_files|deobfuscate dry-run'`
- `mise run test test/changes.bats --filter 'inherited usage_files|dual-present differing'`
- `mise run test`
- `bash -n .mise/tasks/deobfuscate .mise/tasks/stage`
- `git diff --check`
