### PR TITLE
fix: roll back deletion manifest on stage failure

### DIFF
--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -183,9 +183,15 @@ for relpath in "${to_stage[@]}"; do
       fi
 
       tmp_manifest=$(mktemp) || exit 1
+      manifest_backup=$(mktemp) || exit 1
+      cp "$manifest" "$manifest_backup"
       awk -F '\t' -v path="$relpath" '$2 != path { print $0 }' "$manifest" > "$tmp_manifest"
       mv -f "$tmp_manifest" "$manifest"
-      git -C "$TARGET_DIR" add -f "$notes_dir/.manifest"
+      if ! git -C "$TARGET_DIR" add -f "$notes_dir/.manifest"; then
+        mv -f "$manifest_backup" "$manifest"
+        exit 1
+      fi
+      rm -f "$manifest_backup"
       echo "  staged (delete): $relpath"
     fi
   fi

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -370,6 +370,39 @@ rename_manifest_entry_in_head() {
   [ -z "$output" ]
 }
 
+@test "notes stage: deleted note rolls back manifest when manifest staging fails" {
+  local alpha_id manifest_before real_git
+  alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
+  manifest_before=$(cat "$MANIFEST")
+  real_git=$(command -v git)
+  rm "$NOTES_CALLER_PWD/notes/alpha.md"
+
+  mkdir -p "$BATS_TEST_TMPDIR/bin"
+  cat > "$BATS_TEST_TMPDIR/bin/git" <<SH
+#!/usr/bin/env bash
+if [ "\$1" = "-C" ] && [ "\$3" = "add" ] && [ "\$4" = "-f" ] && [ "\$5" = "notes/.manifest" ]; then
+  echo "simulated manifest add failure" >&2
+  exit 99
+fi
+exec "$real_git" "\$@"
+SH
+  chmod +x "$BATS_TEST_TMPDIR/bin/git"
+
+  PATH="$BATS_TEST_TMPDIR/bin:$PATH" run notes stage
+  [ "$status" -ne 0 ]
+  [ "$(cat "$MANIFEST")" = "$manifest_before" ]
+
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-status
+  [[ "$output" == *$'D\tnotes/'"$alpha_id"* ]]
+  [[ "$output" != *$'M\tnotes/.manifest'* ]]
+
+  run notes stage
+  [ "$status" -eq 0 ]
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-status
+  [[ "$output" == *$'D\tnotes/'"$alpha_id"* ]]
+  [[ "$output" == *$'M\tnotes/.manifest'* ]]
+}
+
 @test "notes stage: deleted note stages manifest update in same commit" {
   source "$REPO_DIR/lib/hooks.sh"
   install_obfuscation_hook


### PR DESCRIPTION
Fix-it for KnickKnackLabs/notes#116.

The current deletion path correctly runs `git rm --cached` before mutating `notes/.manifest`, but if `git add -f notes/.manifest` fails after the manifest rewrite, the worktree manifest has already dropped the note while the index only has the obfuscated blob deletion staged. A subsequent `notes stage` then reports no changes, so the half-staged state is not repaired by the normal command.

This patch:

- saves a manifest backup before rewriting it for a deleted note;
- restores the manifest if staging `notes/.manifest` fails;
- adds a regression that injects a manifest-add failure after successful `git rm --cached`, verifies the manifest is restored, and verifies a second normal `notes stage` repairs the deletion.

Validation run locally:

- `bash -n .mise/tasks/stage test/changes.bats`
- `mise run test test/changes.bats --filter 'deleted note'` — 4/4
- `mise run test test/changes.bats` — 33/33
- `git diff --check`

Degraded full-suite note: local `mise run test` still fails existing output-capture baselines in `test/new.bats` and `test/obfuscate.bats`, consistent with Brownie's earlier notes PR reviews in this runner; changed-area tests pass.
