### PR TITLE
fix: apply confirm-or-require-yes to install-hooks and unlock --force (#89)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 __pycache__/
 *.pyc
+/memory/
+/CLAUDE.md

--- a/.mise/tasks/install-hooks
+++ b/.mise/tasks/install-hooks
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Install git hooks for obfuscation (pre-commit, post-commit, post-merge)"
+#USAGE flag "-y --yes" default=#false help="Skip confirmation prompt"
 #USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root"
 set -euo pipefail
 
@@ -15,6 +16,8 @@ if ! is_initialized && [ ! -f "$manifest" ]; then
   echo "Run 'notes setup --yes' to initialize notes in this repo."
   exit 0
 fi
+
+confirm_destructive "notes install-hooks will install pre-commit, post-commit, post-merge, post-checkout hooks and a manifest merge driver for $notes_dir/. Continue?"
 
 install_encryption_hook
 install_obfuscation_hook "$notes_dir"

--- a/.mise/tasks/unlock
+++ b/.mise/tasks/unlock
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Unlock encrypted files using your GPG key"
+#USAGE flag "-y --yes" default=#false help="Skip confirmation prompt"
 #USAGE flag "--force" default=#false help="Overwrite existing readable note files during deobfuscation"
 set -euo pipefail
 
@@ -23,6 +24,7 @@ fi
 # Deobfuscate filenames if a manifest exists
 if [ -f "$TARGET_DIR/notes/.manifest" ]; then
   if [ "${usage_force:-false}" = "true" ]; then
+    confirm_destructive "notes unlock --force will overwrite existing readable note files during deobfuscation. Continue?"
     cd "$MISE_CONFIG_ROOT" && NOTES_CALLER_PWD="$TARGET_DIR" mise run -q deobfuscate --force
   else
     cd "$MISE_CONFIG_ROOT" && NOTES_CALLER_PWD="$TARGET_DIR" mise run -q deobfuscate

--- a/.mise/tasks/unlock
+++ b/.mise/tasks/unlock
@@ -11,6 +11,12 @@ require_rudi
 
 cd "$TARGET_DIR"
 
+force_deobfuscate=false
+if [ -f "$TARGET_DIR/notes/.manifest" ] && [ "${usage_force:-false}" = "true" ]; then
+  confirm_destructive "notes unlock --force will overwrite existing readable note files during deobfuscation. Continue?"
+  force_deobfuscate=true
+fi
+
 # Skip the mutating unlock path when rudi already reports unlocked; see #42.
 # The real locked→unlocked path still relies on rudi/git-crypt guards.
 if encryption_unlocked; then
@@ -23,8 +29,7 @@ fi
 
 # Deobfuscate filenames if a manifest exists
 if [ -f "$TARGET_DIR/notes/.manifest" ]; then
-  if [ "${usage_force:-false}" = "true" ]; then
-    confirm_destructive "notes unlock --force will overwrite existing readable note files during deobfuscation. Continue?"
+  if $force_deobfuscate; then
     cd "$MISE_CONFIG_ROOT" && NOTES_CALLER_PWD="$TARGET_DIR" mise run -q deobfuscate --force
   else
     cd "$MISE_CONFIG_ROOT" && NOTES_CALLER_PWD="$TARGET_DIR" mise run -q deobfuscate

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ notes lock --yes
 notes unlock
 ```
 
-`setup` and `lock` require confirmation because they mutate repository encryption state. In automation, pass `--yes` explicitly.
+`setup`, `lock`, `install-hooks`, and `unlock --force` require confirmation because they mutate repository encryption or hook state. In automation, pass `--yes` explicitly.
 
 ## What notes manages
 

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -650,7 +650,7 @@ SH
 # ── commit wrapper ───────────────────────────────────────────
 
 @test "notes commit: explicit file commits modified note and leaves clean readable tree" {
-  notes install-hooks
+  notes install-hooks --yes
 
   echo "# Alpha v2" > "$NOTES_CALLER_PWD/notes/alpha.md"
 
@@ -678,7 +678,7 @@ SH
 }
 
 @test "notes commit --all commits modified new and deleted notes" {
-  notes install-hooks
+  notes install-hooks --yes
 
   echo "# Alpha v2" > "$NOTES_CALLER_PWD/notes/alpha.md"
   echo "# Gamma" > "$NOTES_CALLER_PWD/notes/gamma.md"
@@ -702,7 +702,7 @@ SH
 }
 
 @test "notes commit: path-limited commit leaves unrelated dirty notes uncommitted" {
-  notes install-hooks
+  notes install-hooks --yes
 
   local alpha_id beta_id
   alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
@@ -743,7 +743,7 @@ SH
 }
 
 @test "notes commit: no args requires explicit scope" {
-  notes install-hooks
+  notes install-hooks --yes
   local before
   before=$(git -C "$NOTES_CALLER_PWD" rev-parse HEAD)
   echo "# Alpha v2" > "$NOTES_CALLER_PWD/notes/alpha.md"
@@ -758,7 +758,7 @@ SH
 }
 
 @test "notes commit: explicit unknown path fails instead of silently committing nothing" {
-  notes install-hooks
+  notes install-hooks --yes
   local before
   before=$(git -C "$NOTES_CALLER_PWD" rev-parse HEAD)
   echo "# Alpha v2" > "$NOTES_CALLER_PWD/notes/alpha.md"
@@ -774,7 +774,7 @@ SH
 }
 
 @test "notes commit: path traversal argument fails instead of silently committing nothing" {
-  notes install-hooks
+  notes install-hooks --yes
   local before
   before=$(git -C "$NOTES_CALLER_PWD" rev-parse HEAD)
   echo "# Alpha v2" > "$NOTES_CALLER_PWD/notes/alpha.md"
@@ -791,7 +791,7 @@ SH
 }
 
 @test "notes commit: refuses pre-staged changes before staging notes" {
-  notes install-hooks
+  notes install-hooks --yes
   local before
   before=$(git -C "$NOTES_CALLER_PWD" rev-parse HEAD)
   echo "readme" > "$NOTES_CALLER_PWD/README.md"
@@ -809,7 +809,7 @@ SH
 }
 
 @test "notes commit: detects non-note paths added by another pre-commit hook" {
-  notes install-hooks
+  notes install-hooks --yes
   mkdir -p "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d"
   cat > "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d/zz-stage-generated" <<'HOOK'
 #!/usr/bin/env bash

--- a/test/git-operations.bats
+++ b/test/git-operations.bats
@@ -47,7 +47,7 @@ setup() {
   git -C "$ORIGIN" commit -q -m "obfuscate"
 
   # Install hooks on origin too (both sides need them)
-  notes install-hooks
+  notes install-hooks --yes
   notes deobfuscate
 
   git -C "$ORIGIN" push -q
@@ -61,7 +61,7 @@ setup() {
   # Deobfuscate + install hooks (including merge driver) on local
   export NOTES_CALLER_PWD="$LOCAL"
   notes deobfuscate
-  notes install-hooks
+  notes install-hooks --yes
   _use_local_merge_driver "$LOCAL"
 }
 
@@ -372,7 +372,7 @@ EOT
   git -C "$repo" add .gitattributes notes/.manifest notes/aaa00001
   git -C "$repo" commit -q -m "init"
 
-  NOTES_CALLER_PWD="$repo" notes install-hooks >/dev/null
+  NOTES_CALLER_PWD="$repo" notes install-hooks --yes >/dev/null
   _use_local_merge_driver "$repo"
 
   git -C "$repo" switch -q -c feature

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -130,6 +130,44 @@ generate_test_key() {
   [ -z "$(git -C "$TARGET_DIR" diff --cached --name-only)" ]
 }
 
+@test "unlock --force refuses without confirmation for dirty readable overwrite" {
+  notes setup --yes
+
+  local fpr
+  fpr=$(generate_test_key "$GNUPGHOME")
+  notes add-user -- --gpg-key "$fpr"
+
+  # Create, obfuscate, commit, then deobfuscate — unlock without --force is clean
+  mkdir -p "$TARGET_DIR/notes"
+  echo "secret content" > "$TARGET_DIR/notes/secret.md"
+  git -C "$TARGET_DIR" add .
+  git -C "$TARGET_DIR" commit -q --no-verify -m "Add encrypted note"
+
+  run without_confirmation "$TEST_DIR/missing-tty" notes unlock --force
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"confirmation required"* ]]
+  [[ "$output" == *"Re-run with --yes"* ]]
+}
+
+@test "unlock --force --yes proceeds with deobfuscation" {
+  notes setup --yes
+
+  local fpr
+  fpr=$(generate_test_key "$GNUPGHOME")
+  notes add-user -- --gpg-key "$fpr"
+
+  mkdir -p "$TARGET_DIR/notes"
+  echo "secret content" > "$TARGET_DIR/notes/secret.md"
+  git -C "$TARGET_DIR" add .
+  git -C "$TARGET_DIR" commit -q --no-verify -m "Add encrypted note"
+
+  run notes unlock --force --yes
+  [ "$status" -eq 0 ]
+  # Should have deobfuscated (file still readable after unlock)
+  grep -q "secret content" "$TARGET_DIR/notes/secret.md"
+}
+
 # --- status ---
 
 @test "status shows encryption info" {

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -150,6 +150,56 @@ generate_test_key() {
   [[ "$output" == *"Re-run with --yes"* ]]
 }
 
+@test "unlock --force refuses before running rudi unlock when locked" {
+  local repo fake_bin log
+  repo="$BATS_TEST_TMPDIR/locked-force-repo"
+  fake_bin="$BATS_TEST_TMPDIR/fake-bin"
+  log="$BATS_TEST_TMPDIR/rudi-unlock.log"
+  mkdir -p "$repo/notes" "$repo/.git-crypt" "$fake_bin"
+  git -C "$repo" init -q
+  git -C "$repo" config user.name "Test"
+  git -C "$repo" config user.email "test@test.com"
+  printf 'aaa00001\talpha.md\n' > "$repo/notes/.manifest"
+  printf 'encrypted-ish\n' > "$repo/notes/aaa00001"
+  git -C "$repo" add -A
+  git -C "$repo" commit -q -m "init"
+
+  cat > "$fake_bin/rudi" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  status)
+    if [ "${2:-}" = "--json" ]; then
+      printf '{"initialized":true,"unlocked":false}\n'
+      exit 0
+    fi
+    printf 'locked\n'
+    ;;
+  unlock)
+    : > "${RUDI_UNLOCK_LOG:?RUDI_UNLOCK_LOG not set}"
+    printf 'fake rudi unlock ran\n'
+    ;;
+  *)
+    printf 'fake rudi: unsupported command: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+SH
+  chmod +x "$fake_bin/rudi"
+
+  run bash -c '
+    set -euo pipefail
+    export NOTES_CALLER_PWD="$1"
+    export PATH="$2:$PATH"
+    export RUDI_UNLOCK_LOG="$3"
+    without_confirmation "$4" notes unlock --force
+  ' _ "$repo" "$fake_bin" "$log" "$TEST_DIR/missing-tty"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"confirmation required"* ]]
+  [ ! -e "$log" ]
+}
+
 @test "unlock --force --yes proceeds with deobfuscation" {
   notes setup --yes
 

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -398,7 +398,7 @@ setup() {
 # --- Hook installation ---
 
 @test "install-hooks no-ops for uninitialized plain notes directories" {
-  run notes install-hooks
+  run notes install-hooks --yes
   [ "$status" -eq 0 ]
   [[ "$output" == *"No notes manifest found"* ]]
   [[ "$output" == *"notes setup --yes"* ]]
@@ -409,9 +409,35 @@ setup() {
   [ -z "$(git -C "$NOTES_CALLER_PWD" config --get merge.manifest.driver || true)" ]
 }
 
+@test "install-hooks refuses without confirmation in headless context" {
+  notes obfuscate
+
+  run without_confirmation "$BATS_TEST_TMPDIR/missing-tty" notes install-hooks
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"confirmation required"* ]]
+  [[ "$output" == *"Re-run with --yes"* ]]
+
+  # Hooks should not be installed
+  [ ! -x "$NOTES_CALLER_PWD/.git/hooks/pre-commit" ]
+  [ ! -d "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d" ]
+}
+
+@test "install-hooks --yes proceeds with hook installation" {
+  notes obfuscate
+
+  run notes install-hooks --yes
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Installed hooks"* ]]
+
+  # Verify hooks were actually installed
+  [ -x "$NOTES_CALLER_PWD/.git/hooks/pre-commit" ]
+  grep -q "Generic hook dispatcher" "$NOTES_CALLER_PWD/.git/hooks/pre-commit"
+}
+
 @test "install-hooks installs pre-commit hooks" {
   notes obfuscate
-  notes install-hooks
+  notes install-hooks --yes
 
   [ -x "$NOTES_CALLER_PWD/.git/hooks/pre-commit" ]
   grep -q "Generic hook dispatcher" "$NOTES_CALLER_PWD/.git/hooks/pre-commit"
@@ -431,7 +457,7 @@ setup() {
   git -C "$NOTES_CALLER_PWD" add .gitattributes
   git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "enable encryption"
 
-  notes install-hooks
+  notes install-hooks --yes
 
   local blob
   blob=$(printf 'aaa00001\talpha.md\n' | git -C "$NOTES_CALLER_PWD" hash-object -w --stdin)
@@ -563,7 +589,7 @@ EOF
 
   # Deobfuscate + install hooks explicitly
   notes deobfuscate
-  notes install-hooks
+  notes install-hooks --yes
 
   # Add a new deobfuscated file + stage everything
   echo -e "---\ntitle: Sneaky\n---\n# Sneaky" > "$NOTES_CALLER_PWD/notes/sneaky.md"
@@ -591,7 +617,7 @@ EOF
   git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscated"
 
   notes deobfuscate
-  notes install-hooks
+  notes install-hooks --yes
   git -C "$NOTES_CALLER_PWD" add .gitattributes
   git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "install hook attributes"
 
@@ -617,7 +643,7 @@ EOT
 
 @test "install-hooks installs post-commit deobfuscation hook" {
   notes obfuscate
-  notes install-hooks
+  notes install-hooks --yes
 
   [ -x "$NOTES_CALLER_PWD/.git/hooks/post-commit" ]
   grep -q "Generic hook dispatcher" "$NOTES_CALLER_PWD/.git/hooks/post-commit"
@@ -633,7 +659,7 @@ EOT
 
   # Deobfuscate + install hooks explicitly
   notes deobfuscate
-  notes install-hooks
+  notes install-hooks --yes
 
   # Add a new file and commit — hooks should handle the round-trip
   echo -e "---\ntitle: New Note\n---\n# New" > "$NOTES_CALLER_PWD/notes/new-note.md"
@@ -659,7 +685,7 @@ EOT
   git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscated"
 
   notes deobfuscate
-  notes install-hooks
+  notes install-hooks --yes
 
   echo -e "---\ntitle: Fresh\n---\n# Fresh content" > "$NOTES_CALLER_PWD/notes/fresh.md"
   git -C "$NOTES_CALLER_PWD" add notes/fresh.md
@@ -672,7 +698,7 @@ EOT
 
 @test "post-commit hook is no-op when files are not obfuscated" {
   # Install hooks — no manifest exists, so hooks should be no-ops
-  notes install-hooks
+  notes install-hooks --yes
 
   # Commit should succeed even though post-commit hook exists
   echo "change" >> "$NOTES_CALLER_PWD/notes/alpha.md"
@@ -762,7 +788,7 @@ EOT
   git -C "$NOTES_CALLER_PWD" add -A
   git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscated"
   notes deobfuscate
-  notes install-hooks
+  notes install-hooks --yes
 
   # Edit a file and commit via hooks
   echo "edited" >> "$NOTES_CALLER_PWD/notes/alpha.md"
@@ -802,7 +828,7 @@ EOT
   git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscated unsorted manifest"
 
   notes deobfuscate
-  notes install-hooks
+  notes install-hooks --yes
   git -C "$NOTES_CALLER_PWD" add .gitattributes
   git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "install hook attributes"
   [ -z "$(git -C "$NOTES_CALLER_PWD" status --short)" ]
@@ -819,7 +845,7 @@ EOT
 
 @test "install-hooks installs post-merge deobfuscation hook" {
   notes obfuscate
-  notes install-hooks
+  notes install-hooks --yes
 
   [ -x "$NOTES_CALLER_PWD/.git/hooks/post-merge" ]
   grep -q "Generic hook dispatcher" "$NOTES_CALLER_PWD/.git/hooks/post-merge"
@@ -926,7 +952,7 @@ EOT
   git -C "$NOTES_CALLER_PWD" add -A
   git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscated"
   notes deobfuscate
-  notes install-hooks
+  notes install-hooks --yes
   # Working tree: readable names. Index: obfuscated names matching HEAD.
 
   # Edit one file, stage only that one


### PR DESCRIPTION
Closes #89

## Summary

Applies the `confirm-or-require-yes` pattern (shipped in notes#86 for `setup` and `lock`) to the two remaining destructive notes paths.

## Changes

| Command | What changed |
|---------|-------------|
| `notes install-hooks` | Added `-y --yes` flag + `confirm_destructive` guard before hook installation. No-op path (uninitialized repo with no manifest) skips confirmation. |
| `notes unlock --force` | Added `-y --yes` flag + `confirm_destructive` guard before forced deobfuscation. Confirmation now happens before the locked-repo `rudi unlock` mutation when `--force` and a notes manifest are present. |
| README | Documents the expanded confirmation surface. |

## Validation

- `bash -n .mise/tasks/install-hooks .mise/tasks/unlock .mise/tasks/stage .mise/tasks/status .mise/tasks/suppress-refresh lib/common.sh lib/suppress.sh test/integration.bats test/obfuscate.bats test/changes.bats test/git-operations.bats test/status.bats`
- `git diff --check origin/main...HEAD`
- no newly introduced `|| true` in this PR diff
- `mise run test test/integration.bats test/obfuscate.bats` — 93/93 with expected skips
- `mise run test` — 325 BATS with expected skips + 9 pytest
