### PR TITLE
Reject unknown explicit note paths

### DIFF
--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -62,6 +62,23 @@ scope_matches() {
 # Detect changes
 changes=$(detect_changes "$abs_notes_dir") || true
 
+if [ "$scope_all" != "true" ]; then
+  unknown=()
+  for f in ${ARGS[@]+"${ARGS[@]}"}; do
+    if [ -f "$abs_notes_dir/$f" ] || [ -n "$(manifest_id_for_name "$manifest" "$f")" ]; then
+      continue
+    fi
+    unknown+=("$f")
+  done
+  if [ ${#unknown[@]} -gt 0 ]; then
+    echo "Error: requested note path(s) are not known notes:" >&2
+    for f in ${unknown[@]+"${unknown[@]}"}; do
+      echo "  $f" >&2
+    done
+    exit 1
+  fi
+fi
+
 if [ -z "$changes" ]; then
   echo "No changes to stage."
   exit 0

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -350,6 +350,18 @@ rename_manifest_entry_in_head() {
   [[ "$output" == *"notes/gamma.md"* ]]
 }
 
+@test "notes stage: explicit unknown path fails instead of silently selecting nothing" {
+  echo "# Alpha modified" > "$NOTES_CALLER_PWD/notes/alpha.md"
+
+  run notes stage alhpa.md
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"requested note path"* ]]
+  [[ "$output" == *"alhpa.md"* ]]
+
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
+  [ -z "$output" ]
+}
+
 @test "notes stage --dry-run: deleted note leaves manifest and index untouched" {
   local manifest_before
   manifest_before=$(cat "$MANIFEST")
@@ -726,6 +738,22 @@ SH
   run notes commit -m "missing scope"
   [ "$status" -ne 0 ]
   [[ "$output" == *"provide note paths or --all"* ]]
+  [ "$(git -C "$NOTES_CALLER_PWD" rev-parse HEAD)" = "$before" ]
+
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
+  [ -z "$output" ]
+}
+
+@test "notes commit: explicit unknown path fails instead of silently committing nothing" {
+  notes install-hooks
+  local before
+  before=$(git -C "$NOTES_CALLER_PWD" rev-parse HEAD)
+  echo "# Alpha v2" > "$NOTES_CALLER_PWD/notes/alpha.md"
+
+  run notes commit -m "typo" alhpa.md
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"requested note path"* ]]
+  [[ "$output" == *"alhpa.md"* ]]
   [ "$(git -C "$NOTES_CALLER_PWD" rev-parse HEAD)" = "$before" ]
 
   run git -C "$NOTES_CALLER_PWD" diff --cached --name-only


### PR DESCRIPTION
## Summary

Fix-it for KnickKnackLabs/notes#131.

When `notes stage <path>` / `notes commit <path>` is given an explicit path that is neither an existing readable note nor a manifest-known note, fail instead of exiting successfully with "No selected changes".

This keeps explicit scope agent-friendly: a typo like `alhpa.md` should be visible, not silently produce no commit while another note remains dirty.

## Validation

- `bash -n .mise/tasks/stage .mise/tasks/commit`
- `mise run test test/changes.bats --filter 'notes stage|notes commit'` — 21/21
- `git diff --check`
