### PR TITLE
Fix status reporting for unsafe conflict mappings

### DIFF
--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -166,6 +166,10 @@ else
     echo "Unmerged note content conflicts: $unmerged_content_conflict_count"
     while IFS=$'\t' read -r conflict_id conflict_readable conflict_git_path; do
       [ -z "$conflict_id" ] && continue
+      if [ -z "$conflict_git_path" ]; then
+        conflict_git_path="$conflict_readable"
+        conflict_readable=""
+      fi
       if [ -n "$conflict_readable" ]; then
         echo "  $conflict_readable ($conflict_git_path)"
       else

--- a/lib/conflicts.sh
+++ b/lib/conflicts.sh
@@ -158,7 +158,7 @@ notes_conflict_records() {
       :
     else
       lookup_rc=$?
-      if [ "$mode" = "allow-unmapped" ] && [ "$lookup_rc" -eq 2 ]; then
+      if [ "$mode" = "allow-unmapped" ]; then
         readable=""
       else
         if [ "$lookup_rc" -eq 2 ]; then

--- a/test/conflicts.bats
+++ b/test/conflicts.bats
@@ -235,3 +235,31 @@ create_conflicted_gitcrypt_header_repo() {
   [ "$status" -eq 0 ]
   echo "$output" | jq -e '.unmerged_content_conflicts.conflicts == 1'
 }
+
+@test "notes status reports conflicts even when manifest mapping is unsafe" {
+  printf 'aaaaaaaa\t../alpha.md\n' > "$NOTES_CALLER_PWD/notes/.manifest"
+  printf '# Alpha\nbase\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "base unsafe path"
+  git -C "$NOTES_CALLER_PWD" branch -M main
+
+  git -C "$NOTES_CALLER_PWD" checkout -q -b feature
+  printf '# Alpha\nfeature\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "feature unsafe path"
+
+  git -C "$NOTES_CALLER_PWD" checkout -q main
+  printf '# Alpha\nmain\n' > "$NOTES_CALLER_PWD/notes/aaaaaaaa"
+  commit_all "main unsafe path"
+  run git -C "$NOTES_CALLER_PWD" merge feature
+  [ "$status" -ne 0 ]
+
+  run notes status
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Unmerged note content conflicts: 1"* ]]
+  [[ "$output" == *"notes/aaaaaaaa (unmapped; manifest unavailable)"* ]]
+
+  run notes status --json
+
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.unmerged_content_conflicts.conflicts == 1'
+}


### PR DESCRIPTION
## Summary

- keep Encryption: not_initialized

Obfuscation: none (0 notes) conflict counts visible when manifest lookup fails for unsafe/ambiguous mappings
- print unmapped conflict rows correctly despite empty readable fields
- add regression coverage for unsafe manifest mappings in status text and JSON

## Validation

- 
- 1..30
ok 1 notes conflicts writes readable base ours theirs artifacts
ok 2 notes conflicts leaves conflicted index and worktree unchanged
ok 3 notes conflicts reports no note content conflicts
ok 4 notes conflicts refuses symlink output directory
ok 5 notes conflicts refuses encrypted stages that filters did not decrypt
ok 6 notes conflicts refuses unsafe manifest paths
ok 7 notes conflicts refuses unmapped obfuscated conflict
ok 8 notes conflicts ignores manifest-only conflicts
ok 9 notes merge --dry-run delegates to readable conflict artifacts
ok 10 notes merge refuses apply mode for the first slice
ok 11 notes status reports unmerged note content conflicts
ok 12 notes status --json counts unmerged note content conflicts
ok 13 notes status reports conflicts even when manifest mapping is unsafe
ok 14 status shows encryption state
ok 15 status shows not_initialized when no git-crypt
ok 16 status shows encryption unlocked after setup
ok 17 status shows obfuscation state
ok 18 status shows obfuscation none when no manifest
ok 19 status shows obfuscation state after obfuscate
ok 20 status reports incomplete deobfuscation for dual-present differing pair
ok 21 status --json outputs valid JSON
ok 22 status --json has encryption and obfuscation fields
ok 23 status --json shows not_initialized when no git-crypt
ok 24 status --json shows unlocked after setup
ok 25 status --json shows obfuscation none when no manifest
ok 26 status --json shows note count after obfuscate
ok 27 status handles locked repo gracefully # skip needs notes#39 (clean git status via exclude management)
ok 28 status --json reports unknown obfuscation when locked # skip needs notes#39 (clean git status via exclude management)
ok 29 status text reports locked with unlock hint # skip needs notes#39 (clean git status via exclude management)
ok 30 status --json shows deobfuscated after deobfuscate
- 
