### PR TITLE
fix: detect double-tracked notes (readable + obfuscated both in index)

### DIFF
--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -135,6 +135,31 @@ if [ -n "$conflicting_notes" ]; then
   fi
 fi
 
+double_tracked=$(detect_double_tracked_notes "$TARGET_DIR" "$notes_dir" 2>/dev/null) || true
+if [ -n "$double_tracked" ]; then
+  blocked_tracked=()
+  while IFS=$'\t' read -r dt_id dt_relpath; do
+    [ -z "$dt_id" ] && continue
+    scope_matches "$dt_relpath" || continue
+    blocked_tracked+=("$dt_id"$'\t'"$dt_relpath")
+  done <<< "$double_tracked"
+
+  if [ ${#blocked_tracked[@]} -gt 0 ]; then
+    echo "Error: double-tracked notes detected; refusing to stage." >&2
+    echo "Readable names are tracked in git alongside their obfuscated IDs (notes#51):" >&2
+    for dt in "${blocked_tracked[@]}"; do
+      IFS=$'\t' read -r dt_id dt_relpath <<< "$dt"
+      echo "  $notes_dir/$dt_relpath (also tracked as $notes_dir/$dt_id)" >&2
+    done
+    echo "" >&2
+    echo "This causes silent content drift. To fix:" >&2
+    echo "  1. Decide which version is correct." >&2
+    echo "  2. Run: git rm --cached $notes_dir/<readable>" >&2
+    echo "  3. Commit the untrack, then retry 'notes stage'." >&2
+    exit 1
+  fi
+fi
+
 while IFS=$'\t' read -r status relpath; do
   scope_matches "$relpath" || continue
 

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -64,6 +64,14 @@ if [ "$enc_status" != "locked" ] && [ -f "$NOTES_DIR/.manifest" ]; then
   fi
 fi
 
+# --- Double-tracked notes (readable + obfuscated both tracked) ---
+
+double_tracked=$(detect_double_tracked_notes "$TARGET_DIR" "$NOTES_DIR" 2>/dev/null) || true
+double_tracked_count=0
+if [ -n "$double_tracked" ]; then
+  double_tracked_count=$(printf '%s\n' "$double_tracked" | grep -c . || true)
+fi
+
 # --- Unmerged encrypted/obfuscated note content conflicts ---
 
 unmerged_content_conflicts=$(notes_conflict_records "$TARGET_DIR" "$NOTES_DIR" allow-unmapped 2>/dev/null) || true
@@ -102,11 +110,13 @@ if [ "$JSON" = "true" ]; then
     jq -nc \
       --arg enc "$enc_status" \
       --argjson enc_unlocked "$enc_unlocked" \
+      --argjson double_tracked "$double_tracked_count" \
       --argjson unmerged_content_conflicts "$unmerged_content_conflict_count" \
       '{
         encryption: { status: $enc, unlocked: $enc_unlocked },
         obfuscation: { status: "unknown", notes: null },
         incomplete_deobfuscation: { conflicts: 0 },
+        double_tracked: { conflicts: $double_tracked },
         unmerged_content_conflicts: { conflicts: $unmerged_content_conflicts },
         changes: null
       }'
@@ -122,11 +132,13 @@ if [ "$JSON" = "true" ]; then
       --argjson chg_stale "$changes_stale" \
       --argjson chg_total "$changes_total" \
       --argjson incomplete_conflicts "$incomplete_conflicts" \
+      --argjson double_tracked "$double_tracked_count" \
       --argjson unmerged_content_conflicts "$unmerged_content_conflict_count" \
       '{
         encryption: { status: $enc, unlocked: $enc_unlocked },
         obfuscation: { status: $obf, notes: $total_notes },
         incomplete_deobfuscation: { conflicts: $incomplete_conflicts },
+        double_tracked: { conflicts: $double_tracked },
         unmerged_content_conflicts: { conflicts: $unmerged_content_conflicts },
         changes: { total: $chg_total, modified: $chg_modified, new: $chg_new, deleted: $chg_deleted, stale_readable: $chg_stale }
       }'
@@ -158,6 +170,20 @@ else
       else
         echo "Changes:     none"
       fi
+    fi
+    if [ "$double_tracked_count" -gt 0 ]; then
+      echo ""
+      echo "DOUBLE-TRACKED NOTES: $double_tracked_count file(s) tracked as both readable and obfuscated!"
+      echo "This is a data-loss bug (notes#51). Content will silently drift on every commit."
+      while IFS=$'\t' read -r dt_id dt_relpath; do
+        [ -z "$dt_id" ] && continue
+        echo "  $NOTES_DIR/$dt_relpath (also tracked as $NOTES_DIR/$dt_id)"
+      done <<< "$double_tracked"
+      echo ""
+      echo "To fix:"
+      echo "  1. Decide which version is correct (readable vs hex)."
+      echo "  2. Run: git rm --cached $NOTES_DIR/<readable>"
+      echo "  3. Commit the untrack, then use 'notes stage' to sync."
     fi
   fi
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -146,3 +146,25 @@ manifest_name_for_id() {
   [ ! -f "$manifest" ] && return
   grep "^${id}"$'\t' "$manifest" | cut -f2
 }
+
+# Detect notes that are tracked both as readable names and as obfuscated IDs.
+# This is the double-tracking bug from notes#51: a readable-named file got
+# committed alongside its obfuscated hex counterpart, causing silent content
+# drift on every subsequent commit.
+#
+# Outputs one line per double-tracked note: "<id>\t<relpath>"
+# Usage: detect_double_tracked_notes <repo_root> <notes_dir_rel>
+detect_double_tracked_notes() {
+  local repo_root="${1:?usage: detect_double_tracked_notes <repo_root> <notes_dir_rel>}"
+  local notes_dir_rel="${2:?usage: detect_double_tracked_notes <repo_root> <notes_dir_rel>}"
+  local manifest="$repo_root/$notes_dir_rel/.manifest"
+  [ ! -f "$manifest" ] && return 0
+
+  while IFS=$'\t' read -r id relpath; do
+    [ -z "$id" ] && continue
+    # If the readable path is tracked in git's index, it's double-tracked.
+    if git -C "$repo_root" ls-files --error-unmatch -- "$notes_dir_rel/$relpath" >/dev/null 2>&1; then
+      printf '%s\t%s\n' "$id" "$relpath"
+    fi
+  done < "$manifest"
+}

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -484,6 +484,35 @@ SH
   [[ "$output" != *"notes/alpha.md"* ]]
 }
 
+@test "notes stage: refuses double-tracked notes (readable + obfuscated both in index)" {
+  local alpha_id
+  alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
+
+  # Simulate the double-tracking bug from notes#51: both readable and hex tracked.
+  # Use identical content so the dual-present conflict check does not fire first.
+  echo "# Alpha obfuscated" > "$NOTES_CALLER_PWD/notes/alpha.md"
+  echo "# Alpha obfuscated" > "$NOTES_CALLER_PWD/notes/$alpha_id"
+  git -C "$NOTES_CALLER_PWD" add -f "notes/alpha.md"
+
+  run notes stage alpha.md
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"double-tracked"* ]]
+  [[ "$output" == *"alpha.md"* ]]
+  [[ "$output" == *"notes#51"* ]]
+}
+
+@test "notes stage: does not refuse when readable is only on disk, not tracked" {
+  local alpha_id
+  alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
+
+  # Normal deobfuscated state: readable on disk, hex tracked in index
+  echo "# Alpha v2" > "$NOTES_CALLER_PWD/notes/alpha.md"
+
+  run notes stage alpha.md
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"staged: alpha.md"* ]]
+}
+
 @test "notes stage --all refuses stale readable files left from another branch" {
   local repo="$BATS_TEST_TMPDIR/branch-repo"
   mkdir -p "$repo/notes"

--- a/test/status.bats
+++ b/test/status.bats
@@ -62,6 +62,42 @@ load test_helper
   [[ "$output" == *"notes/aaaaaaaa"* ]]
 }
 
+@test "status reports double-tracked notes when readable path is tracked in index" {
+  mkdir -p "$TARGET_DIR/notes"
+  git -C "$TARGET_DIR" init -q
+  printf 'aaaaaaaa\talpha.md\n' > "$TARGET_DIR/notes/.manifest"
+  echo "# Alpha tracked" > "$TARGET_DIR/notes/alpha.md"
+  echo "# Alpha obfuscated" > "$TARGET_DIR/notes/aaaaaaaa"
+  git -C "$TARGET_DIR" add -A
+  git -C "$TARGET_DIR" commit -q -m "init"
+
+  # Simulate the double-tracking bug: readable name committed alongside hex
+  # (In the test repo, both are committed via `add -A` above. This matches the
+  # real-world state where readable + hex both exist in the index.)
+
+  run notes status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DOUBLE-TRACKED NOTES"* ]]
+  [[ "$output" == *"alpha.md"* ]]
+  [[ "$output" == *"notes/aaaaaaaa"* ]]
+}
+
+@test "status does not report double-tracked when only obfuscated is tracked" {
+  mkdir -p "$TARGET_DIR/notes"
+  git -C "$TARGET_DIR" init -q
+  printf 'aaaaaaaa\talpha.md\n' > "$TARGET_DIR/notes/.manifest"
+  echo "# Alpha obfuscated" > "$TARGET_DIR/notes/aaaaaaaa"
+  git -C "$TARGET_DIR" add -A
+  git -C "$TARGET_DIR" commit -q -m "init"
+
+  # Readable is on disk but not tracked
+  echo "# Alpha readable" > "$TARGET_DIR/notes/alpha.md"
+
+  run notes status
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"DOUBLE-TRACKED NOTES"* ]]
+}
+
 # --- JSON output ---
 
 @test "status --json outputs valid JSON" {


### PR DESCRIPTION
## Summary

Add detection for a dangerous data-integrity bug (notes#51): when a readable-named file and its obfuscated hex counterpart are both tracked in git's index, content silently drifts on every commit. This caused a real regression in ricon-family/fold#51.

## Changes

- **lib/common.sh** — add `detect_double_tracked_notes()` helper that checks git's index for readable-name paths that have hex counterparts already tracked
- **.mise/tasks/status** — report double-tracked notes in both text output (`DOUBLE-TRACKED NOTES: N file(s)`) and JSON output (`double_tracked.conflicts`)
- **.mise/tasks/stage** — refuse to stage when double-tracked notes are in scope, with remediation steps printed
- **test/status.bats** — 2 new tests: detection on tracked readable, no false-positive on disk-only readable
- **test/changes.bats** — 2 new tests: stage refusal on double-tracked, normal stage passing through

## Testing

All 4 new BATS tests pass. All existing status and changes tests continue to pass.

## Related

Closes notes#51 (short-term: detection). The medium-term fix (pre-commit hook prevention) can build on this detection helper.