### PR TITLE
Add note search and show primitives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+__pycache__/
+*.pyc

--- a/.mise/tasks/add-user
+++ b/.mise/tasks/add-user
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Add a GPG collaborator who can decrypt this repo"
 #USAGE flag "--gpg-key <fingerprint>" help="GPG key fingerprint" required=#true
-set -eo pipefail
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
 require_git

--- a/.mise/tasks/changes
+++ b/.mise/tasks/changes
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #MISE description="Show changed notes (diffs against last commit)"
-#USAGE flag "--dir <dir>" help="Notes directory relative to repo root (default: notes)"
-#USAGE flag "--summary" help="Show only the change summary (modified/new/deleted), no diffs"
-#USAGE arg "[files]..." help="Specific notes to check (readable names, relative to notes dir). Omit for all."
-set -eo pipefail
+#USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root"
+#USAGE flag "--summary" default=#false help="Show only the change summary (modified/new/deleted), no diffs"
+#USAGE arg "[files]" var=#true default="" help="Specific notes to check (readable names, relative to notes dir). Omit for all."
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
 source "$MISE_CONFIG_ROOT/lib/obfuscate.sh"
@@ -25,6 +25,7 @@ ARGS=()
 if [ -n "${usage_files:-}" ]; then
   while IFS= read -r arg; do
     arg="${arg#"${notes_dir}/"}"
+    [ -z "$arg" ] && continue
     ARGS+=("$arg")
   done < <(printf '%s' "${usage_files}" | xargs printf '%s\n')
 fi
@@ -43,7 +44,7 @@ if [ "${usage_summary:-}" = "true" ]; then
   while IFS=$'\t' read -r status relpath; do
     if [ ${#ARGS[@]} -gt 0 ] && [ -n "${ARGS[0]}" ]; then
       match=false
-      for f in "${ARGS[@]}"; do
+      for f in ${ARGS[@]+"${ARGS[@]}"}; do
         [ "$f" = "$relpath" ] && match=true && break
       done
       $match || continue
@@ -73,5 +74,5 @@ else
     exit 0
   fi
 
-  show_diffs "$abs_notes_dir" "${ARGS[@]}"
+  show_diffs "$abs_notes_dir" ${ARGS[@]+"${ARGS[@]}"}
 fi

--- a/.mise/tasks/deobfuscate
+++ b/.mise/tasks/deobfuscate
@@ -4,7 +4,7 @@
 #USAGE flag "--dry-run" default=#false help="Show what would be renamed without doing it"
 #USAGE flag "--force" default=#false help="Overwrite existing readable files intentionally"
 #USAGE arg "[files]" var=#true default="" help="Specific obfuscated IDs to deobfuscate. Omit for all."
-set -eo pipefail
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
 source "$MISE_CONFIG_ROOT/lib/obfuscate.sh"
@@ -36,7 +36,7 @@ fi
 if [ "${usage_dry_run:-}" = "true" ]; then
   # Dry-run: just show what would be renamed
   if [ ${#ARGS[@]} -gt 0 ]; then
-    for id in "${ARGS[@]}"; do
+    for id in ${ARGS[@]+"${ARGS[@]}"}; do
       relpath=$(manifest_name_for_id "$manifest" "$id")
       if [ -z "$relpath" ]; then
         echo "Warning: unknown ID '$id', skipping" >&2
@@ -73,7 +73,7 @@ fi
 # Exit codes: 0=success, 2=nothing to do, 3=dirty readable preserved, 1=error.
 # Use subshell to capture exit code without triggering errexit.
 export NOTES_DEOBFUSCATE_FORCE="${usage_force:-false}"
-output=$(rename_to_readable "$abs_notes_dir" "${ARGS[@]}") && rc=0 || rc=$?
+output=$(rename_to_readable "$abs_notes_dir" ${ARGS[@]+"${ARGS[@]}"}) && rc=0 || rc=$?
 
 # Print what was renamed, collect IDs. Do this even on partial failure so
 # the state file stays consistent with disk; surface the rc afterwards.
@@ -108,7 +108,7 @@ fi
 
 # Warn about unknown IDs in scoped mode (matches dry-run behavior)
 if [ ${#ARGS[@]} -gt 0 ]; then
-  for id in "${ARGS[@]}"; do
+  for id in ${ARGS[@]+"${ARGS[@]}"}; do
     found=false
     for sid in ${suppressed_ids[@]+"${suppressed_ids[@]}"}; do
       [ "$sid" = "$id" ] && found=true && break
@@ -126,7 +126,7 @@ if $full_mode; then
   rebuild_status_suppression "$abs_notes_dir" \
     || echo "Warning: failed to rebuild status suppression" >&2
 elif [ ${#suppressed_ids[@]} -gt 0 ]; then
-  set_status_suppression "$abs_notes_dir" "${suppressed_ids[@]}" \
+  set_status_suppression "$abs_notes_dir" ${suppressed_ids[@]+"${suppressed_ids[@]}"} \
     || echo "Warning: failed to update status suppression" >&2
 fi
 
@@ -134,7 +134,7 @@ fi
 # helper errors with `|| warn` so the original rename rc isn't masked under
 # `set -e`.
 if [ ${#suppressed_ids[@]} -gt 0 ]; then
-  _record_deobfuscation_base_hashes "$abs_notes_dir" "${suppressed_ids[@]}" \
+  _record_deobfuscation_base_hashes "$abs_notes_dir" ${suppressed_ids[@]+"${suppressed_ids[@]}"} \
     || echo "Warning: failed to record deobfuscation base hashes" >&2
 fi
 

--- a/.mise/tasks/install-hooks
+++ b/.mise/tasks/install-hooks
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Install git hooks for obfuscation (pre-commit, post-commit, post-merge)"
-#USAGE flag "--dir <dir>" help="Notes directory relative to repo root (default: notes)"
-set -eo pipefail
+#USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root"
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
 source "$MISE_CONFIG_ROOT/lib/hooks.sh"

--- a/.mise/tasks/list
+++ b/.mise/tasks/list
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 #MISE description="List notes with metadata"
-#USAGE flag "--json" help="Output as JSON array"
-#USAGE flag "--recent <n>" help="Show N most recently updated notes"
-#USAGE flag "--tag <tag>" help="Filter by tag"
-#USAGE flag "--dir <dir>" help="Notes directory relative to repo root (default: notes)"
-set -eo pipefail
+#USAGE flag "--json" help="Output as JSON array" default=#false
+#USAGE flag "--recent <n>" help="Show N most recently updated notes" default=""
+#USAGE flag "--tag <tag>" help="Filter by tag" default=""
+#USAGE flag "--type <type>" help="Filter by frontmatter type" default=""
+#USAGE flag "--status <status>" help="Filter by frontmatter status" default=""
+#USAGE flag "--dir <dir>" help="Notes directory relative to repo root" default="notes"
+set -euo pipefail
 
-TARGET_DIR="${NOTES_CALLER_PWD:-${CALLER_PWD:-.}}"
+REPO_DIR="${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}"
+TARGET_DIR="${NOTES_CALLER_PWD:-.}"
 notes_dir="$TARGET_DIR/${usage_dir:-notes}"
 
 if [ ! -d "$notes_dir" ]; then
@@ -14,113 +17,59 @@ if [ ! -d "$notes_dir" ]; then
   exit 1
 fi
 
-python3 - "$notes_dir" "${usage_json:-false}" "${usage_recent:-}" "${usage_tag:-}" <<'PY'
+python3 - "$REPO_DIR" "$notes_dir" "${usage_json:-false}" "${usage_recent:-}" "${usage_tag:-}" "${usage_type:-}" "${usage_status:-}" <<'PY'
 import json
+import subprocess
 import sys
 from pathlib import Path
 
-notes_dir = Path(sys.argv[1])
-json_output = sys.argv[2] == "true"
-recent = sys.argv[3]
-tag_filter = sys.argv[4]
+repo_dir = Path(sys.argv[1])
+notes_dir = Path(sys.argv[2])
+json_output = sys.argv[3] == "true"
+recent = sys.argv[4]
+tag_filter = sys.argv[5]
+type_filter = sys.argv[6]
+status_filter = sys.argv[7]
 
+sys.path.insert(0, str(repo_dir / "lib"))
+from frontmatter import filter_notes, iter_notes  # noqa: E402
 
-def parse_scalar(value: str) -> str:
-    value = value.strip()
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
-        return value[1:-1]
-    return value
-
-
-def parse_list(value: str):
-    value = value.strip()
-    if not value:
-        return []
-    if value.startswith("[") and value.endswith("]"):
-        inner = value[1:-1].strip()
-        if not inner:
-            return []
-        return [parse_scalar(part) for part in inner.split(",") if parse_scalar(part)]
-    return [parse_scalar(value)]
-
-
-def parse_frontmatter(path: Path):
-    try:
-        text = path.read_text(encoding="utf-8")
-    except UnicodeDecodeError:
-        return None
-    if not text.startswith("---\n"):
-        return None
-    end = text.find("\n---", 4)
-    if end == -1:
-        return None
-
-    data = {}
-    current_list_key = None
-    for line in text[4:end].splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-
-        if current_list_key and line.startswith((" ", "\t")) and stripped.startswith("-"):
-            item = stripped[1:].strip()
-            if item:
-                data[current_list_key].append(parse_scalar(item))
-            continue
-
-        current_list_key = None
-        if ":" not in line:
-            continue
-        key, value = line.split(":", 1)
-        key = key.strip()
-        value = value.strip()
-        if key in {"tags", "related"}:
-            data[key] = parse_list(value)
-            if not value:
-                current_list_key = key
-        else:
-            data[key] = parse_scalar(value)
-    return data
-
-
-rows = []
-for path in sorted(notes_dir.glob("*.md")):
-    meta = parse_frontmatter(path)
-    if not meta:
-        continue
-    title = str(meta.get("title", "")).strip()
-    if not title:
-        continue
-    tags = meta.get("tags", [])
-    if not isinstance(tags, list):
-        tags = []
-    if tag_filter and tag_filter not in tags:
-        continue
-    date = str(meta.get("updated") or meta.get("created") or "")
-    rows.append({
-        "title": title,
-        "tags": tags,
-        "date": date,
-        "slug": path.stem,
-        "path": str(path),
-    })
+rows = [
+    note.row()
+    for note in filter_notes(
+        iter_notes(notes_dir),
+        tag=tag_filter,
+        note_type=type_filter,
+        status=status_filter,
+    )
+]
 
 rows.sort(key=lambda row: row["date"], reverse=True)
 if recent:
-    rows = rows[: int(recent)]
+    try:
+        rows = rows[: int(recent)]
+    except ValueError:
+        print(f"Error: --recent must be an integer: {recent}", file=sys.stderr)
+        sys.exit(1)
 
 if json_output:
     print(json.dumps(rows, indent=2, ensure_ascii=False))
 elif not rows:
+    filters = []
     if tag_filter:
-        print(f"No notes found with tag: {tag_filter}")
+        filters.append(f"tag={tag_filter}")
+    if type_filter:
+        filters.append(f"type={type_filter}")
+    if status_filter:
+        filters.append(f"status={status_filter}")
+    if filters:
+        print(f"No notes found with {' '.join(filters)}")
     else:
         print("No notes found.")
 else:
-    table = "Title\tTags\tUpdated\n" + "\n".join(
-        f"{row['title']}\t{', '.join(row['tags'])}\t{row['date']}" for row in rows
+    table = "Title\tType\tStatus\tTags\tUpdated\n" + "\n".join(
+        f"{row['title']}\t{row['type']}\t{row['status']}\t{', '.join(row['tags'])}\t{row['date']}" for row in rows
     )
-    import subprocess
     subprocess.run(
         ["gum", "table", "--print", "--separator", "\t"],
         input=table,

--- a/.mise/tasks/lock
+++ b/.mise/tasks/lock
@@ -2,7 +2,7 @@
 #MISE description="Lock encrypted files (re-encrypt on disk)"
 #USAGE flag "-y --yes" default=#false help="Skip confirmation prompt"
 #USAGE flag "-k --key <name>" default="" help="Lock only this named key's files (default: lock all)"
-set -eo pipefail
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
 require_git

--- a/.mise/tasks/new
+++ b/.mise/tasks/new
@@ -2,15 +2,15 @@
 #MISE description="Create a new note with frontmatter"
 #USAGE flag "--slug <slug>" help="Filename without extension" required=#true
 #USAGE flag "--title <title>" help="Note title" required=#true
-#USAGE flag "--tags <tags>" help="Comma-separated tags"
-#USAGE flag "--updated <updated>" help="Updated date (default: today)"
-#USAGE flag "--created <created>" help="Created date (default: today)"
-#USAGE flag "--related <related>" help="Comma-separated related slugs"
-#USAGE flag "--body <body>" help="Body text after frontmatter"
-#USAGE flag "--dir <dir>" help="Notes directory relative to repo root (default: notes)"
-set -eo pipefail
+#USAGE flag "--tags <tags>" default="" help="Comma-separated tags"
+#USAGE flag "--updated <updated>" default="" help="Updated date (default: today)"
+#USAGE flag "--created <created>" default="" help="Created date (default: today)"
+#USAGE flag "--related <related>" default="" help="Comma-separated related slugs"
+#USAGE flag "--body <body>" default="" help="Body text after frontmatter"
+#USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root"
+set -euo pipefail
 
-TARGET_DIR="${NOTES_CALLER_PWD:-${CALLER_PWD:-.}}"
+TARGET_DIR="${NOTES_CALLER_PWD:-.}"
 notes_dir="$TARGET_DIR/${usage_dir:-notes}"
 today=$(date +%Y-%m-%d)
 

--- a/.mise/tasks/obfuscate
+++ b/.mise/tasks/obfuscate
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #MISE description="Obfuscate note filenames (reversible via deobfuscate)"
-#USAGE flag "--dir <dir>" help="Notes directory relative to repo root (default: notes)"
-#USAGE flag "--dry-run" help="Show what would be renamed without doing it"
-#USAGE arg "[files]..." help="Specific files to obfuscate (relative to notes dir). Omit for all."
-set -eo pipefail
+#USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root"
+#USAGE flag "--dry-run" default=#false help="Show what would be renamed without doing it"
+#USAGE arg "[files]" var=#true default="" help="Specific files to obfuscate (relative to notes dir). Omit for all."
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
 source "$MISE_CONFIG_ROOT/lib/obfuscate.sh"
@@ -25,6 +25,7 @@ if [ -n "${usage_files:-}" ]; then
   while IFS= read -r arg; do
     # Strip notes_dir prefix if provided (e.g. "notes/alpha.md" → "alpha.md")
     arg="${arg#"${notes_dir}/"}"
+    [ -z "$arg" ] && continue
     ARGS+=("$arg")
   done < <(printf '%s' "${usage_files}" | xargs printf '%s\n')
 fi
@@ -33,7 +34,7 @@ if [ "${usage_dry_run:-}" = "true" ]; then
   # Dry-run: show what would be renamed without doing it.
   # Use the same classification logic as rename_to_obfuscated.
   if [ ${#ARGS[@]} -gt 0 ]; then
-    for relpath in "${ARGS[@]}"; do
+    for relpath in ${ARGS[@]+"${ARGS[@]}"}; do
       [[ "$relpath" == ".manifest" ]] && continue
       [ ! -f "$abs_notes_dir/$relpath" ] && continue
       base=$(basename "$relpath")
@@ -67,11 +68,11 @@ fi
 # In scoped mode, we need to find the IDs for files being re-obfuscated.
 if [ ${#ARGS[@]} -gt 0 ]; then
   scoped_ids=()
-  for relpath in "${ARGS[@]}"; do
+  for relpath in ${ARGS[@]+"${ARGS[@]}"}; do
     id=$(manifest_id_for_name "$manifest" "$relpath" || true)
     [ -n "$id" ] && scoped_ids+=("$id")
   done
-  [ ${#scoped_ids[@]} -gt 0 ] && clear_status_suppression "$abs_notes_dir" "${scoped_ids[@]}"
+  [ ${#scoped_ids[@]} -gt 0 ] && clear_status_suppression "$abs_notes_dir" ${scoped_ids[@]+"${scoped_ids[@]}"}
 else
   clear_status_suppression "$abs_notes_dir"
 fi
@@ -79,7 +80,7 @@ fi
 # Perform the rename via Layer 1
 # Exit codes: 0=success, 2=nothing to do, 1=error
 # Use && rc=0 || rc=$? to capture exit code without triggering errexit.
-output=$(rename_to_obfuscated "$abs_notes_dir" "${ARGS[@]}") && rc=0 || rc=$?
+output=$(rename_to_obfuscated "$abs_notes_dir" ${ARGS[@]+"${ARGS[@]}"}) && rc=0 || rc=$?
 if [ $rc -eq 2 ]; then
   echo "Nothing to obfuscate."
   exit 0

--- a/.mise/tasks/search
+++ b/.mise/tasks/search
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#MISE description="Search notes by title, frontmatter, and body"
+#USAGE arg "<query>" help="Case-insensitive text to search for" required=#true
+#USAGE flag "--json" help="Output as JSON array" default=#false
+#USAGE flag "--tag <tag>" help="Filter by tag" default=""
+#USAGE flag "--type <type>" help="Filter by frontmatter type" default=""
+#USAGE flag "--status <status>" help="Filter by frontmatter status" default=""
+#USAGE flag "--limit <n>" help="Maximum results to show" default="50"
+#USAGE flag "--dir <dir>" help="Notes directory relative to repo root" default="notes"
+set -euo pipefail
+
+REPO_DIR="${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}"
+TARGET_DIR="${NOTES_CALLER_PWD:-.}"
+notes_dir="$TARGET_DIR/${usage_dir:-notes}"
+
+if [ ! -d "$notes_dir" ]; then
+  echo "Error: notes directory not found: $notes_dir" >&2
+  exit 1
+fi
+
+python3 - "$REPO_DIR" "$notes_dir" "${usage_query:-}" "${usage_json:-false}" "${usage_tag:-}" "${usage_type:-}" "${usage_status:-}" "${usage_limit:-50}" <<'PY'
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+repo_dir = Path(sys.argv[1])
+notes_dir = Path(sys.argv[2])
+query = sys.argv[3]
+json_output = sys.argv[4] == "true"
+tag_filter = sys.argv[5]
+type_filter = sys.argv[6]
+status_filter = sys.argv[7]
+limit = sys.argv[8]
+
+sys.path.insert(0, str(repo_dir / "lib"))
+from frontmatter import filter_notes, iter_notes  # noqa: E402
+
+try:
+    limit_count = int(limit)
+except ValueError:
+    print(f"Error: --limit must be an integer: {limit}", file=sys.stderr)
+    sys.exit(1)
+if limit_count < 1:
+    print("Error: --limit must be greater than zero", file=sys.stderr)
+    sys.exit(1)
+
+needle = query.lower()
+rows = []
+for note in filter_notes(
+    iter_notes(notes_dir),
+    tag=tag_filter,
+    note_type=type_filter,
+    status=status_filter,
+):
+    if needle not in note.searchable_blob().lower():
+        continue
+
+    matches = []
+    if needle in note.title.lower():
+        matches.append(f"title: {note.title}")
+    if needle in note.slug.lower():
+        matches.append(f"slug: {note.slug}")
+    for key, value in note.metadata.items():
+        text = json.dumps(value, ensure_ascii=False) if isinstance(value, (list, dict)) else str(value)
+        if needle in text.lower() and key not in {"title"}:
+            matches.append(f"{key}: {text}")
+    for line_number, line in enumerate(note.body.splitlines(), start=1):
+        if needle in line.lower():
+            snippet = line.strip()
+            if len(snippet) > 120:
+                snippet = snippet[:117] + "..."
+            matches.append(f"body:{line_number}: {snippet}")
+        if len(matches) >= 5:
+            break
+
+    row = note.row()
+    row["matches"] = matches[:5]
+    rows.append(row)
+
+rows.sort(key=lambda row: row["date"], reverse=True)
+rows = rows[:limit_count]
+
+if json_output:
+    print(json.dumps(rows, indent=2, ensure_ascii=False))
+elif not rows:
+    filters = []
+    if tag_filter:
+        filters.append(f"tag={tag_filter}")
+    if type_filter:
+        filters.append(f"type={type_filter}")
+    if status_filter:
+        filters.append(f"status={status_filter}")
+    suffix = f" with {' '.join(filters)}" if filters else ""
+    print(f"No notes found matching: {query}{suffix}")
+else:
+    table = "Title\tType\tStatus\tUpdated\tMatches\n" + "\n".join(
+        f"{row['title']}\t{row['type']}\t{row['status']}\t{row['date']}\t{' | '.join(row['matches'][:2])}" for row in rows
+    )
+    subprocess.run(
+        ["gum", "table", "--print", "--separator", "\t"],
+        input=table,
+        text=True,
+        check=True,
+    )
+PY

--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -5,7 +5,7 @@
 #USAGE flag "--pattern <pattern>" var=#true default="" help="Gitattributes patterns to encrypt (default: <dir>/**)"
 #USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root"
 #USAGE flag "--unlock" default=#false help="Unlock after setup (for joining an existing repo)"
-set -eo pipefail
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
 source "$MISE_CONFIG_ROOT/lib/hooks.sh"

--- a/.mise/tasks/show
+++ b/.mise/tasks/show
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#MISE description="Show a note by slug, title, or path"
+#USAGE arg "<note>" help="Note slug, title, or path" required=#true
+#USAGE flag "--json" help="Output metadata and body as JSON" default=#false
+#USAGE flag "--dir <dir>" help="Notes directory relative to repo root" default="notes"
+set -euo pipefail
+
+REPO_DIR="${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}"
+TARGET_DIR="${NOTES_CALLER_PWD:-.}"
+notes_dir="$TARGET_DIR/${usage_dir:-notes}"
+
+if [ ! -d "$notes_dir" ]; then
+  echo "Error: notes directory not found: $notes_dir" >&2
+  exit 1
+fi
+
+python3 - "$REPO_DIR" "$TARGET_DIR" "$notes_dir" "${usage_note:-}" "${usage_json:-false}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+repo_dir = Path(sys.argv[1])
+target_dir = Path(sys.argv[2])
+notes_dir = Path(sys.argv[3])
+selector = sys.argv[4]
+json_output = sys.argv[5] == "true"
+
+sys.path.insert(0, str(repo_dir / "lib"))
+from frontmatter import Note, iter_notes, read_frontmatter  # noqa: E402
+
+
+def existing_path_candidates(selector: str) -> list[Path]:
+    raw = Path(selector).expanduser()
+    candidates: list[Path] = []
+    if raw.is_absolute():
+        candidates.append(raw)
+    else:
+        candidates.extend([target_dir / raw, notes_dir / raw])
+        if raw.suffix != ".md":
+            candidates.extend([target_dir / f"{selector}.md", notes_dir / f"{selector}.md"])
+    seen = set()
+    unique: list[Path] = []
+    for candidate in candidates:
+        resolved = candidate.resolve() if candidate.exists() else candidate
+        key = str(resolved)
+        if key not in seen:
+            unique.append(candidate)
+            seen.add(key)
+    return unique
+
+
+def note_from_path(path: Path) -> Note | None:
+    metadata, body = read_frontmatter(path)
+    if metadata is None or body is None:
+        return None
+    note = Note(path=path, metadata=metadata, body=body)
+    return note if note.title else None
+
+for candidate in existing_path_candidates(selector):
+    if candidate.is_file():
+        if json_output:
+            note = note_from_path(candidate)
+            if note is None:
+                print(json.dumps({"path": str(candidate), "metadata": {}, "body": candidate.read_text(encoding="utf-8")}, indent=2, ensure_ascii=False))
+            else:
+                print(json.dumps(note.json(include_body=True), indent=2, ensure_ascii=False))
+        else:
+            print(candidate.read_text(encoding="utf-8"), end="")
+        sys.exit(0)
+
+notes = iter_notes(notes_dir)
+exact_slug = [note for note in notes if note.slug == selector]
+if exact_slug:
+    matches = exact_slug
+else:
+    selector_lower = selector.lower()
+    matches = [note for note in notes if note.title.lower() == selector_lower]
+
+if not matches:
+    print(f"Error: note not found: {selector}", file=sys.stderr)
+    sys.exit(1)
+if len(matches) > 1:
+    print(f"Error: note selector is ambiguous: {selector}", file=sys.stderr)
+    for note in matches:
+        print(f"  {note.slug}\t{note.title}\t{note.path}", file=sys.stderr)
+    sys.exit(1)
+
+note = matches[0]
+if json_output:
+    print(json.dumps(note.json(include_body=True), indent=2, ensure_ascii=False))
+else:
+    print(note.path.read_text(encoding="utf-8"), end="")
+PY

--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -3,7 +3,7 @@
 #USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root (default: notes)"
 #USAGE flag "--dry-run" default=#false help="Show what would be staged without doing it"
 #USAGE arg "[files]" var=#true default="" help="Specific notes to stage (readable names, relative to notes dir). Omit to stage modified/deleted only; new notes require explicit files."
-set -eo pipefail
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
 source "$MISE_CONFIG_ROOT/lib/obfuscate.sh"
@@ -56,7 +56,7 @@ while IFS=$'\t' read -r status relpath; do
   [ "$status" = "stale-readable" ] || continue
   if $explicit_files; then
     match=false
-    for f in "${ARGS[@]}"; do
+    for f in ${ARGS[@]+"${ARGS[@]}"}; do
       [ "$f" = "$relpath" ] && match=true && break
     done
     $match || continue
@@ -81,7 +81,7 @@ if [ -n "$conflicting_notes" ]; then
     [ -z "$conflict_id" ] && continue
     if $explicit_files; then
       match=false
-      for f in "${ARGS[@]}"; do
+      for f in ${ARGS[@]+"${ARGS[@]}"}; do
         [ "$f" = "$conflict_relpath" ] && match=true && break
       done
       $match || continue
@@ -110,7 +110,7 @@ print_skipped_new() {
   [ ${#skipped_new[@]} -eq 0 ] && return 0
 
   echo "Skipped ${#skipped_new[@]} new note(s). Stage explicitly with: notes stage <file>"
-  for relpath in "${skipped_new[@]}"; do
+  for relpath in ${skipped_new[@]+"${skipped_new[@]}"}; do
     echo "  new: $relpath"
   done
 }
@@ -118,7 +118,7 @@ print_skipped_new() {
 while IFS=$'\t' read -r status relpath; do
   if $explicit_files; then
     match=false
-    for f in "${ARGS[@]}"; do
+    for f in ${ARGS[@]+"${ARGS[@]}"}; do
       [ "$f" = "$relpath" ] && match=true && break
     done
     $match || continue
@@ -153,7 +153,7 @@ fi
 
 if [ "${usage_dry_run:-}" = "true" ]; then
   echo "Would stage:"
-  for relpath in "${to_stage[@]}"; do
+  for relpath in ${to_stage[@]+"${to_stage[@]}"}; do
     echo "  $relpath"
   done
   print_skipped_new
@@ -162,7 +162,7 @@ fi
 
 # Stage each file using git add -f to bypass .git/info/exclude
 staged=0
-for relpath in "${to_stage[@]}"; do
+for relpath in ${to_stage[@]+"${to_stage[@]}"}; do
   local_file="$abs_notes_dir/$relpath"
 
   if [ -f "$local_file" ]; then

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,13 +1,37 @@
 #!/usr/bin/env bash
 #MISE description="Run test suite"
 #MISE hide=true
-#USAGE arg "[args...]" help="Test files or bats flags (e.g., test/obfuscate.bats, --filter 'pattern')"
-set -eo pipefail
+#USAGE arg "[args]" var=#true default="" help="Test files or bats flags (e.g., test/obfuscate.bats, --filter 'pattern')"
+#USAGE example "mise run test" header="Run all tests"
+#USAGE example "mise run test list" header="Run test/list.bats"
+#USAGE example "mise run test --filter rejects" header="Filter tests by name"
+set -euo pipefail
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REPO_DIR="${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}"
+TEST_DIR="$REPO_DIR/test"
 
-if [ $# -gt 0 ]; then
-  exec bats "$@"
+args=()
+if [ -n "${usage_args:-}" ]; then
+  while IFS= read -r arg; do
+    [ -z "$arg" ] && continue
+    args+=("$arg")
+  done < <(printf '%s' "${usage_args}" | xargs printf '%s\n')
 fi
 
-exec bats --jobs 8 --parallel-binary-name rush "$REPO_DIR/test/"
+resolved=()
+has_target=false
+for arg in ${args[@]+"${args[@]}"}; do
+  if [[ "$arg" != -* && "$arg" != *.bats && -f "$TEST_DIR/$arg.bats" ]]; then
+    resolved+=("$TEST_DIR/$arg.bats")
+    has_target=true
+  else
+    [[ "$arg" == *.bats || -d "$arg" ]] && has_target=true
+    resolved+=("$arg")
+  fi
+done
+
+if ! $has_target; then
+  resolved+=("$TEST_DIR/")
+fi
+
+exec bats --jobs 8 --parallel-binary-name rush ${resolved[@]+"${resolved[@]}"}

--- a/.mise/tasks/unlock
+++ b/.mise/tasks/unlock
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Unlock encrypted files using your GPG key"
-#USAGE flag "--force" help="Overwrite existing readable note files during deobfuscation"
-set -eo pipefail
+#USAGE flag "--force" default=#false help="Overwrite existing readable note files during deobfuscation"
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
 require_git
@@ -19,7 +19,7 @@ echo "Note: unlock decrypts all encrypted files in this repo (rudi#5)."
 # Deobfuscate filenames if a manifest exists
 if [ -f "$TARGET_DIR/notes/.manifest" ]; then
   if [ "${usage_force:-false}" = "true" ]; then
-    cd "$MISE_CONFIG_ROOT" && NOTES_CALLER_PWD="$TARGET_DIR" mise run -q deobfuscate -- --force
+    cd "$MISE_CONFIG_ROOT" && NOTES_CALLER_PWD="$TARGET_DIR" mise run -q deobfuscate --force
   else
     cd "$MISE_CONFIG_ROOT" && NOTES_CALLER_PWD="$TARGET_DIR" mise run -q deobfuscate
   fi

--- a/.mise/tasks/verify
+++ b/.mise/tasks/verify
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #MISE description="Verify that a public key produces a given fingerprint"
 #USAGE flag "--gpg-key <fingerprint>" help="Expected GPG fingerprint" required=#true
-#USAGE flag "--key-file <file>" help="Path to armored public key file (or - for stdin)"
-set -eo pipefail
+#USAGE flag "--key-file <file>" default="" help="Path to armored public key file (or - for stdin)"
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
 require_rudi

--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ notes setup --yes
 # Add a note with YAML frontmatter.
 notes new --slug project-plan --title "Project plan" --tags planning
 
-# See note metadata.
+# See note metadata, search notes, and show one note.
 notes list
+notes search "workflow"
+notes show project-plan
 
 # Check encryption + obfuscation state.
 notes status
@@ -38,6 +40,11 @@ notes status
 # Show note changes against HEAD.
 notes changes
 notes changes --summary
+
+# Query notes by metadata or content.
+notes list --type skill
+notes search "review capacity" --tag workflow
+notes show project-plan --json
 
 # Show readable diffs for local changes, refs, or PRs.
 notes diff

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -8,9 +8,9 @@
 #   - hooks.sh     — git hook installation
 
 # Prefer the notes-specific caller dir to avoid inheriting stale generic
-# caller context from another shiv-managed tool. CALLER_PWD remains a
-# temporary migration fallback for older shims/callers.
-TARGET_DIR="${NOTES_CALLER_PWD:-${CALLER_PWD:-.}}"
+# caller context from another shiv-managed tool. Direct repo-local task runs
+# fall back to the current working directory.
+TARGET_DIR="${NOTES_CALLER_PWD:-.}"
 
 NOTES_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NOTES_REPO_DIR="$(cd "$NOTES_LIB_DIR/.." && pwd)"

--- a/lib/frontmatter.py
+++ b/lib/frontmatter.py
@@ -1,0 +1,212 @@
+"""Small Markdown frontmatter helpers for notes tasks.
+
+This intentionally avoids a YAML dependency. It supports the frontmatter shape
+`notes new` writes plus simple block lists used by shared note repos.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any
+
+LIST_KEYS = {"tags", "related"}
+
+
+def parse_scalar(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+    return value
+
+
+def split_inline_list(value: str) -> list[str]:
+    """Split a YAML-ish inline list without pulling in a YAML parser."""
+    parts: list[str] = []
+    current: list[str] = []
+    quote: str | None = None
+    escape = False
+
+    for char in value:
+        if escape:
+            current.append(char)
+            escape = False
+            continue
+        if char == "\\" and quote:
+            current.append(char)
+            escape = True
+            continue
+        if quote:
+            current.append(char)
+            if char == quote:
+                quote = None
+            continue
+        if char in {'"', "'"}:
+            quote = char
+            current.append(char)
+            continue
+        if char == ",":
+            item = parse_scalar("".join(current))
+            if item:
+                parts.append(item)
+            current = []
+            continue
+        current.append(char)
+
+    item = parse_scalar("".join(current))
+    if item:
+        parts.append(item)
+    return parts
+
+
+def parse_list(value: str) -> list[str]:
+    value = value.strip()
+    if not value:
+        return []
+    if value.startswith("[") and value.endswith("]"):
+        inner = value[1:-1].strip()
+        if not inner:
+            return []
+        return split_inline_list(inner)
+    return [parse_scalar(value)]
+
+
+def parse_frontmatter_text(text: str) -> tuple[dict[str, Any] | None, str]:
+    if not text.startswith("---\n"):
+        return None, text
+    end = text.find("\n---", 4)
+    if end == -1:
+        return None, text
+
+    data: dict[str, Any] = {}
+    current_list_key: str | None = None
+    for line in text[4:end].splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if current_list_key and line.startswith((" ", "\t")) and stripped.startswith("-"):
+            item = stripped[1:].strip()
+            if item:
+                data[current_list_key].append(parse_scalar(item))
+            continue
+
+        current_list_key = None
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if key in LIST_KEYS:
+            data[key] = parse_list(value)
+            if not value:
+                current_list_key = key
+        else:
+            data[key] = parse_scalar(value)
+
+    body_start = end + len("\n---")
+    if body_start < len(text) and text[body_start] == "\n":
+        body_start += 1
+    return data, text[body_start:]
+
+
+def read_frontmatter(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return None, None
+    metadata, body = parse_frontmatter_text(text)
+    return metadata, body
+
+
+@dataclass(frozen=True)
+class Note:
+    path: Path
+    metadata: dict[str, Any]
+    body: str
+
+    @property
+    def slug(self) -> str:
+        return self.path.stem
+
+    @property
+    def title(self) -> str:
+        return str(self.metadata.get("title", "")).strip()
+
+    @property
+    def tags(self) -> list[str]:
+        tags = self.metadata.get("tags", [])
+        return tags if isinstance(tags, list) else []
+
+    @property
+    def date(self) -> str:
+        return str(self.metadata.get("updated") or self.metadata.get("created") or "")
+
+    @property
+    def note_type(self) -> str:
+        return str(self.metadata.get("type", ""))
+
+    @property
+    def status(self) -> str:
+        return str(self.metadata.get("status", ""))
+
+    def row(self) -> dict[str, Any]:
+        return {
+            "title": self.title,
+            "tags": self.tags,
+            "date": self.date,
+            "created": str(self.metadata.get("created", "")),
+            "updated": str(self.metadata.get("updated", "")),
+            "type": self.note_type,
+            "status": self.status,
+            "slug": self.slug,
+            "path": str(self.path),
+        }
+
+    def json(self, include_body: bool = False) -> dict[str, Any]:
+        row = self.row()
+        row["metadata"] = self.metadata
+        if include_body:
+            row["body"] = self.body
+        return row
+
+    def searchable_blob(self) -> str:
+        return "\n".join(
+            [
+                self.slug,
+                self.title,
+                json.dumps(self.metadata, ensure_ascii=False, sort_keys=True),
+                self.body,
+            ]
+        )
+
+
+def iter_notes(notes_dir: Path) -> list[Note]:
+    notes: list[Note] = []
+    for path in sorted(notes_dir.glob("*.md")):
+        metadata, body = read_frontmatter(path)
+        if metadata is None or body is None:
+            continue
+        note = Note(path=path, metadata=metadata, body=body)
+        if not note.title:
+            continue
+        notes.append(note)
+    return notes
+
+
+def filter_notes(
+    notes: list[Note],
+    *,
+    tag: str = "",
+    note_type: str = "",
+    status: str = "",
+) -> list[Note]:
+    filtered = notes
+    if tag:
+        filtered = [note for note in filtered if tag in note.tags]
+    if note_type:
+        filtered = [note for note in filtered if note.note_type == note_type]
+    if status:
+        filtered = [note for note in filtered if note.status == status]
+    return filtered

--- a/lib/manifest-merge-driver.sh
+++ b/lib/manifest-merge-driver.sh
@@ -22,7 +22,7 @@
 # happen because rename = delete old + create new with new ID under the
 # current obfuscate logic. If rename-in-place is ever added, this driver
 # should detect the "two names → one ID" case.
-set -eo pipefail
+set -euo pipefail
 
 ANCESTOR="$1"  # %O — common ancestor
 OURS="$2"      # %A — current branch (merge result goes here)
@@ -38,7 +38,7 @@ trap 'rm -rf "$WORK"' EXIT
 #
 # If the file is encrypted, decrypt it through git-crypt's smudge filter. If
 # smudge fails (repo locked, git-crypt not installed), this is a hard error
-# — we exit non-zero with a diagnostic. The calling `set -eo pipefail` will
+# — we exit non-zero with a diagnostic. The calling `set -euo pipefail` will
 # abort the driver, which leaves `ours` unchanged. That's the right
 # behavior: git then surfaces a merge conflict on the manifest, and the
 # user is forced to investigate rather than silently accepting a corrupted

--- a/test/common.bats
+++ b/test/common.bats
@@ -43,21 +43,22 @@ EOF
   [[ "$output" != *"Wrong Repo"* ]]
 }
 
-@test "legacy CALLER_PWD fallback still resolves target repo" {
-  local legacy="$BATS_TEST_TMPDIR/legacy-repo"
-  mkdir -p "$legacy/notes"
-  cat > "$legacy/notes/legacy.md" <<'EOF'
+@test "generic CALLER_PWD is ignored to avoid stale caller context" {
+  local stale="$BATS_TEST_TMPDIR/stale-repo"
+  mkdir -p "$stale/notes"
+  cat > "$stale/notes/stale.md" <<'EOF'
 ---
-title: Legacy Repo
+title: Stale Repo
 tags: []
 ---
 EOF
 
   unset NOTES_CALLER_PWD
-  run bash -c 'cd "$REPO_DIR" && CALLER_PWD="$1" mise run -q list --json' _ "$legacy"
+  run bash -c 'cd "$REPO_DIR" && CALLER_PWD="$1" mise run -q list --json' _ "$stale"
 
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"Legacy Repo"* ]]
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"notes directory not found"* ]]
+  [[ "$output" != *"Stale Repo"* ]]
 }
 
 # ── Confirmation helpers ─────────────────────────────────────

--- a/test/list.bats
+++ b/test/list.bats
@@ -110,6 +110,57 @@ EOF
   echo "$output" | python3 -c "import sys, json; data = json.load(sys.stdin); assert len(data) == 1; assert data[0]['title'] == 'Block Tag Note'"
 }
 
+@test "list --type filters by frontmatter type" {
+  cat > "$NOTES_CALLER_PWD/notes/skill.md" <<'EOF'
+---
+title: Skill Note
+type: skill
+status: candidate
+tags: [skill, testing]
+created: 2026-01-01
+updated: 2026-01-03
+---
+
+# Skill Note
+EOF
+  notes new --slug pattern --title "Pattern Note" --tags "testing" --updated "2026-01-04"
+
+  run notes list --json --type skill
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import sys, json; data = json.load(sys.stdin); assert len(data) == 1; assert data[0]['title'] == 'Skill Note'; assert data[0]['type'] == 'skill'"
+}
+
+@test "list --status filters by frontmatter status" {
+  cat > "$NOTES_CALLER_PWD/notes/candidate.md" <<'EOF'
+---
+title: Candidate Note
+type: skill
+status: candidate
+tags: [skill]
+created: 2026-01-01
+updated: 2026-01-03
+---
+
+# Candidate Note
+EOF
+  cat > "$NOTES_CALLER_PWD/notes/accepted.md" <<'EOF'
+---
+title: Accepted Note
+type: skill
+status: accepted
+tags: [skill]
+created: 2026-01-01
+updated: 2026-01-04
+---
+
+# Accepted Note
+EOF
+
+  run notes list --json --status candidate
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import sys, json; data = json.load(sys.stdin); assert len(data) == 1; assert data[0]['title'] == 'Candidate Note'; assert data[0]['status'] == 'candidate'"
+}
+
 @test "list empty directory shows no notes" {
   run notes list
   [ "$status" -eq 0 ]

--- a/test/search.bats
+++ b/test/search.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  export NOTES_CALLER_PWD="$BATS_TEST_TMPDIR"
+  mkdir -p "$NOTES_CALLER_PWD/notes"
+}
+
+@test "search finds matching body text" {
+  notes new --slug alpha --title "Alpha Note" --tags "testing" --body "Dispatch the follow-up packet."
+  notes new --slug beta --title "Beta Note" --tags "testing" --body "Nothing relevant here."
+
+  run notes search dispatch --json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import sys, json; data = json.load(sys.stdin); assert len(data) == 1; assert data[0]['title'] == 'Alpha Note'; assert data[0]['matches'][0].startswith('body:')"
+}
+
+@test "search finds matching frontmatter" {
+  cat > "$NOTES_CALLER_PWD/notes/skill.md" <<'EOF'
+---
+title: Parallel Follow-up
+type: skill
+status: candidate
+tags: [skill, workflow]
+created: 2026-01-01
+updated: 2026-01-02
+---
+
+# Parallel Follow-up
+EOF
+
+  run notes search candidate --json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import sys, json; data = json.load(sys.stdin); assert len(data) == 1; assert data[0]['status'] == 'candidate'; assert any(m.startswith('status:') for m in data[0]['matches'])"
+}
+
+@test "search --type filters results" {
+  cat > "$NOTES_CALLER_PWD/notes/skill.md" <<'EOF'
+---
+title: Skill Note
+type: skill
+status: candidate
+tags: [skill]
+created: 2026-01-01
+updated: 2026-01-03
+---
+
+# Skill Note
+Reusable workflow instructions.
+EOF
+  cat > "$NOTES_CALLER_PWD/notes/pattern.md" <<'EOF'
+---
+title: Pattern Note
+type: pattern
+status: candidate
+tags: [pattern]
+created: 2026-01-01
+updated: 2026-01-04
+---
+
+# Pattern Note
+Reusable workflow instructions.
+EOF
+
+  run notes search workflow --json --type skill
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import sys, json; data = json.load(sys.stdin); assert len(data) == 1; assert data[0]['title'] == 'Skill Note'"
+}
+
+@test "search --limit bounds output" {
+  notes new --slug one --title "One" --tags "testing" --updated "2026-01-01" --body "same needle"
+  notes new --slug two --title "Two" --tags "testing" --updated "2026-01-02" --body "same needle"
+
+  run notes search needle --json --limit 1
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import sys, json; data = json.load(sys.stdin); assert len(data) == 1; assert data[0]['title'] == 'Two'"
+}
+
+@test "search empty match reports no notes" {
+  notes new --slug alpha --title "Alpha Note" --tags "testing" --body "Useful body text"
+
+  run notes search absent
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No notes found matching: absent"* ]]
+}

--- a/test/show.bats
+++ b/test/show.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  export NOTES_CALLER_PWD="$BATS_TEST_TMPDIR"
+  mkdir -p "$NOTES_CALLER_PWD/notes"
+}
+
+@test "show prints a note by slug" {
+  notes new --slug alpha --title "Alpha Note" --tags "testing" --body "Useful body text"
+
+  run notes show alpha
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"title: Alpha Note"* ]]
+  [[ "$output" == *"Useful body text"* ]]
+}
+
+@test "show accepts an explicit note path" {
+  notes new --slug alpha --title "Alpha Note" --tags "testing" --body "Useful body text"
+
+  run notes show notes/alpha.md
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"# Alpha Note"* ]]
+}
+
+@test "show --json includes metadata and body" {
+  notes new --slug beta --title "Beta Note" --tags "guide, testing" --body "JSON body text"
+
+  run notes show beta --json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import sys, json; data = json.load(sys.stdin); assert data['title'] == 'Beta Note'; assert data['metadata']['tags'] == ['guide', 'testing']; assert 'JSON body text' in data['body']"
+}
+
+@test "show resolves exact title" {
+  notes new --slug beta --title "Beta Note" --tags "guide" --body "Title lookup"
+
+  run notes show "Beta Note"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Title lookup"* ]]
+}
+
+@test "show reports missing notes" {
+  run notes show missing
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"note not found: missing"* ]]
+}


### PR DESCRIPTION
## Summary

- add shared stdlib frontmatter helpers plus `notes search` and `notes show`
- extend `notes list` with `--type` / `--status` filters for skill-note discovery
- apply repo-wide mise/bash hygiene: `set -euo pipefail`, explicit optional `#USAGE` defaults, canonical variadic syntax, package-scoped caller cwd only, and a more flexible `test` task

## Validation

- `bash -n .mise/tasks/* lib/*.sh hooks/*`
- `python3 -m py_compile lib/frontmatter.py`
- `git diff --check`
- `env -u MISE_CONFIG_ROOT mise run test list --filter 'list --json'`
- `env -u MISE_CONFIG_ROOT mise run test common list search show new changes obfuscate`
- `env -u MISE_CONFIG_ROOT mise run test` (277/277)
- fold smoke via local task checkout:
  - `NOTES_CALLER_PWD=.../modules/fold mise run -q list --json --type skill`
  - `NOTES_CALLER_PWD=.../modules/fold mise run -q search orchestration --json --type skill`
  - `NOTES_CALLER_PWD=.../modules/fold mise run -q show parallel-follow-up-orchestration`

## Notes

This is the notes-layer primitive needed before adding fold `skills:list/search/show` wrappers. The fold wrappers can stay thin over `notes list/search/show` rather than reimplementing frontmatter scanning.
