### PR TITLE
fix: keep conflict status visible when names fail

### DIFF
--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -166,10 +166,12 @@ else
     echo "Unmerged note content conflicts: $unmerged_content_conflict_count"
     while IFS=$'\t' read -r conflict_id conflict_readable conflict_git_path; do
       [ -z "$conflict_id" ] && continue
-      if [ -n "$conflict_readable" ]; then
+      if [ "$conflict_readable" = "__NOTES_UNMAPPED__" ]; then
+        echo "  $conflict_git_path (readable name unavailable)"
+      elif [ -n "$conflict_readable" ]; then
         echo "  $conflict_readable ($conflict_git_path)"
       else
-        echo "  $conflict_git_path (unmapped; manifest unavailable)"
+        echo "  $conflict_git_path (readable name unavailable)"
       fi
     done <<< "$unmerged_content_conflicts"
     echo "Run 'notes conflicts --out <dir>' to write readable base/ours/theirs artifacts."

--- a/lib/conflicts.sh
+++ b/lib/conflicts.sh
@@ -146,7 +146,7 @@ notes_conflict_records() {
 
     if ! _notes_conflict_guard_id "$id"; then
       if [ "$mode" = "allow-unmapped" ]; then
-        printf '%s\t\t%s\n' "$id" "$git_path"
+        printf '%s\t__NOTES_UNMAPPED__\t%s\n' "$id" "$git_path"
         continue
       fi
       echo "Error: unsupported unmerged note path: $git_path" >&2
@@ -158,8 +158,8 @@ notes_conflict_records() {
       :
     else
       lookup_rc=$?
-      if [ "$mode" = "allow-unmapped" ] && [ "$lookup_rc" -eq 2 ]; then
-        readable=""
+      if [ "$mode" = "allow-unmapped" ]; then
+        readable="__NOTES_UNMAPPED__"
       else
         if [ "$lookup_rc" -eq 2 ]; then
           echo "Error: missing manifest mapping for $git_path" >&2

--- a/test/conflicts.bats
+++ b/test/conflicts.bats
@@ -227,6 +227,51 @@ create_conflicted_gitcrypt_header_repo() {
   [[ "$output" == *"notes conflicts --out"* ]]
 }
 
+@test "notes status still reports conflicts with unsafe manifest mappings" {
+  printf 'aaaaaaaa\t../alpha.md\n' > "$NOTES_CALLER_PWD/notes/.manifest"
+  printf '# Alpha\nbase\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "base unsafe path"
+  git -C "$NOTES_CALLER_PWD" branch -M main
+
+  git -C "$NOTES_CALLER_PWD" checkout -q -b feature
+  printf '# Alpha\nfeature\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "feature unsafe path"
+
+  git -C "$NOTES_CALLER_PWD" checkout -q main
+  printf '# Alpha\nmain\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "main unsafe path"
+  run git -C "$NOTES_CALLER_PWD" merge feature
+  [ "$status" -ne 0 ]
+
+  run notes status
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Unmerged note content conflicts: 1"* ]]
+  [[ "$output" == *"notes/aaaaaaaa (readable name unavailable)"* ]]
+}
+
+@test "notes status still reports conflicts with ambiguous manifest mappings" {
+  printf 'aaaaaaaa\talpha.md\naaaaaaaa\tbeta.md\n' > "$NOTES_CALLER_PWD/notes/.manifest"
+  printf '# Alpha\nbase\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "base ambiguous path"
+  git -C "$NOTES_CALLER_PWD" branch -M main
+
+  git -C "$NOTES_CALLER_PWD" checkout -q -b feature
+  printf '# Alpha\nfeature\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "feature ambiguous path"
+
+  git -C "$NOTES_CALLER_PWD" checkout -q main
+  printf '# Alpha\nmain\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "main ambiguous path"
+  run git -C "$NOTES_CALLER_PWD" merge feature
+  [ "$status" -ne 0 ]
+
+  run notes status --json
+
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.unmerged_content_conflicts.conflicts == 1'
+}
+
 @test "notes status --json counts unmerged note content conflicts" {
   create_conflicted_note_repo
 


### PR DESCRIPTION
Fix-it for #113.

`notes status` called `notes_conflict_records ... allow-unmapped` with stderr suppressed and `|| true`, but `allow-unmapped` only tolerated missing manifest entries. Ambiguous or unsafe mappings still made the helper return non-zero, so status silently reported zero unmerged content conflicts.

This keeps status conflict counts visible when the readable name cannot be trusted, while leaving `notes conflicts --out` strict/fail-closed.

Validation:
- `bash -n .mise/tasks/conflicts .mise/tasks/merge .mise/tasks/status lib/conflicts.sh test/conflicts.bats`
- `mise run test test/conflicts.bats`
- `git diff --check origin/rho/notes-70-conflicts...HEAD`
