### PR TITLE
Add note component parser

### DIFF
--- a/.mise/tasks/parse
+++ b/.mise/tasks/parse
@@ -1,0 +1,69 @@
+#!/usr/bin/env -S uv run --script
+#MISE description="Parse a note into convention-aware components as JSON"
+#USAGE arg "<note>" help="Note path or slug" required=#true
+#USAGE flag "--dir <dir>" help="Notes directory relative to repo root" default="notes"
+# /// script
+# dependencies = []
+# ///
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+repo_dir = Path(os.environ["MISE_CONFIG_ROOT"])
+target_dir = Path(os.environ.get("NOTES_CALLER_PWD", "."))
+notes_dir = target_dir / os.environ.get("usage_dir", "notes")
+selector = os.environ.get("usage_note", "")
+
+sys.path.insert(0, str(repo_dir / "lib"))
+# note_components is a repo-local import loaded from MISE_CONFIG_ROOT/lib, not
+# a uv dependency.
+from note_components import read_note_components  # noqa: E402
+
+
+def existing_path_candidates(selector: str) -> list[Path]:
+    raw = Path(selector).expanduser()
+    candidates: list[Path] = []
+    if raw.is_absolute():
+        candidates.append(raw)
+    else:
+        candidates.extend([target_dir / raw, notes_dir / raw])
+        if raw.suffix != ".md":
+            candidates.extend([target_dir / f"{selector}.md", notes_dir / f"{selector}.md"])
+
+    seen: set[str] = set()
+    unique: list[Path] = []
+    for candidate in candidates:
+        resolved = candidate.resolve() if candidate.exists() else candidate
+        key = str(resolved)
+        if key not in seen:
+            unique.append(candidate)
+            seen.add(key)
+    return unique
+
+
+def main() -> int:
+    note_path = None
+    for candidate in existing_path_candidates(selector):
+        if candidate.is_file():
+            note_path = candidate
+            break
+
+    if note_path is None:
+        print(f"Error: note not found: {selector}", file=sys.stderr)
+        return 1
+
+    try:
+        parsed = read_note_components(note_path)
+    except UnicodeDecodeError:
+        print(f"Error: note is not valid UTF-8: {note_path}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(parsed.to_json(), indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ notes list
 notes search "workflow"
 notes show project-plan
 
+# Parse convention-aware components without changing raw Markdown reads.
+notes parse notes/project-plan.md
+
 # Check encryption + obfuscation state.
 notes status
 
@@ -45,6 +48,7 @@ notes changes --summary
 notes list --type skill
 notes search "review capacity" --tag workflow
 notes show project-plan --json
+notes parse notes/project-plan.md
 
 # Show readable diffs for local changes, refs, or PRs.
 notes diff
@@ -77,6 +81,7 @@ notes unlock
 - **Safe staging** — stages notes despite local exclude/assume-unchanged rules used for readable working copies.
 - **Readable review diffs** — materializes obfuscated note refs/PRs as readable Markdown and emits a normal patch.
 - **Readable conflict artifacts** — detects unmerged encrypted/obfuscated note content and writes base/ours/theirs Markdown files for manual resolution.
+- **Convention-aware parsing** — `notes parse <file>` returns JSON components for frontmatter and body without changing raw Markdown compatibility.
 
 ## Important gotchas
 
@@ -84,6 +89,7 @@ notes unlock
 - Use `notes stage` for notes, not raw `git add notes/`; readable note names are intentionally excluded locally.
 - After pulling shared note repos, inspect `notes status` and `notes changes --summary` before committing follow-up changes.
 - `notes unlock` / `notes deobfuscate` reconcile stale readable files left by upstream note deletion or rename. Clean generated stale files are removed; dirty or unproven stale files are moved to `.git/info/notes-stale-readable/` so they cannot be accidentally staged as new notes.
+- `notes parse` is a parser/query foundation for existing Markdown/frontmatter conventions. Raw Markdown reads remain valid; future conventions should settle separately before they become parser output.
 
 ## Development
 

--- a/lib/frontmatter.py
+++ b/lib/frontmatter.py
@@ -72,16 +72,16 @@ def parse_list(value: str) -> list[str]:
     return [parse_scalar(value)]
 
 
-def parse_frontmatter_text(text: str) -> tuple[dict[str, Any] | None, str]:
-    if not text.startswith("---\n"):
-        return None, text
-    end = text.find("\n---", 4)
-    if end == -1:
-        return None, text
+def parse_mapping_text(text: str, *, list_keys: set[str] = LIST_KEYS) -> dict[str, Any]:
+    """Parse the small YAML-ish mapping subset notes uses.
 
+    The parser is deliberately modest. It accepts scalar `key: value` pairs,
+    inline lists for configured list keys, and indented block-list items for
+    those same keys. It is not a general YAML parser.
+    """
     data: dict[str, Any] = {}
     current_list_key: str | None = None
-    for line in text[4:end].splitlines():
+    for line in text.splitlines():
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
             continue
@@ -98,12 +98,23 @@ def parse_frontmatter_text(text: str) -> tuple[dict[str, Any] | None, str]:
         key, value = line.split(":", 1)
         key = key.strip()
         value = value.strip()
-        if key in LIST_KEYS:
+        if key in list_keys:
             data[key] = parse_list(value)
             if not value:
                 current_list_key = key
         else:
             data[key] = parse_scalar(value)
+    return data
+
+
+def parse_frontmatter_text(text: str) -> tuple[dict[str, Any] | None, str]:
+    if not text.startswith("---\n"):
+        return None, text
+    end = text.find("\n---", 4)
+    if end == -1:
+        return None, text
+
+    data = parse_mapping_text(text[4:end])
 
     body_start = end + len("\n---")
     if body_start < len(text) and text[body_start] == "\n":
@@ -118,6 +129,7 @@ def read_frontmatter(path: Path) -> tuple[dict[str, Any] | None, str | None]:
         return None, None
     metadata, body = parse_frontmatter_text(text)
     return metadata, body
+
 
 
 @dataclass(frozen=True)

--- a/lib/note_components.py
+++ b/lib/note_components.py
@@ -1,0 +1,54 @@
+"""Convention-aware Markdown note component parser.
+
+This first parser surface only separates existing YAML frontmatter from the
+visible Markdown body. Future conventions can build here after their syntax and
+semantics are settled.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from frontmatter import parse_frontmatter_text
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    code: str
+    message: str
+    line: int | None = None
+
+    def to_json(self) -> dict[str, Any]:
+        row: dict[str, Any] = {"code": self.code, "message": self.message}
+        if self.line is not None:
+            row["line"] = self.line
+        return row
+
+
+@dataclass(frozen=True)
+class ParsedNote:
+    path: Path | None
+    frontmatter: dict[str, Any] | None
+    body: str
+    diagnostics: list[Diagnostic]
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path) if self.path is not None else "",
+            "frontmatter": self.frontmatter or {},
+            "frontmatter_present": self.frontmatter is not None,
+            "body": self.body,
+            "diagnostics": [diagnostic.to_json() for diagnostic in self.diagnostics],
+        }
+
+
+def parse_note_text(text: str, *, path: Path | None = None) -> ParsedNote:
+    frontmatter, body = parse_frontmatter_text(text)
+    return ParsedNote(path=path, frontmatter=frontmatter, body=body, diagnostics=[])
+
+
+def read_note_components(path: Path) -> ParsedNote:
+    text = path.read_text(encoding="utf-8")
+    return parse_note_text(text, path=path)

--- a/mise.toml
+++ b/mise.toml
@@ -9,6 +9,7 @@ shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 [tools]
 bats = "1.13.0"
 gum = "0.17.0"
+uv = "0.11.19"
 "aqua:shenwei356/rush" = "0.9.0"
 "shiv:rudi" = "0.5"
 # git-crypt has no macOS binary on GitHub releases.

--- a/test/parse.bats
+++ b/test/parse.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  export NOTES_CALLER_PWD="$BATS_TEST_TMPDIR"
+  mkdir -p "$NOTES_CALLER_PWD/notes"
+}
+
+save_parse_output() {
+  parse_json="$BATS_TEST_TMPDIR/parse-output.json"
+  printf '%s\n' "$output" > "$parse_json"
+}
+
+@test "parse outputs frontmatter/body components for a plain Markdown note" {
+  cat > "$NOTES_CALLER_PWD/notes/plain.md" <<'EOF'
+# Plain Note
+
+Visible body.
+EOF
+
+  run notes parse notes/plain.md
+  [ "$status" -eq 0 ]
+
+  save_parse_output
+  JSON_PATH="$parse_json" python3 <<'PY'
+import json
+import os
+from pathlib import Path
+
+with Path(os.environ["JSON_PATH"]).open(encoding="utf-8") as handle:
+    data = json.load(handle)
+
+assert data["frontmatter"] == {}
+assert data["frontmatter_present"] is False
+assert data["body"] == "# Plain Note\n\nVisible body.\n"
+assert data["diagnostics"] == []
+assert set(data) == {"path", "frontmatter", "frontmatter_present", "body", "diagnostics"}
+PY
+}
+
+@test "parse splits frontmatter from the visible body" {
+  cat > "$NOTES_CALLER_PWD/notes/frontmatter.md" <<'EOF'
+---
+title: Frontmatter Note
+tags:
+  - testing
+  - parser
+---
+# Frontmatter Note
+
+Visible body.
+EOF
+
+  run notes parse frontmatter
+  [ "$status" -eq 0 ]
+
+  save_parse_output
+  JSON_PATH="$parse_json" python3 <<'PY'
+import json
+import os
+from pathlib import Path
+
+with Path(os.environ["JSON_PATH"]).open(encoding="utf-8") as handle:
+    data = json.load(handle)
+
+assert data["frontmatter_present"] is True
+assert data["frontmatter"]["title"] == "Frontmatter Note"
+assert data["frontmatter"]["tags"] == ["testing", "parser"]
+assert data["body"].startswith("# Frontmatter Note")
+assert data["diagnostics"] == []
+PY
+}
+
+@test "parse preserves HTML comments as ordinary body text" {
+  cat > "$NOTES_CALLER_PWD/notes/comments.md" <<'EOF'
+---
+title: Comment Note
+---
+# Comment Note
+
+Visible body.
+
+<!-- Any future comment-based convention stays in the body for this PR. -->
+EOF
+
+  run notes parse comments
+  [ "$status" -eq 0 ]
+
+  save_parse_output
+  JSON_PATH="$parse_json" python3 <<'PY'
+import json
+import os
+from pathlib import Path
+
+with Path(os.environ["JSON_PATH"]).open(encoding="utf-8") as handle:
+    data = json.load(handle)
+
+assert "future comment-based convention" in data["body"]
+assert data["diagnostics"] == []
+assert set(data) == {"path", "frontmatter", "frontmatter_present", "body", "diagnostics"}
+PY
+}
+
+@test "parse treats malformed frontmatter delimiters as body text" {
+  cat > "$NOTES_CALLER_PWD/notes/malformed.md" <<'EOF'
+---
+title: Missing End
+# This is all still body text.
+EOF
+
+  run notes parse malformed
+  [ "$status" -eq 0 ]
+
+  save_parse_output
+  JSON_PATH="$parse_json" python3 <<'PY'
+import json
+import os
+from pathlib import Path
+
+with Path(os.environ["JSON_PATH"]).open(encoding="utf-8") as handle:
+    data = json.load(handle)
+
+assert data["frontmatter_present"] is False
+assert data["frontmatter"] == {}
+assert data["body"].startswith("---\ntitle: Missing End")
+assert data["diagnostics"] == []
+PY
+}
+
+@test "parse reports missing notes" {
+  run notes parse missing
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"note not found: missing"* ]]
+}


### PR DESCRIPTION
## Summary

This is a conservative first slice for #126, following the Brownie/k7r2 and Junior/Or review guidance to avoid making `notes read` defaults social infrastructure before component semantics are boring.

- adds `notes parse <file>` as a JSON component parser instead of changing `notes show`/raw reads
- implements the parse task as a direct uv Python mise file task (`#!/usr/bin/env -S uv run --script`) with an explicit empty PEP 723 dependency block
- adds an explicit `uv = "0.11.19"` tool pin
- keeps existing YAML-ish frontmatter helpers in `lib/frontmatter.py`
- adds the new component parser surface in `lib/note_components.py`
- returns frontmatter/frontmatter_present/body/diagnostics JSON for existing Markdown/frontmatter conventions
- leaves future tail-block syntax/naming out of this PR

This deliberately does **not** add `notes read`, hidden-by-default read behavior, or tail-block parser output yet.

Refs #126.

## Validation

- `mise install`
- `git diff --check origin/main...HEAD`
- `python3 -m py_compile lib/*.py .mise/tasks/parse`
- `mise run test test/parse.bats` (5/5)
- `mise run test test/list.bats test/show.bats test/search.bats test/parse.bats` (28/28)
- `mise run test` (288/288, with existing expected skips)

## Review notes

Please focus first on whether this is the right Python task/component parser pattern for future notes task migrations: direct uv file task, repo-local imports through `MISE_CONFIG_ROOT/lib`, caller path resolution via `NOTES_CALLER_PWD` only, and component parsing separated from frontmatter helpers.
