### PR TITLE
Add readable note conflict artifacts

### DIFF
--- a/.mise/tasks/conflicts
+++ b/.mise/tasks/conflicts
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#MISE description="Write readable artifacts for unresolved note content conflicts"
+#USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root (default: notes)"
+#USAGE flag "--out <dir>" default="" help="Output directory for readable conflict artifacts"
+set -euo pipefail
+
+source "$MISE_CONFIG_ROOT/lib/common.sh"
+source "$MISE_CONFIG_ROOT/lib/conflicts.sh"
+require_git
+
+notes_dir="${usage_dir:-notes}"
+out_arg="${usage_out:-}"
+repo_root=$(git -C "$TARGET_DIR" rev-parse --show-toplevel)
+
+if ! records=$(notes_conflict_records "$repo_root" "$notes_dir"); then
+  exit 1
+fi
+
+if [ -z "$records" ]; then
+  echo "No note content conflicts."
+  exit 0
+fi
+
+record_count=$(printf '%s\n' "$records" | grep -c . || true)
+
+if [ -n "$out_arg" ]; then
+  out_dir="$out_arg"
+else
+  out_dir=$(mktemp -d "${TMPDIR:-/tmp}/notes-conflicts.XXXXXX") || exit 1
+fi
+
+echo "Unmerged note content conflicts: $record_count"
+while IFS=$'\t' read -r id readable git_path; do
+  [ -n "$id" ] || continue
+  echo "  $readable ($git_path)"
+done <<< "$records"
+
+notes_conflict_write_artifacts "$repo_root" "$notes_dir" "$out_dir" "$records"
+notes_conflict_print_next_steps "$out_dir"

--- a/.mise/tasks/merge
+++ b/.mise/tasks/merge
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#MISE description="Preview note merge-conflict resolution artifacts"
+#USAGE flag "--dry-run" default=#false help="Preview conflict artifacts without resolving or staging"
+#USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root (default: notes)"
+#USAGE flag "--out <dir>" default="" help="Output directory for readable conflict artifacts"
+set -euo pipefail
+
+source "$MISE_CONFIG_ROOT/lib/common.sh"
+require_git
+
+if [ "${usage_dry_run:-false}" != "true" ]; then
+  echo "Error: notes merge currently only supports --dry-run." >&2
+  echo "Run: notes merge --dry-run --out <dir>" >&2
+  exit 1
+fi
+
+args=(conflicts --dir "${usage_dir:-notes}")
+if [ -n "${usage_out:-}" ]; then
+  args+=(--out "${usage_out}")
+fi
+
+cd "$MISE_CONFIG_ROOT" && NOTES_CALLER_PWD="$TARGET_DIR" mise run -q "${args[@]}"

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -166,10 +166,12 @@ else
     echo "Unmerged note content conflicts: $unmerged_content_conflict_count"
     while IFS=$'\t' read -r conflict_id conflict_readable conflict_git_path; do
       [ -z "$conflict_id" ] && continue
-      if [ -n "$conflict_readable" ]; then
+      if [ "$conflict_readable" = "__NOTES_UNMAPPED__" ]; then
+        echo "  $conflict_git_path (readable name unavailable)"
+      elif [ -n "$conflict_readable" ]; then
         echo "  $conflict_readable ($conflict_git_path)"
       else
-        echo "  $conflict_git_path (unmapped; manifest unavailable)"
+        echo "  $conflict_git_path (readable name unavailable)"
       fi
     done <<< "$unmerged_content_conflicts"
     echo "Run 'notes conflicts --out <dir>' to write readable base/ours/theirs artifacts."

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -8,6 +8,7 @@ source "$MISE_CONFIG_ROOT/lib/common.sh"
 source "$MISE_CONFIG_ROOT/lib/obfuscate.sh"
 source "$MISE_CONFIG_ROOT/lib/suppress.sh"
 source "$MISE_CONFIG_ROOT/lib/changes.sh"
+source "$MISE_CONFIG_ROOT/lib/conflicts.sh"
 require_git
 require_rudi
 
@@ -63,6 +64,14 @@ if [ "$enc_status" != "locked" ] && [ -f "$NOTES_DIR/.manifest" ]; then
   fi
 fi
 
+# --- Unmerged encrypted/obfuscated note content conflicts ---
+
+unmerged_content_conflicts=$(notes_conflict_records "$TARGET_DIR" "$NOTES_DIR" allow-unmapped 2>/dev/null) || true
+unmerged_content_conflict_count=0
+if [ -n "$unmerged_content_conflicts" ]; then
+  unmerged_content_conflict_count=$(printf '%s\n' "$unmerged_content_conflicts" | grep -c . || true)
+fi
+
 # --- Changes (only when deobfuscated) ---
 
 changes_modified=0
@@ -93,10 +102,12 @@ if [ "$JSON" = "true" ]; then
     jq -nc \
       --arg enc "$enc_status" \
       --argjson enc_unlocked "$enc_unlocked" \
+      --argjson unmerged_content_conflicts "$unmerged_content_conflict_count" \
       '{
         encryption: { status: $enc, unlocked: $enc_unlocked },
         obfuscation: { status: "unknown", notes: null },
         incomplete_deobfuscation: { conflicts: 0 },
+        unmerged_content_conflicts: { conflicts: $unmerged_content_conflicts },
         changes: null
       }'
   else
@@ -111,10 +122,12 @@ if [ "$JSON" = "true" ]; then
       --argjson chg_stale "$changes_stale" \
       --argjson chg_total "$changes_total" \
       --argjson incomplete_conflicts "$incomplete_conflicts" \
+      --argjson unmerged_content_conflicts "$unmerged_content_conflict_count" \
       '{
         encryption: { status: $enc, unlocked: $enc_unlocked },
         obfuscation: { status: $obf, notes: $total_notes },
         incomplete_deobfuscation: { conflicts: $incomplete_conflicts },
+        unmerged_content_conflicts: { conflicts: $unmerged_content_conflicts },
         changes: { total: $chg_total, modified: $chg_modified, new: $chg_new, deleted: $chg_deleted, stale_readable: $chg_stale }
       }'
   fi
@@ -146,5 +159,20 @@ else
         echo "Changes:     none"
       fi
     fi
+  fi
+
+  if [ "$unmerged_content_conflict_count" -gt 0 ]; then
+    echo ""
+    echo "Unmerged note content conflicts: $unmerged_content_conflict_count"
+    while IFS=$'\t' read -r conflict_id conflict_readable conflict_git_path; do
+      [ -z "$conflict_id" ] && continue
+      if [ -n "$conflict_readable" ]; then
+        echo "  $conflict_readable ($conflict_git_path)"
+      else
+        echo "  $conflict_git_path (unmapped; manifest unavailable)"
+      fi
+    done <<< "$unmerged_content_conflicts"
+    echo "Run 'notes conflicts --out <dir>' to write readable base/ours/theirs artifacts."
+    echo "See: $NOTES_CONFLICT_RESOLUTION_URL"
   fi
 fi

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ notes diff
 notes diff main...HEAD
 notes diff --pr 109 --out /tmp/notes-109-review
 
+# Inspect unresolved encrypted-note merge conflicts without resolving them.
+notes conflicts --out /tmp/notes-conflicts
+notes merge --dry-run --out /tmp/notes-conflicts
+
 # Stage modified/deleted notes. New notes should be explicit.
 notes stage
 notes stage notes/new-note.md
@@ -65,6 +69,7 @@ notes unlock
 - **Manifest merging** — uses a custom merge driver for `notes/.manifest` so concurrent note additions can merge cleanly.
 - **Safe staging** — stages notes despite local exclude/assume-unchanged rules used for readable working copies.
 - **Readable review diffs** — materializes obfuscated note refs/PRs as readable Markdown and emits a normal patch.
+- **Readable conflict artifacts** — detects unmerged encrypted/obfuscated note content and writes base/ours/theirs Markdown files for manual resolution.
 
 ## Important gotchas
 

--- a/lib/conflicts.sh
+++ b/lib/conflicts.sh
@@ -146,7 +146,7 @@ notes_conflict_records() {
 
     if ! _notes_conflict_guard_id "$id"; then
       if [ "$mode" = "allow-unmapped" ]; then
-        printf '%s\t\t%s\n' "$id" "$git_path"
+        printf '%s\t__NOTES_UNMAPPED__\t%s\n' "$id" "$git_path"
         continue
       fi
       echo "Error: unsupported unmerged note path: $git_path" >&2
@@ -158,8 +158,8 @@ notes_conflict_records() {
       :
     else
       lookup_rc=$?
-      if [ "$mode" = "allow-unmapped" ] && [ "$lookup_rc" -eq 2 ]; then
-        readable=""
+      if [ "$mode" = "allow-unmapped" ]; then
+        readable="__NOTES_UNMAPPED__"
       else
         if [ "$lookup_rc" -eq 2 ]; then
           echo "Error: missing manifest mapping for $git_path" >&2

--- a/lib/conflicts.sh
+++ b/lib/conflicts.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# conflicts.sh — Read-only helpers for encrypted/obfuscated note conflicts.
+
+NOTES_CONFLICT_RESOLUTION_URL="https://github.com/ricon-family/fold/blob/main/notes/resolving-encrypted-notes-merge-conflicts.md"
+
+_notes_conflict_guard_id() {
+  local id="$1"
+  case "$id" in
+    ""|.|..|*/*)
+      echo "Error: unsafe note id: $id" >&2
+      return 1
+      ;;
+  esac
+}
+
+_notes_conflict_guard_readable_path() {
+  local relpath="$1"
+  case "$relpath" in
+    ""|.|..|/*|../*|*/../*|*"/.."|*"//"*)
+      echo "Error: unsafe manifest path: $relpath" >&2
+      return 1
+      ;;
+  esac
+}
+
+notes_conflict_prepare_out_dir() {
+  local out_dir="$1"
+
+  if [ -L "$out_dir" ]; then
+    echo "Error: --out path must not be a symlink: $out_dir" >&2
+    return 1
+  fi
+  if [ -e "$out_dir" ] && [ ! -d "$out_dir" ]; then
+    echo "Error: --out path exists and is not a directory: $out_dir" >&2
+    return 1
+  fi
+  if [ -e "$out_dir" ] && [ -n "$(find "$out_dir" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]; then
+    echo "Error: --out directory already exists and is not empty: $out_dir" >&2
+    return 1
+  fi
+
+  mkdir -p "$out_dir/conflicts"
+}
+
+_notes_conflict_stage_exists() {
+  local repo_root="$1" stage="$2" git_path="$3"
+  git -C "$repo_root" cat-file -e ":$stage:$git_path" 2>/dev/null
+}
+
+_notes_conflict_manifest_stage_to_file() {
+  local repo_root="$1" notes_dir="$2" stage="$3" out="$4"
+  local manifest_path="$notes_dir/.manifest"
+
+  if _notes_conflict_stage_exists "$repo_root" "$stage" "$manifest_path"; then
+    git -C "$repo_root" cat-file --filters ":$stage:$manifest_path" >> "$out" 2>/dev/null || return 1
+    printf '\n' >> "$out"
+  fi
+}
+
+_notes_conflict_lookup_readable_name() {
+  local repo_root="$1" notes_dir="$2" id="$3"
+  local candidates matches relpath count
+
+  _notes_conflict_guard_id "$id" || return 1
+
+  candidates=$(mktemp) || return 1
+  matches=$(mktemp) || { rm -f "$candidates"; return 1; }
+  : > "$candidates"
+  : > "$matches"
+
+  # Prefer the current index entry when present, then ours/theirs/base for a
+  # conflicted manifest. This is enough to map stable obfuscated IDs while
+  # still refusing ambiguous or unproven mappings.
+  _notes_conflict_manifest_stage_to_file "$repo_root" "$notes_dir" 0 "$candidates" || true
+  _notes_conflict_manifest_stage_to_file "$repo_root" "$notes_dir" 2 "$candidates" || true
+  _notes_conflict_manifest_stage_to_file "$repo_root" "$notes_dir" 3 "$candidates" || true
+  _notes_conflict_manifest_stage_to_file "$repo_root" "$notes_dir" 1 "$candidates" || true
+
+  while IFS=$'\t' read -r entry_id entry_name _extra; do
+    [ "$entry_id" = "$id" ] || continue
+    if ! _notes_conflict_guard_readable_path "$entry_name"; then
+      rm -f "$candidates" "$matches"
+      return 1
+    fi
+    printf '%s\n' "$entry_name" >> "$matches"
+  done < "$candidates"
+
+  local sorted_matches
+  sorted_matches=$(mktemp) || { rm -f "$candidates" "$matches"; return 1; }
+  sort -u "$matches" > "$sorted_matches"
+  mv -f "$sorted_matches" "$matches"
+  count=$(grep -c . "$matches" 2>/dev/null || true)
+  case "$count" in
+    0)
+      rm -f "$candidates" "$matches"
+      return 2
+      ;;
+    1)
+      relpath=$(cat "$matches")
+      rm -f "$candidates" "$matches"
+      printf '%s' "$relpath"
+      return 0
+      ;;
+    *)
+      echo "Error: ambiguous manifest mapping for $notes_dir/$id" >&2
+      cat "$matches" >&2
+      rm -f "$candidates" "$matches"
+      return 1
+      ;;
+  esac
+}
+
+notes_conflict_unmerged_paths() {
+  local repo_root="$1" notes_dir="$2"
+  local meta git_path relpath tmp
+
+  tmp=$(mktemp) || return 1
+  : > "$tmp"
+
+  while IFS=$'\t' read -r meta git_path; do
+    [ -n "$git_path" ] || continue
+    case "$git_path" in
+      "$notes_dir/.manifest") continue ;;
+      "$notes_dir"/*)
+        relpath="${git_path#"$notes_dir/"}"
+        [ -n "$relpath" ] || continue
+        printf '%s\n' "$git_path" >> "$tmp"
+        ;;
+    esac
+  done < <(git -C "$repo_root" ls-files -u -- "$notes_dir" 2>/dev/null || true)
+
+  sort -u "$tmp"
+  rm -f "$tmp"
+}
+
+# Output one row per unmerged note-content path:
+#   <id>\t<readable-name-or-empty>\t<git-path>
+# The optional third argument may be "allow-unmapped" for status/reporting.
+notes_conflict_records() {
+  local repo_root="$1" notes_dir="$2" mode="${3:-strict}"
+  local git_path id readable lookup_rc
+
+  while IFS= read -r git_path; do
+    [ -n "$git_path" ] || continue
+    id="${git_path#"$notes_dir/"}"
+
+    if ! _notes_conflict_guard_id "$id"; then
+      if [ "$mode" = "allow-unmapped" ]; then
+        printf '%s\t\t%s\n' "$id" "$git_path"
+        continue
+      fi
+      echo "Error: unsupported unmerged note path: $git_path" >&2
+      return 1
+    fi
+
+    readable=""
+    if readable=$(_notes_conflict_lookup_readable_name "$repo_root" "$notes_dir" "$id"); then
+      :
+    else
+      lookup_rc=$?
+      if [ "$mode" = "allow-unmapped" ] && [ "$lookup_rc" -eq 2 ]; then
+        readable=""
+      else
+        if [ "$lookup_rc" -eq 2 ]; then
+          echo "Error: missing manifest mapping for $git_path" >&2
+        fi
+        return 1
+      fi
+    fi
+
+    printf '%s\t%s\t%s\n' "$id" "$readable" "$git_path"
+  done < <(notes_conflict_unmerged_paths "$repo_root" "$notes_dir")
+}
+
+notes_conflict_require_three_stages() {
+  local repo_root="$1" git_path="$2"
+  local stage
+
+  for stage in 1 2 3; do
+    if ! _notes_conflict_stage_exists "$repo_root" "$stage" "$git_path"; then
+      echo "Error: unsupported conflict shape for $git_path; expected base, ours, and theirs stages" >&2
+      return 1
+    fi
+  done
+}
+
+_notes_conflict_file_has_gitcrypt_header() {
+  local file="$1" sig
+  sig=$(dd if="$file" bs=9 count=1 2>/dev/null | od -An -tx1 | tr -d ' \n')
+  [ "$sig" = "004749544352595054" ]
+}
+
+notes_conflict_extract_stage() {
+  local repo_root="$1" stage="$2" git_path="$3" dest="$4"
+  local tmp
+
+  tmp=$(mktemp) || return 1
+  if ! git -C "$repo_root" cat-file --filters ":$stage:$git_path" > "$tmp" 2>/dev/null; then
+    echo "Error: failed to extract stage $stage for $git_path" >&2
+    rm -f "$tmp"
+    return 1
+  fi
+  if _notes_conflict_file_has_gitcrypt_header "$tmp"; then
+    echo "Error: git-crypt filters did not decrypt stage $stage for $git_path" >&2
+    echo "Unlock the repo or reinstall notes hooks/filters before writing conflict artifacts." >&2
+    rm -f "$tmp"
+    return 1
+  fi
+  mv -f "$tmp" "$dest"
+}
+
+notes_conflict_write_artifacts() {
+  local repo_root="$1" notes_dir="$2" out_dir="$3" records="$4"
+  local id readable git_path conflict_dir
+
+  notes_conflict_prepare_out_dir "$out_dir" || return 1
+
+  while IFS=$'\t' read -r id readable git_path; do
+    [ -n "$id" ] || continue
+    [ -n "$readable" ] || { echo "Error: missing readable name for $git_path" >&2; return 1; }
+    notes_conflict_require_three_stages "$repo_root" "$git_path" || return 1
+
+    conflict_dir="$out_dir/conflicts/$readable"
+    mkdir -p "$conflict_dir"
+    notes_conflict_extract_stage "$repo_root" 1 "$git_path" "$conflict_dir/base.md" || return 1
+    notes_conflict_extract_stage "$repo_root" 2 "$git_path" "$conflict_dir/ours.md" || return 1
+    notes_conflict_extract_stage "$repo_root" 3 "$git_path" "$conflict_dir/theirs.md" || return 1
+  done <<< "$records"
+}
+
+notes_conflict_print_next_steps() {
+  local out_dir="$1"
+  cat <<EOF
+
+Artifacts written under: $out_dir/conflicts
+Next steps:
+  1. Compare base.md, ours.md, and theirs.md for each note.
+  2. Write the resolved plaintext into the conflicted obfuscated note path.
+  3. Stage that obfuscated path with git add after resolving it.
+  4. Confirm git ls-files -u no longer lists the note path before committing.
+See: $NOTES_CONFLICT_RESOLUTION_URL
+EOF
+}

--- a/test/conflicts.bats
+++ b/test/conflicts.bats
@@ -227,6 +227,51 @@ create_conflicted_gitcrypt_header_repo() {
   [[ "$output" == *"notes conflicts --out"* ]]
 }
 
+@test "notes status still reports conflicts with unsafe manifest mappings" {
+  printf 'aaaaaaaa\t../alpha.md\n' > "$NOTES_CALLER_PWD/notes/.manifest"
+  printf '# Alpha\nbase\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "base unsafe path"
+  git -C "$NOTES_CALLER_PWD" branch -M main
+
+  git -C "$NOTES_CALLER_PWD" checkout -q -b feature
+  printf '# Alpha\nfeature\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "feature unsafe path"
+
+  git -C "$NOTES_CALLER_PWD" checkout -q main
+  printf '# Alpha\nmain\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "main unsafe path"
+  run git -C "$NOTES_CALLER_PWD" merge feature
+  [ "$status" -ne 0 ]
+
+  run notes status
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Unmerged note content conflicts: 1"* ]]
+  [[ "$output" == *"notes/aaaaaaaa (readable name unavailable)"* ]]
+}
+
+@test "notes status still reports conflicts with ambiguous manifest mappings" {
+  printf 'aaaaaaaa\talpha.md\naaaaaaaa\tbeta.md\n' > "$NOTES_CALLER_PWD/notes/.manifest"
+  printf '# Alpha\nbase\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "base ambiguous path"
+  git -C "$NOTES_CALLER_PWD" branch -M main
+
+  git -C "$NOTES_CALLER_PWD" checkout -q -b feature
+  printf '# Alpha\nfeature\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "feature ambiguous path"
+
+  git -C "$NOTES_CALLER_PWD" checkout -q main
+  printf '# Alpha\nmain\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "main ambiguous path"
+  run git -C "$NOTES_CALLER_PWD" merge feature
+  [ "$status" -ne 0 ]
+
+  run notes status --json
+
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.unmerged_content_conflicts.conflicts == 1'
+}
+
 @test "notes status --json counts unmerged note content conflicts" {
   create_conflicted_note_repo
 

--- a/test/conflicts.bats
+++ b/test/conflicts.bats
@@ -1,0 +1,237 @@
+#!/usr/bin/env bats
+
+# Tests for readable artifacts from unresolved encrypted/obfuscated note conflicts.
+
+load test_helper
+
+setup() {
+  export NOTES_CALLER_PWD="$BATS_TEST_TMPDIR/repo"
+  mkdir -p "$NOTES_CALLER_PWD/notes"
+  git -C "$NOTES_CALLER_PWD" init -q
+  git -C "$NOTES_CALLER_PWD" config user.name "Test"
+  git -C "$NOTES_CALLER_PWD" config user.email "test@test.com"
+}
+
+commit_all() {
+  local message="$1"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "$message"
+}
+
+create_conflicted_note_repo() {
+  printf 'aaaaaaaa\talpha.md\n' > "$NOTES_CALLER_PWD/notes/.manifest"
+  printf '# Alpha\nbase\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "base note"
+  git -C "$NOTES_CALLER_PWD" branch -M main
+
+  git -C "$NOTES_CALLER_PWD" checkout -q -b feature
+  printf '# Alpha\nfeature\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "feature edit"
+
+  git -C "$NOTES_CALLER_PWD" checkout -q main
+  printf '# Alpha\nmain\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "main edit"
+
+  run git -C "$NOTES_CALLER_PWD" merge feature
+  [ "$status" -ne 0 ]
+  [ "$(git -C "$NOTES_CALLER_PWD" ls-files -u -- notes/aaaaaaaa | wc -l | tr -d ' ')" -eq 3 ]
+}
+
+create_conflicted_gitcrypt_header_repo() {
+  printf 'aaaaaaaa\talpha.md\n' > "$NOTES_CALLER_PWD/notes/.manifest"
+  printf '\0GITCRYPT base\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "base encrypted-looking note"
+  git -C "$NOTES_CALLER_PWD" branch -M main
+
+  git -C "$NOTES_CALLER_PWD" checkout -q -b feature
+  printf '\0GITCRYPT feature\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "feature encrypted-looking edit"
+
+  git -C "$NOTES_CALLER_PWD" checkout -q main
+  printf '\0GITCRYPT main\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "main encrypted-looking edit"
+
+  run git -C "$NOTES_CALLER_PWD" merge feature
+  [ "$status" -ne 0 ]
+}
+
+@test "notes conflicts writes readable base ours theirs artifacts" {
+  create_conflicted_note_repo
+  local out_dir="$BATS_TEST_TMPDIR/conflict-artifacts"
+
+  run notes conflicts --out "$out_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Unmerged note content conflicts: 1"* ]]
+  [[ "$output" == *"alpha.md (notes/aaaaaaaa)"* ]]
+  [ -f "$out_dir/conflicts/alpha.md/base.md" ]
+  [ -f "$out_dir/conflicts/alpha.md/ours.md" ]
+  [ -f "$out_dir/conflicts/alpha.md/theirs.md" ]
+  grep -q '^base$' "$out_dir/conflicts/alpha.md/base.md"
+  grep -q '^main$' "$out_dir/conflicts/alpha.md/ours.md"
+  grep -q '^feature$' "$out_dir/conflicts/alpha.md/theirs.md"
+}
+
+@test "notes conflicts leaves conflicted index and worktree unchanged" {
+  create_conflicted_note_repo
+  local out_dir="$BATS_TEST_TMPDIR/conflict-artifacts"
+  local index_before worktree_before index_after worktree_after
+  index_before=$(git -C "$NOTES_CALLER_PWD" ls-files -u)
+  worktree_before=$(cat "$NOTES_CALLER_PWD/notes/aaaaaaaa")
+
+  run notes conflicts --out "$out_dir"
+
+  [ "$status" -eq 0 ]
+  index_after=$(git -C "$NOTES_CALLER_PWD" ls-files -u)
+  worktree_after=$(cat "$NOTES_CALLER_PWD/notes/aaaaaaaa")
+  [ "$index_after" = "$index_before" ]
+  [ "$worktree_after" = "$worktree_before" ]
+}
+
+@test "notes conflicts reports no note content conflicts" {
+  printf 'aaaaaaaa\talpha.md\n' > "$NOTES_CALLER_PWD/notes/.manifest"
+  printf '# Alpha\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "base note"
+  local out_dir="$BATS_TEST_TMPDIR/no-conflicts-out"
+
+  run notes conflicts --out "$out_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No note content conflicts."* ]]
+  [ ! -e "$out_dir" ]
+}
+
+@test "notes conflicts refuses symlink output directory" {
+  create_conflicted_note_repo
+  local out_target="$BATS_TEST_TMPDIR/out-target"
+  local out_link="$BATS_TEST_TMPDIR/out-link"
+  mkdir -p "$out_target"
+  ln -s "$out_target" "$out_link"
+
+  run notes conflicts --out "$out_link"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Error: --out path must not be a symlink"* ]]
+  [ -z "$(find "$out_target" -mindepth 1 -print -quit)" ]
+}
+
+@test "notes conflicts refuses encrypted stages that filters did not decrypt" {
+  create_conflicted_gitcrypt_header_repo
+  local out_dir="$BATS_TEST_TMPDIR/locked-out"
+
+  run notes conflicts --out "$out_dir"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Error: git-crypt filters did not decrypt stage"* ]]
+  [ ! -f "$out_dir/conflicts/alpha.md/base.md" ]
+}
+
+@test "notes conflicts refuses unsafe manifest paths" {
+  printf 'aaaaaaaa\t../alpha.md\n' > "$NOTES_CALLER_PWD/notes/.manifest"
+  printf '# Alpha\nbase\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "base unsafe path"
+  git -C "$NOTES_CALLER_PWD" branch -M main
+
+  git -C "$NOTES_CALLER_PWD" checkout -q -b feature
+  printf '# Alpha\nfeature\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "feature unsafe path"
+
+  git -C "$NOTES_CALLER_PWD" checkout -q main
+  printf '# Alpha\nmain\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "main unsafe path"
+  run git -C "$NOTES_CALLER_PWD" merge feature
+  [ "$status" -ne 0 ]
+
+  run notes conflicts --out "$BATS_TEST_TMPDIR/unsafe-out"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Error: unsafe manifest path: ../alpha.md"* ]]
+}
+
+@test "notes conflicts refuses unmapped obfuscated conflict" {
+  printf 'aaaaaaaa\talpha.md\n' > "$NOTES_CALLER_PWD/notes/.manifest"
+  printf '# Orphan\nbase\n' > "$NOTES_CALLER_PWD/notes/bbbbbbbb"
+  commit_all "base orphan"
+  git -C "$NOTES_CALLER_PWD" branch -M main
+
+  git -C "$NOTES_CALLER_PWD" checkout -q -b feature
+  printf '# Orphan\nfeature\n' > "$NOTES_CALLER_PWD/notes/bbbbbbbb"
+  commit_all "feature orphan"
+
+  git -C "$NOTES_CALLER_PWD" checkout -q main
+  printf '# Orphan\nmain\n' > "$NOTES_CALLER_PWD/notes/bbbbbbbb"
+  commit_all "main orphan"
+  run git -C "$NOTES_CALLER_PWD" merge feature
+  [ "$status" -ne 0 ]
+
+  local out_dir="$BATS_TEST_TMPDIR/unmapped-out"
+  run notes conflicts --out "$out_dir"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Error: missing manifest mapping for notes/bbbbbbbb"* ]]
+  [ ! -e "$out_dir/conflicts" ]
+}
+
+@test "notes conflicts ignores manifest-only conflicts" {
+  printf 'aaaaaaaa\talpha.md\n' > "$NOTES_CALLER_PWD/notes/.manifest"
+  printf '# Alpha\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "base note"
+  git -C "$NOTES_CALLER_PWD" branch -M main
+
+  git -C "$NOTES_CALLER_PWD" checkout -q -b feature
+  printf 'aaaaaaaa\talpha.md\nbbbbbbbb\tbeta.md\n' > "$NOTES_CALLER_PWD/notes/.manifest"
+  commit_all "feature manifest edit"
+
+  git -C "$NOTES_CALLER_PWD" checkout -q main
+  printf 'aaaaaaaa\talpha.md\ncccccccc\tgamma.md\n' > "$NOTES_CALLER_PWD/notes/.manifest"
+  commit_all "main manifest edit"
+  run git -C "$NOTES_CALLER_PWD" merge feature
+  [ "$status" -ne 0 ]
+
+  run notes conflicts
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No note content conflicts."* ]]
+}
+
+@test "notes merge --dry-run delegates to readable conflict artifacts" {
+  create_conflicted_note_repo
+  local out_dir="$BATS_TEST_TMPDIR/merge-dry-run-artifacts"
+
+  run notes merge --dry-run --out "$out_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Unmerged note content conflicts: 1"* ]]
+  [ -f "$out_dir/conflicts/alpha.md/base.md" ]
+  grep -q '^main$' "$out_dir/conflicts/alpha.md/ours.md"
+  grep -q '^feature$' "$out_dir/conflicts/alpha.md/theirs.md"
+}
+
+@test "notes merge refuses apply mode for the first slice" {
+  create_conflicted_note_repo
+
+  run notes merge
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Error: notes merge currently only supports --dry-run."* ]]
+}
+
+@test "notes status reports unmerged note content conflicts" {
+  create_conflicted_note_repo
+
+  run notes status
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Unmerged note content conflicts: 1"* ]]
+  [[ "$output" == *"alpha.md (notes/aaaaaaaa)"* ]]
+  [[ "$output" == *"notes conflicts --out"* ]]
+}
+
+@test "notes status --json counts unmerged note content conflicts" {
+  create_conflicted_note_repo
+
+  run notes status --json
+
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.unmerged_content_conflicts.conflicts == 1'
+}


### PR DESCRIPTION
## Summary

- add `notes conflicts --out <dir>` to detect unresolved note-content conflicts and write readable `base.md` / `ours.md` / `theirs.md` artifacts
- add `notes merge --dry-run` as a read-only alias for the first conservative merge-helper slice
- surface unmerged note content conflicts from `notes status` text and JSON output
- document the conflict-artifact workflow in the README

Fixes #70.

## Safety boundaries

- no automatic merge/apply behavior
- no writes to the conflicted worktree or index
- refuses unmapped/unsafe manifest paths, missing decrypt filters, unsupported non-3-stage conflicts, symlink/non-empty `--out` targets

## Validation

- `bash -n lib/*.sh .mise/tasks/* test/*.bats test/test_helper.bash`
- `mise run test test/conflicts.bats test/status.bats test/diff.bats`
- `mise run test` — 263 tests, 3 expected skips
- `git diff --check`
- `git pre-commit`
- `git pre-push` — WARN only after push because no local commits remained to push
