### PR TITLE
fix(hooks): resolve manifest merge driver via PATH shim, not stale absolute path (#50)

### DIFF
--- a/.mise/tasks/merge-driver
+++ b/.mise/tasks/merge-driver
@@ -6,25 +6,12 @@
 #USAGE arg "<other>" help="Other branch file (%B)"
 set -euo pipefail
 
-# Invoked by git's merge machinery via the `manifest` driver config.
-# Resolves at merge-time via PATH → shiv shim → current installed notes version,
-# so upgrading notes does not leave a stale absolute path in .git/config (which
-# would silently fall back to the default merge strategy and corrupt the
-# encrypted manifest — exactly the failure notes#48's driver exists to prevent).
+# Git passes %O/%A/%B relative to the merge worktree. The shiv shim runs this
+# task from the installed notes package, so return to the caller's worktree
+# before handing those relative paths to the real driver.
 #
-# Path handling: git passes %O %A %B as paths relative to the worktree where the
-# merge happens (e.g., `.merge_file_AbCdEf`). The shiv shim cd's into the notes
-# package dir before exec'ing mise, so by the time we run those relative paths
-# point nowhere. Cd back into `$NOTES_CALLER_PWD` (which the shim exported as the
-# user's original cwd) so the paths resolve. The lib script is invoked via
-# $MISE_CONFIG_ROOT which is absolute and unaffected.
-#
-# Refuse rather than guess: if caller context is missing, falling back to $PWD
-# would silently re-introduce the very bug the cd guards against (in production
-# $PWD = the notes pkg dir the shim cd'd into, which is exactly the broken
-# state). Better to fail the merge loudly than to corrupt the manifest. To invoke
-# this task manually outside the shim, set NOTES_CALLER_PWD explicitly:
-# `NOTES_CALLER_PWD=$PWD mise run merge-driver ...`.
+# Missing caller context is unsafe: using the package directory would make the
+# merge inputs point nowhere. Fail loudly rather than risk corrupting .manifest.
 CALLER_DIR="${NOTES_CALLER_PWD:-${CALLER_PWD:-}}"
 if [ -z "$CALLER_DIR" ]; then
   echo "notes merge-driver: NOTES_CALLER_PWD is not set." >&2

--- a/.mise/tasks/merge-driver
+++ b/.mise/tasks/merge-driver
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#MISE description="Custom git merge driver for notes .manifest (invoked by git, not users)"
+#MISE hide=true
+#USAGE arg "<ancestor>" help="Common ancestor file (%O)"
+#USAGE arg "<current>" help="Current branch file (%A) — written in place"
+#USAGE arg "<other>" help="Other branch file (%B)"
+set -euo pipefail
+
+# Invoked by git's merge machinery via the `manifest` driver config.
+# Resolves at merge-time via PATH → shiv shim → current installed notes version,
+# so upgrading notes does not leave a stale absolute path in .git/config (which
+# would silently fall back to the default merge strategy and corrupt the
+# encrypted manifest — exactly the failure notes#48's driver exists to prevent).
+#
+# Path handling: git passes %O %A %B as paths relative to the worktree where the
+# merge happens (e.g., `.merge_file_AbCdEf`). The shiv shim cd's into the notes
+# package dir before exec'ing mise, so by the time we run those relative paths
+# point nowhere. Cd back into `$NOTES_CALLER_PWD` (which the shim exported as the
+# user's original cwd) so the paths resolve. The lib script is invoked via
+# $MISE_CONFIG_ROOT which is absolute and unaffected.
+#
+# Refuse rather than guess: if caller context is missing, falling back to $PWD
+# would silently re-introduce the very bug the cd guards against (in production
+# $PWD = the notes pkg dir the shim cd'd into, which is exactly the broken
+# state). Better to fail the merge loudly than to corrupt the manifest. To invoke
+# this task manually outside the shim, set NOTES_CALLER_PWD explicitly:
+# `NOTES_CALLER_PWD=$PWD mise run merge-driver ...`.
+CALLER_DIR="${NOTES_CALLER_PWD:-${CALLER_PWD:-}}"
+if [ -z "$CALLER_DIR" ]; then
+  echo "notes merge-driver: NOTES_CALLER_PWD is not set." >&2
+  echo "  This task must be invoked via the notes shim (which exports NOTES_CALLER_PWD)." >&2
+  echo "  Aborting to avoid producing a corrupt manifest from unresolved relative paths." >&2
+  exit 1
+fi
+cd "$CALLER_DIR"
+exec bash "$MISE_CONFIG_ROOT/lib/manifest-merge-driver.sh" \
+  "${usage_ancestor}" "${usage_current}" "${usage_other}"

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -64,14 +64,8 @@ install_manifest_merge_driver() {
   local notes_dir="${1:-notes}"
   local gitattributes="$TARGET_DIR/.gitattributes"
 
-  # Register the merge driver in repo-local git config.
-  #
-  # Resolve the driver at merge time via the `notes` shim on PATH, not by writing
-  # an absolute path. An absolute path pins the driver to the notes version
-  # installed at setup time; on upgrade (shiv installs each version to a new
-  # directory) that path goes stale, git silently falls back to the default
-  # recursive merge, and the encrypted manifest gets corrupted on any concurrent
-  # edit — exactly the failure mode this driver exists to prevent (notes#48/#50).
+  # Resolve the driver through the stable notes shim instead of pinning setup to
+  # one installed package path. The task wrapper handles git's relative paths.
   git -C "$TARGET_DIR" config merge.manifest.name "Union merge driver for notes manifest"
   git -C "$TARGET_DIR" config merge.manifest.driver "notes merge-driver %O %A %B"
 

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -62,12 +62,18 @@ install_obfuscation_hook() {
 # Configures git to use our custom merge driver for .manifest files.
 install_manifest_merge_driver() {
   local notes_dir="${1:-notes}"
-  local driver_path="$HOOKS_REPO_DIR/lib/manifest-merge-driver.sh"
   local gitattributes="$TARGET_DIR/.gitattributes"
 
-  # Register the merge driver in git config
+  # Register the merge driver in repo-local git config.
+  #
+  # Resolve the driver at merge time via the `notes` shim on PATH, not by writing
+  # an absolute path. An absolute path pins the driver to the notes version
+  # installed at setup time; on upgrade (shiv installs each version to a new
+  # directory) that path goes stale, git silently falls back to the default
+  # recursive merge, and the encrypted manifest gets corrupted on any concurrent
+  # edit — exactly the failure mode this driver exists to prevent (notes#48/#50).
   git -C "$TARGET_DIR" config merge.manifest.name "Union merge driver for notes manifest"
-  git -C "$TARGET_DIR" config merge.manifest.driver "bash \"$driver_path\" %O %A %B"
+  git -C "$TARGET_DIR" config merge.manifest.driver "notes merge-driver %O %A %B"
 
   # Add .gitattributes entry if not already present
   local pattern="$notes_dir/.manifest merge=manifest"

--- a/test/git-operations.bats
+++ b/test/git-operations.bats
@@ -13,10 +13,9 @@ assert_gitcrypt_blob() {
   [ "$header" = "GITCRYPT" ] || fail "expected encrypted blob at $ref_path"
 }
 
-# Point the manifest merge driver at the in-tree script. install-hooks writes
-# 'notes merge-driver %O %A %B' (resolves via the shim on PATH at merge time —
-# notes#50), but the test harness has no installed shim git can drive mid-merge,
-# so rewrite to the local driver to exercise the in-tree merge logic.
+# The installed config resolves via the notes shim. The test harness uses the
+# in-tree script so git can exercise the same merge logic without an installed
+# package shim.
 _use_local_merge_driver() {
   git -C "$1" config merge.manifest.driver \
     "bash $REPO_DIR/lib/manifest-merge-driver.sh %O %A %B"

--- a/test/git-operations.bats
+++ b/test/git-operations.bats
@@ -13,6 +13,15 @@ assert_gitcrypt_blob() {
   [ "$header" = "GITCRYPT" ] || fail "expected encrypted blob at $ref_path"
 }
 
+# Point the manifest merge driver at the in-tree script. install-hooks writes
+# 'notes merge-driver %O %A %B' (resolves via the shim on PATH at merge time —
+# notes#50), but the test harness has no installed shim git can drive mid-merge,
+# so rewrite to the local driver to exercise the in-tree merge logic.
+_use_local_merge_driver() {
+  git -C "$1" config merge.manifest.driver \
+    "bash $REPO_DIR/lib/manifest-merge-driver.sh %O %A %B"
+}
+
 # Override default setup — we need a remote + local pair, not a single repo.
 setup() {
   source "$REPO_DIR/lib/common.sh"
@@ -54,6 +63,7 @@ setup() {
   export NOTES_CALLER_PWD="$LOCAL"
   notes deobfuscate
   notes install-hooks
+  _use_local_merge_driver "$LOCAL"
 }
 
 # ── Pull ──────────────────────────────────────────────────────
@@ -364,6 +374,7 @@ EOT
   git -C "$repo" commit -q -m "init"
 
   NOTES_CALLER_PWD="$repo" notes install-hooks >/dev/null
+  _use_local_merge_driver "$repo"
 
   git -C "$repo" switch -q -c feature
   cat > "$repo/notes/.manifest" <<'EOT'

--- a/test/merge-driver.bats
+++ b/test/merge-driver.bats
@@ -595,3 +595,17 @@ EOT
   grep -qF "b	y" "$OURS" || fail "missing b"
   grep -qF "c	z" "$OURS" || fail "missing c"
 }
+
+# ── Config stability across upgrades (notes#50) ──────────────
+
+@test "install_manifest_merge_driver: config resolves via PATH shim, no absolute path" {
+  source "$REPO_DIR/lib/hooks.sh"
+  install_manifest_merge_driver
+
+  # Resolves via the `notes` shim on PATH at merge time — an absolute path would
+  # go stale when shiv installs a new version, silently disabling the driver.
+  run git -C "$TARGET_DIR" config --get merge.manifest.driver
+  [ "$status" -eq 0 ]
+  [ "$output" = "notes merge-driver %O %A %B" ]
+  ! printf '%s' "$output" | grep -q "/"
+}


### PR DESCRIPTION
Closes #50.

## Problem

`install_manifest_merge_driver` (`lib/hooks.sh`) writes an **absolute, version-pinned** path into `.git/config`:

```
merge.manifest.driver = bash "/…/shiv/packages/notes/lib/manifest-merge-driver.sh" %O %A %B
```

When shiv installs a new `notes` version (each release → its own directory), that path no longer exists. Git silently falls back to the default recursive merge, which corrupts the encrypted `.manifest` on any concurrent edit — exactly the failure mode (notes#48) the merge driver exists to prevent. Found in peer review on modules#17, which adapted its driver pattern from notes; the same absolute-path install still lives here.

## Fix

Port modules' fix (the same shape it landed for `.modules/manifest`):

1. **New hidden `notes merge-driver` mise task** (`.mise/tasks/merge-driver`) taking `%O %A %B`. It cd's back into `$NOTES_CALLER_PWD` (git passes paths relative to the merge worktree; the shim cd's into the package dir) and execs `$MISE_CONFIG_ROOT/lib/manifest-merge-driver.sh`. Refuses if caller context is missing — fail the merge loudly rather than corrupt the manifest.
2. **Config now uses the PATH shim:** `merge.manifest.driver = notes merge-driver %O %A %B`. The `notes` shim is at a stable mise-shims location and resolves to the current installed version at merge time, so upgrades stay valid with no config rewrite.

Driver name `manifest` and the `.gitattributes` `merge=manifest` pattern are unchanged. Re-running `notes install-hooks` / `notes setup` overwrites a stale absolute config, so existing clones self-heal on next setup.

## Before / after

```
# before — pinned to the install-time version dir, breaks on upgrade
$ git config --get merge.manifest.driver
bash "/…/packages/notes/lib/manifest-merge-driver.sh" %O %A %B

# after — resolves via the notes shim on PATH at merge time
$ git config --get merge.manifest.driver
notes merge-driver %O %A %B
```

## Tests

- **`test/merge-driver.bats`** — new guard: after `install_manifest_merge_driver`, assert the config equals `notes merge-driver %O %A %B` and contains no `/` (future-proofs against reintroducing an absolute path).
- **`test/git-operations.bats`** — added a `_use_local_merge_driver` helper that repoints the config at the in-tree driver script for the 3 through-git merge/rebase tests (the harness has no installed shim git can drive mid-merge — same accommodation modules' test suite uses). Driver-behavior tests in `merge-driver.bats` already invoke the script directly and were unaffected.

Local: `mise run test` → **278 ok / 4 fail**. The 4 failures are the pre-existing `farts: command not found` (exit 127) environmental failures in `new.bats` — identical on `main` (277 ok / 4 fail), unrelated to this change. Net: +1 passing guard test, the 3 driver tests restored. Task + driver are bash 3.2-safe.

## Open questions

- Kept the driver name `manifest` (avoids `.gitattributes` churn) rather than renaming to `notes-manifest` for symmetry with modules. Preference?
- Migration: existing clones keep the stale absolute config until they re-run `notes install-hooks` / `notes setup` once (same as modules' migration). Acceptable, or should a one-time auto-rewrite live elsewhere?

