### PR TITLE
Stage manifest updates when deleting notes

### DIFF
--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -173,10 +173,18 @@ for relpath in "${to_stage[@]}"; do
     # Deleted: remove the obfuscated ID from the index
     id=$(manifest_id_for_name "$manifest" "$relpath")
     if [ -n "$id" ]; then
+      # First remove the tracked blob when it is still present in the index.
+      # If the index cannot be updated (for example, an index lock exists),
+      # fail before mutating the working manifest. If a previous interrupted
+      # run already staged/removed the blob, keep going and only stage the
+      # manifest repair.
+      if git -C "$TARGET_DIR" ls-files --error-unmatch -- "$notes_dir/$id" >/dev/null 2>&1; then
+        git -C "$TARGET_DIR" rm --cached --quiet "$notes_dir/$id"
+      fi
+
       tmp_manifest=$(mktemp) || exit 1
       awk -F '\t' -v path="$relpath" '$2 != path { print $0 }' "$manifest" > "$tmp_manifest"
       mv -f "$tmp_manifest" "$manifest"
-      git -C "$TARGET_DIR" rm --cached --quiet "$notes_dir/$id" 2>/dev/null || true
       git -C "$TARGET_DIR" add -f "$notes_dir/.manifest"
       echo "  staged (delete): $relpath"
     fi

--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -183,9 +183,15 @@ for relpath in "${to_stage[@]}"; do
       fi
 
       tmp_manifest=$(mktemp) || exit 1
+      manifest_backup=$(mktemp) || exit 1
+      cp "$manifest" "$manifest_backup"
       awk -F '\t' -v path="$relpath" '$2 != path { print $0 }' "$manifest" > "$tmp_manifest"
       mv -f "$tmp_manifest" "$manifest"
-      git -C "$TARGET_DIR" add -f "$notes_dir/.manifest"
+      if ! git -C "$TARGET_DIR" add -f "$notes_dir/.manifest"; then
+        mv -f "$manifest_backup" "$manifest"
+        exit 1
+      fi
+      rm -f "$manifest_backup"
       echo "  staged (delete): $relpath"
     fi
   fi

--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -173,7 +173,11 @@ for relpath in "${to_stage[@]}"; do
     # Deleted: remove the obfuscated ID from the index
     id=$(manifest_id_for_name "$manifest" "$relpath")
     if [ -n "$id" ]; then
+      tmp_manifest=$(mktemp) || exit 1
+      awk -F '\t' -v path="$relpath" '$2 != path { print $0 }' "$manifest" > "$tmp_manifest"
+      mv -f "$tmp_manifest" "$manifest"
       git -C "$TARGET_DIR" rm --cached --quiet "$notes_dir/$id" 2>/dev/null || true
+      git -C "$TARGET_DIR" add -f "$notes_dir/.manifest"
       echo "  staged (delete): $relpath"
     fi
   fi

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -354,6 +354,22 @@ rename_manifest_entry_in_head() {
   [ -z "$output" ]
 }
 
+@test "notes stage: deleted note does not mutate manifest when index removal fails" {
+  local manifest_before
+  manifest_before=$(cat "$MANIFEST")
+  rm "$NOTES_CALLER_PWD/notes/alpha.md"
+  touch "$NOTES_CALLER_PWD/.git/index.lock"
+
+  run notes stage
+  rm -f "$NOTES_CALLER_PWD/.git/index.lock"
+
+  [ "$status" -ne 0 ]
+  [ "$(cat "$MANIFEST")" = "$manifest_before" ]
+
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
+  [ -z "$output" ]
+}
+
 @test "notes stage: deleted note stages manifest update in same commit" {
   source "$REPO_DIR/lib/hooks.sh"
   install_obfuscation_hook

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -339,6 +339,48 @@ rename_manifest_entry_in_head() {
   [[ "$output" == *"notes/gamma.md"* ]]
 }
 
+@test "notes stage --dry-run: deleted note leaves manifest and index untouched" {
+  local manifest_before
+  manifest_before=$(cat "$MANIFEST")
+  rm "$NOTES_CALLER_PWD/notes/alpha.md"
+
+  run notes stage --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Would stage:"* ]]
+  [[ "$output" == *"alpha.md"* ]]
+  [ "$(cat "$MANIFEST")" = "$manifest_before" ]
+
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
+  [ -z "$output" ]
+}
+
+@test "notes stage: deleted note stages manifest update in same commit" {
+  source "$REPO_DIR/lib/hooks.sh"
+  install_obfuscation_hook
+  install_deobfuscation_hook
+
+  local alpha_id
+  alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
+  rm "$NOTES_CALLER_PWD/notes/alpha.md"
+
+  run notes stage
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"staged (delete): alpha.md"* ]]
+
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-status
+  [[ "$output" == *$'D\tnotes/'"$alpha_id"* ]]
+  [[ "$output" == *$'M\tnotes/.manifest'* ]]
+
+  git -C "$NOTES_CALLER_PWD" commit -q -m "delete alpha"
+
+  run git -C "$NOTES_CALLER_PWD" status --porcelain
+  [ -z "$output" ]
+
+  run git -C "$NOTES_CALLER_PWD" cat-file --filters HEAD:notes/.manifest
+  [[ "$output" != *"alpha.md"* ]]
+  [[ "$output" == *"beta.md"* ]]
+}
+
 @test "notes stage: refuses dual-present differing readable and obfuscated pair" {
   local alpha_id
   alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -370,6 +370,39 @@ rename_manifest_entry_in_head() {
   [ -z "$output" ]
 }
 
+@test "notes stage: deleted note rolls back manifest when manifest staging fails" {
+  local alpha_id manifest_before real_git
+  alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
+  manifest_before=$(cat "$MANIFEST")
+  real_git=$(command -v git)
+  rm "$NOTES_CALLER_PWD/notes/alpha.md"
+
+  mkdir -p "$BATS_TEST_TMPDIR/bin"
+  cat > "$BATS_TEST_TMPDIR/bin/git" <<SH
+#!/usr/bin/env bash
+if [ "\$1" = "-C" ] && [ "\$3" = "add" ] && [ "\$4" = "-f" ] && [ "\$5" = "notes/.manifest" ]; then
+  echo "simulated manifest add failure" >&2
+  exit 99
+fi
+exec "$real_git" "\$@"
+SH
+  chmod +x "$BATS_TEST_TMPDIR/bin/git"
+
+  PATH="$BATS_TEST_TMPDIR/bin:$PATH" run notes stage
+  [ "$status" -ne 0 ]
+  [ "$(cat "$MANIFEST")" = "$manifest_before" ]
+
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-status
+  [[ "$output" == *$'D\tnotes/'"$alpha_id"* ]]
+  [[ "$output" != *$'M\tnotes/.manifest'* ]]
+
+  run notes stage
+  [ "$status" -eq 0 ]
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-status
+  [[ "$output" == *$'D\tnotes/'"$alpha_id"* ]]
+  [[ "$output" == *$'M\tnotes/.manifest'* ]]
+}
+
 @test "notes stage: deleted note stages manifest update in same commit" {
   source "$REPO_DIR/lib/hooks.sh"
   install_obfuscation_hook


### PR DESCRIPTION
## Summary

- update `notes stage` deletion handling to remove the deleted note from `notes/.manifest`
- stage the manifest update alongside the obfuscated blob deletion
- add regression coverage that a delete + `notes stage` + commit leaves the repo clean
- add a dry-run guard proving deletion staging preview does not mutate the manifest or index

Fixes #101.

## Validation

- `bash -n .mise/tasks/stage test/changes.bats`
- `mise run test test/changes.bats --filter 'deleted note'`
- `mise run test test/changes.bats`
- `mise run test test/obfuscate.bats test/git-operations.bats`
- `mise run test` — 267 tests, 3 expected skips
- `git diff --check`
- `git pre-commit`
- `git pre-push` — WARN only for no local commits after push / existing GitHub merge commit signature warnings before push
