### PR TITLE
Fix notes diff missing-manifest fail-closed

### DIFF
--- a/lib/diff.sh
+++ b/lib/diff.sh
@@ -85,19 +85,21 @@ materialize_readable_notes_ref() {
   done < "$manifest"
 
   local tree_path relpath unmapped_count=0
-  if $has_manifest; then
-    while IFS= read -r -d '' tree_path; do
-      relpath="${tree_path#"$notes_dir/"}"
-      [ "$relpath" = ".manifest" ] && continue
-      if ! grep -Fxq -- "$relpath" "$manifest_ids"; then
-        unmapped_count=$((unmapped_count + 1))
-      fi
-    done < <(git -C "$repo_root" ls-tree -r -z --name-only "$ref" -- "$notes_dir" 2>/dev/null || true)
-  fi
+  while IFS= read -r -d '' tree_path; do
+    relpath="${tree_path#"$notes_dir/"}"
+    [ "$relpath" = ".manifest" ] && continue
+    if ! $has_manifest || ! grep -Fxq -- "$relpath" "$manifest_ids"; then
+      unmapped_count=$((unmapped_count + 1))
+    fi
+  done < <(git -C "$repo_root" ls-tree -r -z --name-only "$ref" -- "$notes_dir" 2>/dev/null || true)
 
   rm -f "$manifest" "$manifest_ids"
   if [ "$unmapped_count" -gt 0 ]; then
-    echo "Error: $ref has $unmapped_count note file(s) not listed in $notes_dir/.manifest" >&2
+    if $has_manifest; then
+      echo "Error: $ref has $unmapped_count note file(s) not listed in $notes_dir/.manifest" >&2
+    else
+      echo "Error: $ref has $unmapped_count note file(s) but no $notes_dir/.manifest" >&2
+    fi
     return 1
   fi
 }

--- a/test/diff.bats
+++ b/test/diff.bats
@@ -122,6 +122,25 @@ commit_readable_update() {
   [[ "$output" != *"orphan content"* ]]
 }
 
+@test "notes diff errors when a ref has note files but no manifest" {
+  local repo
+  repo="$BATS_TEST_TMPDIR/no-manifest-repo"
+  export NOTES_CALLER_PWD="$repo"
+  mkdir -p "$repo/notes"
+  git -C "$repo" init -q
+  git -C "$repo" config user.name "Test"
+  git -C "$repo" config user.email "test@test.com"
+  echo "plain content" > "$repo/notes/plain.md"
+  git -C "$repo" add notes/plain.md
+  git -C "$repo" commit -q -m "plain note without manifest"
+
+  run notes diff HEAD HEAD
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"but no notes/.manifest"* ]]
+  [[ "$output" != *"plain.md"* ]]
+  [[ "$output" != *"plain content"* ]]
+}
+
 @test "notes diff rejects refs that are not tree-ish" {
   run notes diff does-not-exist HEAD
   [ "$status" -ne 0 ]


### PR DESCRIPTION
Fix-it for #110 adversarial review.\n\nWhen a ref has tracked files under the notes directory but no notes/.manifest, readable diff previously materialized that ref as an empty readable tree and could report a false empty/no-change diff. This changes ref materialization to fail closed without leaking filenames/content and adds coverage.\n\nValidation:\n- bash -n .mise/tasks/diff lib/diff.sh\n- mise run test test/diff.bats\n\nFull suite note: local mise run test still fails existing output-capture assertions in test/new.bats and test/obfuscate.bats, unrelated to diff.