### PR TITLE
Add readable notes diff command

### DIFF
--- a/.mise/tasks/diff
+++ b/.mise/tasks/diff
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#MISE description="Show readable note diffs for the working tree, refs, or a PR"
+#USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root (default: notes)"
+#USAGE flag "--pr <number>" default="" help="Diff a GitHub PR from the current repo's origin remote"
+#USAGE flag "--out <dir>" default="" help="Write readable base/head trees and readable.patch to this directory"
+#USAGE arg "[refs]" var=#true default="" help="Optional ref/range: BASE HEAD, BASE..HEAD, or BASE...HEAD. Omit for working-tree diff against HEAD."
+set -euo pipefail
+
+source "$MISE_CONFIG_ROOT/lib/common.sh"
+source "$MISE_CONFIG_ROOT/lib/changes.sh"
+source "$MISE_CONFIG_ROOT/lib/diff.sh"
+require_git
+
+notes_dir="${usage_dir:-notes}"
+pr_number="${usage_pr:-}"
+out_arg="${usage_out:-}"
+abs_notes_dir="$TARGET_DIR/$notes_dir"
+repo_root=$(git -C "$TARGET_DIR" rev-parse --show-toplevel)
+
+ARGS=()
+if [ -n "${usage_refs:-}" ]; then
+  while IFS= read -r arg; do
+    [ -z "$arg" ] && continue
+    ARGS+=("$arg")
+  done < <(printf '%s' "$usage_refs" | xargs printf '%s\n')
+fi
+
+if [ -n "$pr_number" ] && [ ${#ARGS[@]} -gt 0 ]; then
+  echo "Error: pass either --pr or refs, not both" >&2
+  exit 1
+fi
+
+if [ -z "$pr_number" ] && [ ${#ARGS[@]} -eq 0 ]; then
+  manifest="$abs_notes_dir/.manifest"
+  if [ ! -f "$manifest" ]; then
+    echo "No manifest found. Run 'notes obfuscate' first." >&2
+    exit 1
+  fi
+
+  changes=$(detect_changes "$abs_notes_dir") || true
+  if [ -z "$changes" ]; then
+    echo "No changes."
+    exit 0
+  fi
+
+  show_diffs "$abs_notes_dir"
+  exit 0
+fi
+
+base_ref=""
+head_ref=""
+temp_refs=()
+
+cleanup_temp_refs() {
+  local ref
+  for ref in ${temp_refs[@]+"${temp_refs[@]}"}; do
+    git -C "$repo_root" update-ref -d "$ref" 2>/dev/null || true
+  done
+}
+trap cleanup_temp_refs EXIT
+
+if [ -n "$pr_number" ]; then
+  gh_cmd="${GH:-gh}"
+  if ! command -v "$gh_cmd" >/dev/null 2>&1; then
+    echo "Error: gh not found; --pr requires GitHub CLI or GH=/path/to/gh" >&2
+    exit 1
+  fi
+
+  if ! base_branch=$("$gh_cmd" pr view "$pr_number" --json baseRefName --jq .baseRefName); then
+    echo "Error: failed to resolve PR #$pr_number base branch" >&2
+    exit 1
+  fi
+  if [ -z "$base_branch" ]; then
+    echo "Error: PR #$pr_number did not report a base branch" >&2
+    exit 1
+  fi
+
+  safe_pr=$(printf '%s' "$pr_number" | tr -c 'A-Za-z0-9._-' '-')
+  base_ref="refs/notes-diff/pr-$safe_pr-$$-base"
+  head_ref="refs/notes-diff/pr-$safe_pr-$$-head"
+  temp_refs+=("$base_ref" "$head_ref")
+
+  git -C "$repo_root" fetch --quiet origin \
+    "+refs/heads/$base_branch:$base_ref" \
+    "+refs/pull/$pr_number/head:$head_ref"
+  base_ref=$(git -C "$repo_root" merge-base "$base_ref" "$head_ref")
+else
+  case ${#ARGS[@]} in
+    1)
+      range="${ARGS[0]}"
+      case "$range" in
+        *...*)
+          left_ref="${range%%...*}"
+          right_ref="${range#*...}"
+          if [ -z "$left_ref" ] || [ -z "$right_ref" ]; then
+            echo "Error: triple-dot ranges must include both refs" >&2
+            exit 1
+          fi
+          base_ref=$(git -C "$repo_root" merge-base "$left_ref" "$right_ref")
+          head_ref="$right_ref"
+          ;;
+        *..*)
+          base_ref="${range%%..*}"
+          head_ref="${range#*..}"
+          ;;
+        *)
+          base_ref="$range"
+          head_ref="HEAD"
+          ;;
+      esac
+      ;;
+    2)
+      base_ref="${ARGS[0]}"
+      head_ref="${ARGS[1]}"
+      ;;
+    *)
+      echo "Error: expected at most two refs" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+if [ -z "$base_ref" ] || [ -z "$head_ref" ]; then
+  echo "Error: both base and head refs are required" >&2
+  exit 1
+fi
+
+if [ -n "$out_arg" ]; then
+  out_dir="$out_arg"
+  cleanup_out=false
+else
+  out_dir=$(mktemp -d) || exit 1
+  cleanup_out=true
+fi
+
+cleanup_out_dir() {
+  if [ "${cleanup_out:-false}" = "true" ]; then
+    rm -rf "$out_dir"
+  fi
+}
+trap 'cleanup_temp_refs; cleanup_out_dir' EXIT
+
+_prepare_diff_workspace "$out_dir"
+materialize_readable_notes_ref "$repo_root" "$notes_dir" "$base_ref" "$out_dir/base"
+materialize_readable_notes_ref "$repo_root" "$notes_dir" "$head_ref" "$out_dir/head"
+generate_readable_notes_patch "$out_dir/base" "$out_dir/head" "$out_dir/readable.patch"
+
+if [ -s "$out_dir/readable.patch" ]; then
+  cat "$out_dir/readable.patch"
+else
+  echo "No readable note changes." >&2
+fi
+
+if [ -n "$out_arg" ]; then
+  echo "Wrote readable base: $out_dir/base" >&2
+  echo "Wrote readable head: $out_dir/head" >&2
+  echo "Wrote readable patch: $out_dir/readable.patch" >&2
+fi

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ notes status
 notes changes
 notes changes --summary
 
+# Show readable diffs for local changes, refs, or PRs.
+notes diff
+notes diff main...HEAD
+notes diff --pr 109 --out /tmp/notes-109-review
+
 # Stage modified/deleted notes. New notes should be explicit.
 notes stage
 notes stage notes/new-note.md
@@ -59,6 +64,7 @@ notes unlock
 - **Filename obfuscation** — stores notes with opaque filenames in Git while restoring readable names locally.
 - **Manifest merging** — uses a custom merge driver for `notes/.manifest` so concurrent note additions can merge cleanly.
 - **Safe staging** — stages notes despite local exclude/assume-unchanged rules used for readable working copies.
+- **Readable review diffs** — materializes obfuscated note refs/PRs as readable Markdown and emits a normal patch.
 
 ## Important gotchas
 

--- a/lib/diff.sh
+++ b/lib/diff.sh
@@ -85,19 +85,21 @@ materialize_readable_notes_ref() {
   done < "$manifest"
 
   local tree_path relpath unmapped_count=0
-  if $has_manifest; then
-    while IFS= read -r -d '' tree_path; do
-      relpath="${tree_path#"$notes_dir/"}"
-      [ "$relpath" = ".manifest" ] && continue
-      if ! grep -Fxq -- "$relpath" "$manifest_ids"; then
-        unmapped_count=$((unmapped_count + 1))
-      fi
-    done < <(git -C "$repo_root" ls-tree -r -z --name-only "$ref" -- "$notes_dir" 2>/dev/null || true)
-  fi
+  while IFS= read -r -d '' tree_path; do
+    relpath="${tree_path#"$notes_dir/"}"
+    [ "$relpath" = ".manifest" ] && continue
+    if ! $has_manifest || ! grep -Fxq -- "$relpath" "$manifest_ids"; then
+      unmapped_count=$((unmapped_count + 1))
+    fi
+  done < <(git -C "$repo_root" ls-tree -r -z --name-only "$ref" -- "$notes_dir" 2>/dev/null || true)
 
   rm -f "$manifest" "$manifest_ids"
   if [ "$unmapped_count" -gt 0 ]; then
-    echo "Error: $ref has $unmapped_count note file(s) not listed in $notes_dir/.manifest" >&2
+    if $has_manifest; then
+      echo "Error: $ref has $unmapped_count note file(s) not listed in $notes_dir/.manifest" >&2
+    else
+      echo "Error: $ref has $unmapped_count note file(s) but no $notes_dir/.manifest" >&2
+    fi
     return 1
   fi
 }

--- a/lib/diff.sh
+++ b/lib/diff.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# diff.sh — Materialize readable note trees from refs and diff them.
+
+_ref_has_path() {
+  local repo_root="$1" ref="$2" path="$3"
+  git -C "$repo_root" cat-file -e "$ref:$path" 2>/dev/null
+}
+
+_guard_manifest_path() {
+  local kind="$1" value="$2"
+
+  if [ "$kind" = "id" ]; then
+    case "$value" in
+      ""|.|..|*/*)
+        echo "Error: unsafe manifest $kind: $value" >&2
+        return 1
+        ;;
+    esac
+    return 0
+  fi
+
+  case "$value" in
+    ""|.|..|/*|../*|*/../*|*"/.."|*"//"*)
+      echo "Error: unsafe manifest $kind: $value" >&2
+      return 1
+      ;;
+  esac
+}
+
+_materialize_manifest_for_ref() {
+  local repo_root="$1" notes_dir="$2" ref="$3" out="$4"
+  : > "$out"
+
+  if ! _ref_has_path "$repo_root" "$ref" "$notes_dir/.manifest"; then
+    return 0
+  fi
+
+  git -C "$repo_root" cat-file --filters "$ref:$notes_dir/.manifest" > "$out"
+}
+
+# Materialize a ref's obfuscated notes into readable filenames under dest.
+# Usage: materialize_readable_notes_ref <repo_root> <notes_dir> <ref> <dest>
+materialize_readable_notes_ref() {
+  local repo_root="${1:?usage: materialize_readable_notes_ref <repo_root> <notes_dir> <ref> <dest>}"
+  local notes_dir="${2:?usage: materialize_readable_notes_ref <repo_root> <notes_dir> <ref> <dest>}"
+  local ref="${3:?usage: materialize_readable_notes_ref <repo_root> <notes_dir> <ref> <dest>}"
+  local dest="${4:?usage: materialize_readable_notes_ref <repo_root> <notes_dir> <ref> <dest>}"
+  local manifest
+  manifest=$(mktemp) || return 1
+
+  mkdir -p "$dest/$notes_dir"
+  if ! _materialize_manifest_for_ref "$repo_root" "$notes_dir" "$ref" "$manifest"; then
+    rm -f "$manifest"
+    return 1
+  fi
+
+  while IFS=$'\t' read -r id relpath; do
+    [ -z "$id" ] && continue
+    _guard_manifest_path "id" "$id" || { rm -f "$manifest"; return 1; }
+    _guard_manifest_path "path" "$relpath" || { rm -f "$manifest"; return 1; }
+
+    if ! _ref_has_path "$repo_root" "$ref" "$notes_dir/$id"; then
+      echo "Warning: $ref manifest maps $id to $relpath, but $notes_dir/$id is missing" >&2
+      continue
+    fi
+
+    mkdir -p "$(dirname "$dest/$notes_dir/$relpath")"
+    if ! git -C "$repo_root" cat-file --filters "$ref:$notes_dir/$id" > "$dest/$notes_dir/$relpath"; then
+      rm -f "$manifest"
+      return 1
+    fi
+  done < "$manifest"
+
+  rm -f "$manifest"
+}
+
+_copy_tree_contents() {
+  local src="$1" dest="$2"
+  mkdir -p "$dest"
+  (cd "$src" && tar -cf - .) | (cd "$dest" && tar -xf -)
+}
+
+_clear_tree_contents_except_git() {
+  local dir="$1"
+  find "$dir" -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+}
+
+# Generate a stable git-style patch from two readable trees.
+# Usage: generate_readable_notes_patch <base_tree> <head_tree> <patch_file>
+generate_readable_notes_patch() {
+  local base_tree="${1:?usage: generate_readable_notes_patch <base_tree> <head_tree> <patch_file>}"
+  local head_tree="${2:?usage: generate_readable_notes_patch <base_tree> <head_tree> <patch_file>}"
+  local patch_file="${3:?usage: generate_readable_notes_patch <base_tree> <head_tree> <patch_file>}"
+  local work
+  work=$(mktemp -d) || return 1
+
+  git -C "$work" init -q
+  _copy_tree_contents "$base_tree" "$work"
+  git -C "$work" add -A
+  git -C "$work" \
+    -c user.name="notes diff" \
+    -c user.email="notes-diff@example.invalid" \
+    commit -q --allow-empty -m "readable base"
+
+  _clear_tree_contents_except_git "$work"
+  _copy_tree_contents "$head_tree" "$work"
+  git -C "$work" add -A
+  git -C "$work" diff --cached --no-ext-diff --src-prefix=a/ --dst-prefix=b/ -- . > "$patch_file"
+
+  rm -rf "$work"
+}
+
+_prepare_diff_workspace() {
+  local out_dir="$1"
+  if [ -e "$out_dir" ] && [ -n "$(find "$out_dir" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]; then
+    echo "Error: --out directory already exists and is not empty: $out_dir" >&2
+    return 1
+  fi
+  mkdir -p "$out_dir/base" "$out_dir/head"
+}

--- a/lib/diff.sh
+++ b/lib/diff.sh
@@ -48,16 +48,29 @@ materialize_readable_notes_ref() {
   local manifest
   manifest=$(mktemp) || return 1
 
+  if ! git -C "$repo_root" cat-file -e "$ref^{tree}" 2>/dev/null; then
+    echo "Error: not a tree-ish ref: $ref" >&2
+    rm -f "$manifest"
+    return 1
+  fi
+
   mkdir -p "$dest/$notes_dir"
+  local has_manifest=false
+  if _ref_has_path "$repo_root" "$ref" "$notes_dir/.manifest"; then
+    has_manifest=true
+  fi
   if ! _materialize_manifest_for_ref "$repo_root" "$notes_dir" "$ref" "$manifest"; then
     rm -f "$manifest"
     return 1
   fi
 
+  local manifest_ids
+  manifest_ids=$(mktemp) || { rm -f "$manifest"; return 1; }
   while IFS=$'\t' read -r id relpath; do
     [ -z "$id" ] && continue
-    _guard_manifest_path "id" "$id" || { rm -f "$manifest"; return 1; }
-    _guard_manifest_path "path" "$relpath" || { rm -f "$manifest"; return 1; }
+    _guard_manifest_path "id" "$id" || { rm -f "$manifest" "$manifest_ids"; return 1; }
+    _guard_manifest_path "path" "$relpath" || { rm -f "$manifest" "$manifest_ids"; return 1; }
+    printf '%s\n' "$id" >> "$manifest_ids"
 
     if ! _ref_has_path "$repo_root" "$ref" "$notes_dir/$id"; then
       echo "Warning: $ref manifest maps $id to $relpath, but $notes_dir/$id is missing" >&2
@@ -66,12 +79,27 @@ materialize_readable_notes_ref() {
 
     mkdir -p "$(dirname "$dest/$notes_dir/$relpath")"
     if ! git -C "$repo_root" cat-file --filters "$ref:$notes_dir/$id" > "$dest/$notes_dir/$relpath"; then
-      rm -f "$manifest"
+      rm -f "$manifest" "$manifest_ids"
       return 1
     fi
   done < "$manifest"
 
-  rm -f "$manifest"
+  local tree_path relpath unmapped_count=0
+  if $has_manifest; then
+    while IFS= read -r -d '' tree_path; do
+      relpath="${tree_path#"$notes_dir/"}"
+      [ "$relpath" = ".manifest" ] && continue
+      if ! grep -Fxq -- "$relpath" "$manifest_ids"; then
+        unmapped_count=$((unmapped_count + 1))
+      fi
+    done < <(git -C "$repo_root" ls-tree -r -z --name-only "$ref" -- "$notes_dir" 2>/dev/null || true)
+  fi
+
+  rm -f "$manifest" "$manifest_ids"
+  if [ "$unmapped_count" -gt 0 ]; then
+    echo "Error: $ref has $unmapped_count note file(s) not listed in $notes_dir/.manifest" >&2
+    return 1
+  fi
 }
 
 _copy_tree_contents() {
@@ -112,6 +140,14 @@ generate_readable_notes_patch() {
 
 _prepare_diff_workspace() {
   local out_dir="$1"
+  if [ -L "$out_dir" ]; then
+    echo "Error: --out path must not be a symlink: $out_dir" >&2
+    return 1
+  fi
+  if [ -e "$out_dir" ] && [ ! -d "$out_dir" ]; then
+    echo "Error: --out path exists and is not a directory: $out_dir" >&2
+    return 1
+  fi
   if [ -e "$out_dir" ] && [ -n "$(find "$out_dir" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]; then
     echo "Error: --out directory already exists and is not empty: $out_dir" >&2
     return 1

--- a/test/diff.bats
+++ b/test/diff.bats
@@ -122,6 +122,25 @@ commit_readable_update() {
   [[ "$output" != *"orphan content"* ]]
 }
 
+@test "notes diff errors when a ref has note files but no manifest" {
+  local repo
+  repo="$BATS_TEST_TMPDIR/no-manifest-repo"
+  export NOTES_CALLER_PWD="$repo"
+  mkdir -p "$repo/notes"
+  git -C "$repo" init -q
+  git -C "$repo" config user.name "Test"
+  git -C "$repo" config user.email "test@test.com"
+  echo "plain content" > "$repo/notes/plain.md"
+  git -C "$repo" add notes/plain.md
+  git -C "$repo" commit -q -m "plain note without manifest"
+
+  run notes diff HEAD HEAD
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"but no notes/.manifest"* ]]
+  [[ "$output" != *"plain.md"* ]]
+  [[ "$output" != *"plain content"* ]]
+}
+
 @test "notes diff rejects refs that are not tree-ish" {
   run notes diff does-not-exist HEAD
   [ "$status" -ne 0 ]

--- a/test/diff.bats
+++ b/test/diff.bats
@@ -90,6 +90,44 @@ commit_readable_update() {
   [[ "$output" == *"Wrote readable patch: $out_dir/readable.patch"* ]]
 }
 
+@test "notes diff --out refuses symlink destinations" {
+  local out_target out_link
+  out_target="$BATS_TEST_TMPDIR/out-target"
+  out_link="$BATS_TEST_TMPDIR/out-link"
+  mkdir -p "$out_target"
+  echo "keep" > "$out_target/existing.txt"
+  ln -s "$out_target" "$out_link"
+
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
+  echo "# Alpha v2" > "$NOTES_CALLER_PWD/notes/alpha.md"
+  commit_readable_update "edit alpha"
+
+  run notes diff --out "$out_link" HEAD~1 HEAD
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Error: --out path must not be a symlink"* ]]
+  [ ! -e "$out_target/readable.patch" ]
+  [ ! -e "$out_target/base" ]
+  [ ! -e "$out_target/head" ]
+}
+
+@test "notes diff errors when a ref has manifest-unmapped note files" {
+  echo "orphan content" > "$NOTES_CALLER_PWD/notes/deadbeef"
+  git -C "$NOTES_CALLER_PWD" add notes/deadbeef
+  git -C "$NOTES_CALLER_PWD" commit -q -m "add unmapped note blob"
+
+  run notes diff HEAD~1 HEAD
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not listed in notes/.manifest"* ]]
+  [[ "$output" != *"deadbeef"* ]]
+  [[ "$output" != *"orphan content"* ]]
+}
+
+@test "notes diff rejects refs that are not tree-ish" {
+  run notes diff does-not-exist HEAD
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Error: not a tree-ish ref: does-not-exist"* ]]
+}
+
 @test "notes diff without refs shows working-tree readable diff" {
   rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
   echo "# Alpha local" > "$NOTES_CALLER_PWD/notes/alpha.md"

--- a/test/diff.bats
+++ b/test/diff.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+
+# Tests for readable note diffs across refs and PR refs.
+
+load test_helper
+
+setup() {
+  export NOTES_CALLER_PWD="$BATS_TEST_TMPDIR/repo"
+  mkdir -p "$NOTES_CALLER_PWD/notes"
+  git -C "$NOTES_CALLER_PWD" init -q
+  git -C "$NOTES_CALLER_PWD" config user.name "Test"
+  git -C "$NOTES_CALLER_PWD" config user.email "test@test.com"
+
+  echo "# Alpha" > "$NOTES_CALLER_PWD/notes/alpha.md"
+  echo "# Beta" > "$NOTES_CALLER_PWD/notes/beta.md"
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "initial"
+  git -C "$NOTES_CALLER_PWD" branch -M main
+}
+
+commit_readable_update() {
+  local message="$1"
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "$message"
+}
+
+@test "notes diff with refs shows readable paths and content" {
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
+  echo "# Alpha v2" > "$NOTES_CALLER_PWD/notes/alpha.md"
+  echo "# Gamma" > "$NOTES_CALLER_PWD/notes/gamma.md"
+  commit_readable_update "update notes"
+
+  run notes diff HEAD~1 HEAD
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"diff --git a/notes/alpha.md b/notes/alpha.md"* ]]
+  [[ "$output" == *"-# Alpha"* ]]
+  [[ "$output" == *"+# Alpha v2"* ]]
+  [[ "$output" == *"diff --git a/notes/gamma.md b/notes/gamma.md"* ]]
+  [[ "$output" == *"+# Gamma"* ]]
+  [[ "$output" != *".manifest"* ]]
+}
+
+@test "notes diff parses range syntax" {
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
+  echo "# Beta v2" > "$NOTES_CALLER_PWD/notes/beta.md"
+  commit_readable_update "edit beta"
+
+  run notes diff HEAD~1..HEAD
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"diff --git a/notes/beta.md b/notes/beta.md"* ]]
+  [[ "$output" == *"+# Beta v2"* ]]
+}
+
+@test "notes diff triple-dot uses merge-base" {
+  git -C "$NOTES_CALLER_PWD" checkout -q -b feature
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
+  echo "# Alpha feature" > "$NOTES_CALLER_PWD/notes/alpha.md"
+  commit_readable_update "edit alpha on feature"
+
+  git -C "$NOTES_CALLER_PWD" checkout -q main
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
+  echo "# Beta main" > "$NOTES_CALLER_PWD/notes/beta.md"
+  commit_readable_update "edit beta on main"
+
+  run notes diff main...feature
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"diff --git a/notes/alpha.md b/notes/alpha.md"* ]]
+  [[ "$output" == *"+# Alpha feature"* ]]
+  [[ "$output" != *"beta.md"* ]]
+}
+
+@test "notes diff --out writes readable review artifacts" {
+  local out_dir
+  out_dir="$BATS_TEST_TMPDIR/readable-review"
+
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
+  echo "# Alpha v2" > "$NOTES_CALLER_PWD/notes/alpha.md"
+  commit_readable_update "edit alpha"
+
+  run notes diff --out "$out_dir" HEAD~1 HEAD
+  [ "$status" -eq 0 ]
+  [ -f "$out_dir/base/notes/alpha.md" ]
+  [ -f "$out_dir/head/notes/alpha.md" ]
+  [ -f "$out_dir/readable.patch" ]
+  grep -q "# Alpha" "$out_dir/base/notes/alpha.md"
+  grep -q "# Alpha v2" "$out_dir/head/notes/alpha.md"
+  grep -q "diff --git a/notes/alpha.md b/notes/alpha.md" "$out_dir/readable.patch"
+  [[ "$output" == *"Wrote readable patch: $out_dir/readable.patch"* ]]
+}
+
+@test "notes diff without refs shows working-tree readable diff" {
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
+  echo "# Alpha local" > "$NOTES_CALLER_PWD/notes/alpha.md"
+
+  run notes diff
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"=== alpha.md (modified) ==="* ]]
+  [[ "$output" == *"-# Alpha"* ]]
+  [[ "$output" == *"+# Alpha local"* ]]
+}
+
+@test "notes diff --pr fetches PR refs without checking them out" {
+  local origin fake_gh
+  origin="$BATS_TEST_TMPDIR/origin.git"
+  git init --bare -q "$origin"
+  git -C "$NOTES_CALLER_PWD" remote add origin "$origin"
+  git -C "$NOTES_CALLER_PWD" push -q origin main:refs/heads/main
+
+  git -C "$NOTES_CALLER_PWD" checkout -q -b pr-branch
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
+  echo "# Alpha from PR" > "$NOTES_CALLER_PWD/notes/alpha.md"
+  commit_readable_update "edit alpha on pr"
+  git -C "$NOTES_CALLER_PWD" push -q origin HEAD:refs/pull/1/head
+  git -C "$NOTES_CALLER_PWD" checkout -q main
+
+  fake_gh="$BATS_TEST_TMPDIR/gh"
+  cat > "$fake_gh" <<'SH'
+#!/usr/bin/env bash
+printf 'main\n'
+SH
+  chmod +x "$fake_gh"
+  export GH="$fake_gh"
+
+  run notes diff --pr 1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"diff --git a/notes/alpha.md b/notes/alpha.md"* ]]
+  [[ "$output" == *"+# Alpha from PR"* ]]
+  [ "$(git -C "$NOTES_CALLER_PWD" branch --show-current)" = "main" ]
+  [ -z "$(git -C "$NOTES_CALLER_PWD" for-each-ref refs/notes-diff)" ]
+}


### PR DESCRIPTION
## Summary

- add `notes diff` for readable note diffs against the working tree, refs/ranges, or a GitHub PR
- materialize obfuscated note refs into readable `notes/*.md` trees without checking out those refs
- support `--out` review artifacts: `base/`, `head/`, and `readable.patch`
- cover ref, range, merge-base triple-dot, local working-tree, `--out`, and mocked `--pr` flows

Fixes #108.

## Validation

- `bash -n .mise/tasks/diff lib/diff.sh`
- `mise run test test/diff.bats` — 6/6 passed
- `mise run test` — 246/246 passed, with 3 existing skips
- `git diff --check`
- `git pre-commit` — OK
- `git pre-push` — OK
