### PR TITLE
Harden delete staging against rm failures

### DIFF
--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -173,10 +173,18 @@ for relpath in "${to_stage[@]}"; do
     # Deleted: remove the obfuscated ID from the index
     id=$(manifest_id_for_name "$manifest" "$relpath")
     if [ -n "$id" ]; then
+      # First remove the tracked blob when it is still present in the index.
+      # If the index cannot be updated (for example, an index lock exists),
+      # fail before mutating the working manifest. If a previous interrupted
+      # run already staged/removed the blob, keep going and only stage the
+      # manifest repair.
+      if git -C "$TARGET_DIR" ls-files --error-unmatch -- "$notes_dir/$id" >/dev/null 2>&1; then
+        git -C "$TARGET_DIR" rm --cached --quiet "$notes_dir/$id"
+      fi
+
       tmp_manifest=$(mktemp) || exit 1
       awk -F '\t' -v path="$relpath" '$2 != path { print $0 }' "$manifest" > "$tmp_manifest"
       mv -f "$tmp_manifest" "$manifest"
-      git -C "$TARGET_DIR" rm --cached --quiet "$notes_dir/$id" 2>/dev/null || true
       git -C "$TARGET_DIR" add -f "$notes_dir/.manifest"
       echo "  staged (delete): $relpath"
     fi

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -354,6 +354,22 @@ rename_manifest_entry_in_head() {
   [ -z "$output" ]
 }
 
+@test "notes stage: deleted note does not mutate manifest when index removal fails" {
+  local manifest_before
+  manifest_before=$(cat "$MANIFEST")
+  rm "$NOTES_CALLER_PWD/notes/alpha.md"
+  touch "$NOTES_CALLER_PWD/.git/index.lock"
+
+  run notes stage
+  rm -f "$NOTES_CALLER_PWD/.git/index.lock"
+
+  [ "$status" -ne 0 ]
+  [ "$(cat "$MANIFEST")" = "$manifest_before" ]
+
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
+  [ -z "$output" ]
+}
+
 @test "notes stage: deleted note stages manifest update in same commit" {
   source "$REPO_DIR/lib/hooks.sh"
   install_obfuscation_hook


### PR DESCRIPTION
Fix-it for KnickKnackLabs/notes#116.\n\nThis keeps deletion staging repeatable when the obfuscated blob is already gone from the index, but does not edit notes/.manifest until git can actually remove the tracked blob. It adds an index-lock regression test so a git rm failure leaves the manifest and index untouched.\n\nValidation:\n- bash -n .mise/tasks/stage test/changes.bats\n- mise run test test/changes.bats --filter 'deleted note'\n- mise run test test/changes.bats\n- git diff --check origin/main...HEAD