### PR TITLE
feat: detect orphan files from removed features in notes status (#84)

### DIFF
--- a/.mise/tasks/clean
+++ b/.mise/tasks/clean
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#MISE description="Remove orphan files from removed features"
+#USAGE flag "--orphans" default=#false help="Remove orphan files left behind by removed features (graph.md, index.md)"
+#USAGE flag "--dir <dir>" default="notes" help="Notes directory name (default: notes)"
+set -euo pipefail
+
+source "$MISE_CONFIG_ROOT/lib/common.sh"
+require_git
+
+NOTES_DIR="${usage_dir:-notes}"
+ORPHANS="${usage_orphans:-false}"
+
+cd "$TARGET_DIR"
+
+ORPHAN_PATTERNS=(
+  "graph.md"
+  "index.md"
+)
+
+if [ "$ORPHANS" != "true" ]; then
+  echo "Usage: notes clean --orphans"
+  echo ""
+  echo "Remove orphan files from removed features."
+  echo "Currently recognized orphans: ${ORPHAN_PATTERNS[*]}"
+  exit 0
+fi
+
+found=0
+removed=0
+manifest="$NOTES_DIR/.manifest"
+
+for pattern in "${ORPHAN_PATTERNS[@]}"; do
+  target="$TARGET_DIR/$NOTES_DIR/$pattern"
+  if [ ! -f "$target" ]; then
+    continue
+  fi
+  ((found++)) || true
+
+  # Remove from manifest if present
+  if [ -f "$manifest" ] && manifest_id_for_name "$manifest" "$pattern" >/dev/null 2>&1; then
+    id_of_orphan=$(manifest_id_for_name "$manifest" "$pattern")
+    # Remove the hex blob file too
+    if [ -f "$TARGET_DIR/$NOTES_DIR/$id_of_orphan" ]; then
+      rm -f "$TARGET_DIR/$NOTES_DIR/$id_of_orphan"
+    fi
+    # Filter out the orphan's manifest entry
+    tmp=$(mktemp) || { echo "Error: failed to create temp file" >&2; exit 1; }
+    grep -v "^${id_of_orphan}"$'\t' "$manifest" > "$tmp" || [[ $? -eq 1 ]]
+    mv -f "$tmp" "$manifest"
+    rm -f "$target"
+    echo "  removed $NOTES_DIR/$pattern and manifest entry"
+  else
+    # Remove file only
+    if git -C "$TARGET_DIR" ls-files --error-unmatch "$NOTES_DIR/$pattern" &>/dev/null; then
+      git -C "$TARGET_DIR" rm --quiet "$NOTES_DIR/$pattern"
+      echo "  removed $NOTES_DIR/$pattern (tracked)"
+    else
+      rm -f "$target"
+      echo "  removed $NOTES_DIR/$pattern"
+    fi
+  fi
+  ((removed++)) || true
+done
+
+if [ "$found" -eq 0 ]; then
+  echo "No orphan files found."
+  exit 0
+fi
+
+echo ""
+echo "Removed $removed orphan file(s)."

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -95,6 +95,34 @@ fi
 
 changes_total=$((changes_modified + changes_new + changes_deleted + changes_stale))
 
+# --- Orphans (files from removed features) ---
+
+ORPHAN_PATTERNS=(
+  "graph.md"
+  "index.md"
+)
+
+orphan_files=()
+for pattern in "${ORPHAN_PATTERNS[@]}"; do
+  if [ -f "$TARGET_DIR/$NOTES_DIR/$pattern" ]; then
+    orphan_files+=("$pattern")
+  fi
+done
+
+orphan_count=${#orphan_files[@]}
+
+# Build JSON orphan files array
+orphan_files_json="[]"
+if [ "$orphan_count" -gt 0 ]; then
+  orphan_files_json="["
+  sep=""
+  for f in "${orphan_files[@]}"; do
+    orphan_files_json="${orphan_files_json}${sep}\"$f\""
+    sep=", "
+  done
+  orphan_files_json="${orphan_files_json}]"
+fi
+
 # --- Output ---
 
 if [ "$JSON" = "true" ]; then
@@ -103,12 +131,15 @@ if [ "$JSON" = "true" ]; then
       --arg enc "$enc_status" \
       --argjson enc_unlocked "$enc_unlocked" \
       --argjson unmerged_content_conflicts "$unmerged_content_conflict_count" \
+      --argjson orphan_count "$orphan_count" \
+      --argjson orphan_files "$orphan_files_json" \
       '{
         encryption: { status: $enc, unlocked: $enc_unlocked },
         obfuscation: { status: "unknown", notes: null },
         incomplete_deobfuscation: { conflicts: 0 },
         unmerged_content_conflicts: { conflicts: $unmerged_content_conflicts },
-        changes: null
+        changes: null,
+        orphans: { total: $orphan_count, files: $orphan_files }
       }'
   else
     jq -nc \
@@ -123,12 +154,15 @@ if [ "$JSON" = "true" ]; then
       --argjson chg_total "$changes_total" \
       --argjson incomplete_conflicts "$incomplete_conflicts" \
       --argjson unmerged_content_conflicts "$unmerged_content_conflict_count" \
+      --argjson orphan_count "$orphan_count" \
+      --argjson orphan_files "$orphan_files_json" \
       '{
         encryption: { status: $enc, unlocked: $enc_unlocked },
         obfuscation: { status: $obf, notes: $total_notes },
         incomplete_deobfuscation: { conflicts: $incomplete_conflicts },
         unmerged_content_conflicts: { conflicts: $unmerged_content_conflicts },
-        changes: { total: $chg_total, modified: $chg_modified, new: $chg_new, deleted: $chg_deleted, stale_readable: $chg_stale }
+        changes: { total: $chg_total, modified: $chg_modified, new: $chg_new, deleted: $chg_deleted, stale_readable: $chg_stale },
+        orphans: { total: $orphan_count, files: $orphan_files }
       }'
   fi
 else
@@ -159,6 +193,26 @@ else
         echo "Changes:     none"
       fi
     fi
+  fi
+
+  # --- Orphans output (text) ---
+  if [ "$orphan_count" -gt 0 ]; then
+    echo ""
+    echo "Orphans:     $orphan_count file(s) from removed features"
+    for f in "${orphan_files[@]}"; do
+      case "$f" in
+        graph.md)
+          echo "  $NOTES_DIR/$f   (from removed 'notes graph' — see #83)"
+          ;;
+        index.md)
+          echo "  $NOTES_DIR/$f   (from removed 'notes index' — see 6cd9758)"
+          ;;
+        *)
+          echo "  $NOTES_DIR/$f"
+          ;;
+      esac
+    done
+    echo "Clean with: notes clean --orphans"
   fi
 
   if [ "$unmerged_content_conflict_count" -gt 0 ]; then

--- a/memory/knickknacklabs-notes-84.md
+++ b/memory/knickknacklabs-notes-84.md
@@ -1,0 +1,76 @@
+# notes#84 — Orphan detection in `notes status`
+
+## What was done
+
+Implemented orphan-file detection for removed features (`notes graph`, `notes index`).
+
+**Problem:** Clones that ran `notes graph` or `notes index` before their removal still have stale `notes/graph.md` and `notes/index.md` on disk. These show up as "new" in `notes changes`, confuse `modules update`, and accumulate as background noise.
+
+**Solution:** Three-part additive change:
+1. `notes status` detects known orphan filenames and displays them as a new "Orphans" section (text + JSON output)
+2. `notes clean --orphans` removes orphan files (and any manifest entries pointing to them)
+3. BATS tests verify both detection and cleanup
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `.mise/tasks/status` | Added `ORPHAN_PATTERNS` array, orphan detection block, text output section, `orphans` field in JSON output (both locked and unlocked branches) |
+| `.mise/tasks/clean` | **New** — task with `--orphans` flag that removes orphan files and manifest entries |
+| `test/status.bats` | Added 6 new tests: text orphans (3), JSON orphans (3) |
+| `test/clean.bats` | **New** — 7 tests covering clean detection, removal, manifest cleanup, non-orphan isolation |
+
+## Design decisions
+
+- **Curated allowlist, not heuristics** — `ORPHAN_PATTERNS=("graph.md" "index.md")` is a closed set. Future feature removals add to the list in the removing PR.
+- **Don't auto-clean** — status displays, clean removes. User decides.
+- **Don't tangle with `notes changes`** — orphans remain visible in changes until cleaned; status has a separate "Orphans" surface.
+- **Versioned cleanup framework** — removing PRs add to the allowlist, following issue #84's pattern.
+
+## Test results
+
+### Baseline (before changes)
+- 309 passing, 4 failing (known environmental `farts` failures — exit 127, not installed)
+
+### After changes
+- 322 passing, 4 failing (same 4 farts failures, unchanged)
+- +13 new tests (6 status + 7 clean), zero regressions
+- 3 existing status tests unchanged/skipped (locked-repo tests blocked on #39)
+
+### New clean tests
+| # | Test | Status |
+|---|------|--------|
+| 1 | reports no orphans when notes dir missing | ✅ |
+| 2 | removes orphan file from disk | ✅ |
+| 3 | removes multiple orphan files | ✅ |
+| 4 | ignores non-orphan notes | ✅ |
+| 5 | removes orphan and manifest entry | ✅ |
+| 6 | no-op without --orphans flag | ✅ |
+| 7 | shows count of removed files | ✅ |
+
+### New status tests
+| # | Test | Status |
+|---|------|--------|
+| 1 | shows Orphans section when orphan file exists | ✅ |
+| 2 | shows no Orphans section when no orphan files | ✅ |
+| 3 | shows multiple orphans when multiple exist | ✅ |
+| 4 | --json has orphans field when orphan exists | ✅ |
+| 5 | --json shows total 0 when no orphans | ✅ |
+| 6 | --json shows unknown filename not orphan | ✅ |
+
+## Caveats
+
+- No env changes, no CI gotchas
+- `farts` tests still fail (environmental — `farts` not installed)
+- Notes has no lint gate (bats-only CI)
+- Clean task gains execute permission on first chmod (`write` tool doesn't set +x)
+
+## Status
+
+Ready to push and open PR.
+
+## Related
+
+- Closes #84
+- Companion issue #83 (graph removal) already merged as `5597acd`
+- Companion 6cd9758 (index removal) already merged

--- a/test/clean.bats
+++ b/test/clean.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+# --- Orphans (text) ---
+
+@test "clean --orphans reports no orphans when notes dir missing" {
+  run notes clean --orphans
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No orphan files found"* ]]
+}
+
+@test "clean --orphans removes orphan file from disk" {
+  mkdir -p "$TARGET_DIR/notes"
+  touch "$TARGET_DIR/notes/graph.md"
+
+  run notes clean --orphans
+  [ "$status" -eq 0 ]
+  [ ! -f "$TARGET_DIR/notes/graph.md" ]
+  [[ "$output" == *"graph.md"* ]]
+}
+
+@test "clean --orphans removes multiple orphan files" {
+  mkdir -p "$TARGET_DIR/notes"
+  touch "$TARGET_DIR/notes/graph.md"
+  touch "$TARGET_DIR/notes/index.md"
+
+  run notes clean --orphans
+  [ "$status" -eq 0 ]
+  [ ! -f "$TARGET_DIR/notes/graph.md" ]
+  [ ! -f "$TARGET_DIR/notes/index.md" ]
+  [[ "$output" == *"2"* ]]
+}
+
+@test "clean --orphans ignores non-orphan notes" {
+  mkdir -p "$TARGET_DIR/notes"
+  echo "# Alpha" > "$TARGET_DIR/notes/alpha.md"
+  touch "$TARGET_DIR/notes/graph.md"
+
+  run notes clean --orphans
+  [ "$status" -eq 0 ]
+  [ ! -f "$TARGET_DIR/notes/graph.md" ]
+  [ -f "$TARGET_DIR/notes/alpha.md" ]
+}
+
+@test "clean --orphans removes orphan and manifest entry when present in manifest" {
+  mkdir -p "$TARGET_DIR/notes"
+  printf 'aaaaaaaa\tgraph.md\n' > "$TARGET_DIR/notes/.manifest"
+  touch "$TARGET_DIR/notes/graph.md"
+  touch "$TARGET_DIR/notes/aaaaaaaa"
+
+  run notes clean --orphans
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"manifest entry"* ]]
+  [ ! -f "$TARGET_DIR/notes/graph.md" ]
+  [ ! -f "$TARGET_DIR/notes/aaaaaaaa" ]
+  run grep -c 'aaaaaaaa' "$TARGET_DIR/notes/.manifest"
+  [ "$status" -eq 1 ]
+}
+
+@test "clean --orphans is a no-op without --orphans flag" {
+  mkdir -p "$TARGET_DIR/notes"
+  touch "$TARGET_DIR/notes/graph.md"
+
+  run notes clean
+  [ "$status" -eq 0 ]
+  [ -f "$TARGET_DIR/notes/graph.md" ]
+  [[ "$output" == *"--orphans"* ]]
+}
+
+@test "clean --orphans shows count of removed files" {
+  mkdir -p "$TARGET_DIR/notes"
+  touch "$TARGET_DIR/notes/graph.md"
+
+  run notes clean --orphans
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Removed 1"* ]]
+}

--- a/test/status.bats
+++ b/test/status.bats
@@ -62,6 +62,67 @@ load test_helper
   [[ "$output" == *"notes/aaaaaaaa"* ]]
 }
 
+# --- Orphans (text) ---
+
+@test "status shows Orphans section when orphan file exists" {
+  mkdir -p "$TARGET_DIR/notes"
+  touch "$TARGET_DIR/notes/graph.md"
+
+  run notes status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Orphans:"* ]]
+  [[ "$output" == *"graph.md"* ]]
+}
+
+@test "status shows no Orphans section when no orphan files" {
+  notes setup --yes
+
+  run notes status
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Orphans:"* ]]
+}
+
+@test "status shows multiple orphans when multiple orphan files exist" {
+  mkdir -p "$TARGET_DIR/notes"
+  touch "$TARGET_DIR/notes/graph.md"
+  touch "$TARGET_DIR/notes/index.md"
+
+  run notes status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Orphans:"* ]]
+  [[ "$output" == *"graph.md"* ]]
+  [[ "$output" == *"index.md"* ]]
+  [[ "$output" == *"2 file(s)"* ]]
+}
+
+# --- Orphans (JSON) ---
+
+@test "status --json has orphans field when orphan file exists" {
+  mkdir -p "$TARGET_DIR/notes"
+  touch "$TARGET_DIR/notes/graph.md"
+
+  run notes status -- --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.orphans.total == 1'
+  echo "$output" | jq -e '.orphans.files[0] == "graph.md"'
+}
+
+@test "status --json shows orphans.total 0 when no orphans" {
+  run notes status -- --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.orphans.total == 0'
+  echo "$output" | jq -e '.orphans.files == []'
+}
+
+@test "status --json shows unknown filename not classified as orphan" {
+  mkdir -p "$TARGET_DIR/notes"
+  touch "$TARGET_DIR/notes/random-file.md"
+
+  run notes status -- --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.orphans.total == 0'
+}
+
 # --- JSON output ---
 
 @test "status --json outputs valid JSON" {


### PR DESCRIPTION
## Summary

Adds orphan-file detection for removed features (`notes graph`, `notes index`) — no changes to existing behavior.

## Changes

| File | Change |
|------|--------|
| `.mise/tasks/status` | Added `ORPHAN_PATTERNS` array, orphan detection, text "Orphans" section, `orphans` JSON field (both locked and unlocked output paths) |
| `.mise/tasks/clean` | **New** — `notes clean --orphans` removes orphan files + manifest entries |
| `test/status.bats` | 6 new orphan tests (3 text, 3 JSON) |
| `test/clean.bats` | **New** — 7 tests covering clean detection, removal, manifest cleanup, non-orphan isolation |

## Design

- **Curated allowlist:** `ORPHAN_PATTERNS=("graph.md" "index.md")` — closed set. Future feature removals add to it.
- **Don't auto-clean:** status displays, clean removes. User decides.
- **Don't tangle with `notes changes`:** separate surface, separate semantics.

## Test results

| | Baseline | After |
|--|----------|-------|
| Passing | 309 | **322** (+13) |
| Failing | 4 (farts env) | 4 (unchanged) |
| New tests | — | 6 status + 7 clean |

## Related

Closes #84

Companion removals already merged:
- `notes graph` → `5597acd chore: remove graph task`
- `notes index` → `6cd9758`