### PR TITLE
fix(unlock): no-op cleanly when repo is already unlocked (#42)

### DIFF
--- a/.mise/tasks/unlock
+++ b/.mise/tasks/unlock
@@ -9,12 +9,20 @@ require_initialized
 require_rudi
 
 cd "$TARGET_DIR"
-rudi unlock
 
-# Known limitation: rudi unlock decrypts ALL git-crypt-encrypted files,
-# not just notes. This also decrypts the modules manifest and anything
-# else using git-crypt in this repo. Tracked in KnickKnackLabs/rudi#5.
-echo "Note: unlock decrypts all encrypted files in this repo (rudi#5)."
+# Idempotency (issue #42): only run the git-crypt unlock mutation if the repo is
+# locked. `rudi/git-crypt unlock` refuses on a "dirty" worktree, but an already-
+# unlocked, deobfuscated repo legitimately shows obfuscation noise (D <id> /
+# ?? <name>) and may carry local edits. Re-running unlock there must be a no-op.
+if encryption_unlocked; then
+  echo "Already unlocked."
+else
+  rudi unlock
+  # Known limitation: rudi unlock decrypts ALL git-crypt-encrypted files, not just
+  # notes — also the modules manifest and anything else using git-crypt here.
+  # Tracked in KnickKnackLabs/rudi#5.
+  echo "Note: unlock decrypts all encrypted files in this repo (rudi#5)."
+fi
 
 # Deobfuscate filenames if a manifest exists
 if [ -f "$TARGET_DIR/notes/.manifest" ]; then

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -36,6 +36,16 @@ is_initialized() {
   [ -d "$TARGET_DIR/.git-crypt" ] || [ -d "$TARGET_DIR/.git/git-crypt" ]
 }
 
+# Returns 0 if git-crypt is unlocked in TARGET_DIR (per rudi), 1 otherwise.
+# Callers should run require_rudi first and cd into the repo (matches `status`).
+# Defaults to "not unlocked" on any rudi/jq failure so the caller falls through
+# to a real `rudi unlock`, which surfaces the underlying error.
+encryption_unlocked() {
+  local unlocked
+  unlocked=$(rudi status --json 2>/dev/null | jq -r '.unlocked' 2>/dev/null) || return 1
+  [ "$unlocked" = "true" ]
+}
+
 require_initialized() {
   if ! is_initialized; then
     echo "Error: git-crypt not initialized. Run: notes setup" >&2

--- a/test/encrypt.bats
+++ b/test/encrypt.bats
@@ -238,13 +238,14 @@ generate_test_key() {
 }
 
 @test "setup --unlock runs unlock after setup" {
-  # --unlock on a fresh repo (no GPG users) will fail at unlock
-  # because there's nothing to decrypt. But setup should complete
-  # and then attempt unlock.
+  # On a fresh repo the initializer already holds the git-crypt key, so the repo
+  # is already unlocked. setup --unlock should complete setup and then no-op the
+  # unlock cleanly (issue #42) instead of erroring on the dirty post-setup tree.
   run notes setup --yes --unlock
-  # Verify setup completed before unlock was attempted
+  # Verify setup completed and unlock was attempted
   echo "$output" | grep -q "Installed hooks"
   echo "$output" | grep -q "Unlocking"
-  # unlock fails on a repo with no GPG users — that's expected
-  [ "$status" -ne 0 ]
+  # Already-unlocked repo: unlock is an idempotent no-op, setup succeeds
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Already unlocked."
 }

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -83,6 +83,35 @@ generate_test_key() {
   grep -q "secret content" "$TARGET_DIR/notes/secret.md"
 }
 
+@test "unlock no-ops when already unlocked, even with a dirty tree (#42)" {
+  notes setup --yes
+
+  local fpr
+  fpr=$(generate_test_key "$GNUPGHOME")
+  notes add-user -- --gpg-key "$fpr"
+
+  # Commit a readable, tracked note (--no-verify so the pre-commit hook doesn't
+  # auto-obfuscate/suppress it), then make an uncommitted local edit. This is the
+  # brownie scenario: an already-unlocked repo whose working tree is dirty —
+  # exactly the state git-crypt/rudi unlock refuses on ("Working directory not clean").
+  mkdir -p "$TARGET_DIR/notes"
+  echo "original" > "$TARGET_DIR/notes/secret.md"
+  git -C "$TARGET_DIR" add notes/secret.md
+  git -C "$TARGET_DIR" commit -q --no-verify -m "Add readable note"
+  echo "local edit" >> "$TARGET_DIR/notes/secret.md"
+
+  # Sanity: repo is unlocked and the tree is dirty
+  [ -n "$(git -C "$TARGET_DIR" status --porcelain)" ]
+
+  # unlock must no-op cleanly instead of failing on the dirty-tree guard
+  run notes unlock
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Already unlocked."* ]]
+
+  # The local edit is preserved — unlock did not stash, revert, or re-decrypt
+  grep -q "local edit" "$TARGET_DIR/notes/secret.md"
+}
+
 @test "lock refuses without confirmation before staging or obfuscating" {
   notes setup --yes
 


### PR DESCRIPTION
## Problem

`notes unlock` is not idempotent. On a repo that is already unlocked, `rudi unlock` (→ `git-crypt unlock`) refuses on a "dirty" worktree:

```
Error: Working directory not clean.
Please commit your changes or 'git stash' them before running 'git-crypt unlock'.
```

This bites "unlock if needed" startup flows — e.g. home `agent:prepare` hooks that call `notes unlock` unconditionally — even though the repo is in a normal, usable state (obfuscation noise from a prior deobfuscate, and/or ordinary local edits). Closes #42 (dup #100). Repro'd by the original reporter and @brownie-ricon.

## Fix

Gate the unlock mutation on encryption state, following the ordering agreed in the thread:

1. **detect already-unlocked first** — new reusable `encryption_unlocked()` helper in `lib/common.sh`, mirroring the `rudi status --json | jq .unlocked` check already used inline by the `status` task;
2. **if already unlocked → no-op** — print `Already unlocked.`, skip `rudi unlock`, and fall through to the existing (already idempotent) deobfuscate step. Safe even with local edits: `deobfuscate` returns "nothing to do" (exit 0) when filenames are already restored;
3. **otherwise** — run `rudi unlock` exactly as before, preserving git-crypt's own clean-worktree guard for the real locked→unlocked mutation.

The "joining collaborator" case (`setup --unlock` against a locked repo, `.unlocked=false`) is unaffected — `rudi unlock` still runs and decrypts with the user's GPG key.

## Reproduction log

**Before** (deterministic repro): unlocked repo + dirty tracked note →

```
$ git status --porcelain
 M notes/secret.md
$ rudi status --json | jq -r .unlocked
true
$ git-crypt unlock
Error: Working directory not clean. ...   # exit 1
```

**After**: same state → `notes unlock` prints `Already unlocked.`, exits 0, local edit preserved.

## Tests

- **`test/integration.bats`** — new regression test `unlock no-ops when already unlocked, even with a dirty tree (#42)`. Verified red→green: without the fix it fails on the non-zero exit (the git-crypt dirty-tree error); with it, exit 0 and the local edit survives.
- **`test/encrypt.bats`** — updated `setup --unlock runs unlock after setup`, which previously asserted the **buggy** behaviour (unlock erroring on an already-unlocked fresh repo, where the initializer already holds the git-crypt key). It now expects the clean no-op.

Full suite locally: **278 passing, 6 skipped**. The only failures are pre-existing/environmental — `new.bats`/`obfuscate.bats` tests that require the `farts` frontmatter binary (not installed here; exit 127). Those files are untouched by this PR.

## Out of scope

- Not refactoring `status` to call the new helper (its 3-state `not_initialized`/`locked`/`unlocked` logic is richer than the boolean); deferred to keep the diff tight.
- Not changing git-crypt's clean-worktree guard — it still correctly protects the real unlock mutation.