### PR TITLE
Fix empty variadic defaults

### DIFF
--- a/.mise/tasks/deobfuscate
+++ b/.mise/tasks/deobfuscate
@@ -24,9 +24,14 @@ fi
 ARGS=()
 if [ -n "${usage_files:-}" ]; then
   while IFS= read -r arg; do
+    # Mise renders an empty variadic default as a shell-quoted empty string.
+    # xargs correctly unquotes it to an empty line; do not treat that as an
+    # explicit empty file argument.
+    [ -z "$arg" ] && continue
     # Strip notes_dir prefix if provided (e.g. "notes/abc123" → "abc123")
     arg="${arg#"${notes_dir}/"}"
     arg=$(basename "$arg")
+    [ -z "$arg" ] && continue
     ARGS+=("$arg")
   done < <(printf '%s' "${usage_files}" | xargs printf '%s\n')
 fi

--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -22,7 +22,12 @@ fi
 ARGS=()
 if [ -n "${usage_files:-}" ]; then
   while IFS= read -r arg; do
+    # Mise renders an empty variadic default as a shell-quoted empty string.
+    # xargs correctly unquotes it to an empty line; do not treat that as an
+    # explicit empty file argument.
+    [ -z "$arg" ] && continue
     arg="${arg#"${notes_dir}/"}"
+    [ -z "$arg" ] && continue
     ARGS+=("$arg")
   done < <(printf '%s' "${usage_files}" | xargs printf '%s\n')
 fi


### PR DESCRIPTION
## Summary

- Skip empty values after parsing variadic `usage_files` defaults in `deobfuscate` and `stage`
- Preserves the canonical `#USAGE arg "[files]" var=#true default=""` metadata while avoiding an explicit empty argument when mise renders the default as `''`

## Verification

- `mise run test test/obfuscate.bats --filter 'inherited usage_files|deobfuscate dry-run'`
- `mise run test test/changes.bats --filter 'inherited usage_files|dual-present differing'`
- `mise run test test/status.bats --filter 'incomplete deobfuscation'`
- `mise run test test/git-operations.bats --filter 'dirty readable does not block safe remote updates later in manifest'`
- `bash -n .mise/tasks/deobfuscate .mise/tasks/stage .mise/tasks/status hooks/post-merge-deobfuscate.template lib/changes.sh lib/obfuscate.sh test/test_helper.bash test/changes.bats test/git-operations.bats test/obfuscate.bats test/status.bats`
- `git diff --check`

Full `mise run test` is degraded in this runner: after this fix the PR's targeted paths pass, but pre-existing `test/new.bats` / one round-trip assertion fail because direct setup command output is included in later BATS failure output in this headless environment. I did not treat that as validation for this fix.
