### PR TITLE
Reject traversal note paths in notes stage

### DIFF
--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -65,6 +65,12 @@ changes=$(detect_changes "$abs_notes_dir") || true
 if [ "$scope_all" != "true" ]; then
   unknown=()
   for f in ${ARGS[@]+"${ARGS[@]}"}; do
+    case "$f" in
+      /*|..|../*|*/../*|.|./*|*/./*|*/)
+        unknown+=("$f")
+        continue
+        ;;
+    esac
     if [ -f "$abs_notes_dir/$f" ] || [ -n "$(manifest_id_for_name "$manifest" "$f")" ]; then
       continue
     fi

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -362,6 +362,19 @@ rename_manifest_entry_in_head() {
   [ -z "$output" ]
 }
 
+@test "notes stage: path traversal argument fails instead of selecting nothing" {
+  echo "# Alpha modified" > "$NOTES_CALLER_PWD/notes/alpha.md"
+  echo "readme" > "$NOTES_CALLER_PWD/README.md"
+
+  run notes stage ../README.md
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"requested note path"* ]]
+  [[ "$output" == *"../README.md"* ]]
+
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
+  [ -z "$output" ]
+}
+
 @test "notes stage --dry-run: deleted note leaves manifest and index untouched" {
   local manifest_before
   manifest_before=$(cat "$MANIFEST")
@@ -754,6 +767,23 @@ SH
   [ "$status" -ne 0 ]
   [[ "$output" == *"requested note path"* ]]
   [[ "$output" == *"alhpa.md"* ]]
+  [ "$(git -C "$NOTES_CALLER_PWD" rev-parse HEAD)" = "$before" ]
+
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
+  [ -z "$output" ]
+}
+
+@test "notes commit: path traversal argument fails instead of silently committing nothing" {
+  notes install-hooks
+  local before
+  before=$(git -C "$NOTES_CALLER_PWD" rev-parse HEAD)
+  echo "# Alpha v2" > "$NOTES_CALLER_PWD/notes/alpha.md"
+  echo "readme" > "$NOTES_CALLER_PWD/README.md"
+
+  run notes commit -m "traversal" ../README.md
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"requested note path"* ]]
+  [[ "$output" == *"../README.md"* ]]
   [ "$(git -C "$NOTES_CALLER_PWD" rev-parse HEAD)" = "$before" ]
 
   run git -C "$NOTES_CALLER_PWD" diff --cached --name-only


### PR DESCRIPTION
Fix-it for KnickKnackLabs/notes#131 re-review.

`notes stage` treated explicit path-traversal arguments like `../README.md` as "known" whenever the joined path existed on disk, then selected no note changes and exited successfully. Because `notes commit` delegates path validation to `notes stage`, it had the same silent no-op behavior.

This rejects absolute paths, `..`/`.` path components, and directory-looking arguments before the existing known-note check.

Validation:

- `bash -n .mise/tasks/stage .mise/tasks/commit .mise/tasks/setup .mise/tasks/deobfuscate`
- `mise run test test/changes.bats --filter 'path traversal argument fails'` — 2/2
- `mise run test test/changes.bats` — 46/46
- `git diff --check origin/main...HEAD`
