### PR TITLE
refactor: spell out notes status fallbacks

### DIFF
--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -135,7 +135,10 @@ if [ -n "$conflicting_notes" ]; then
   fi
 fi
 
-double_tracked=$(detect_double_tracked_notes "$TARGET_DIR" "$notes_dir" 2>/dev/null) || true
+double_tracked=""
+if ! double_tracked=$(detect_double_tracked_notes "$TARGET_DIR" "$notes_dir" 2>/dev/null); then
+  double_tracked=""
+fi
 if [ -n "$double_tracked" ]; then
   blocked_tracked=()
   while IFS=$'\t' read -r dt_id dt_relpath; do

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -66,18 +66,24 @@ fi
 
 # --- Double-tracked notes (readable + obfuscated both tracked) ---
 
-double_tracked=$(detect_double_tracked_notes "$TARGET_DIR" "$NOTES_DIR" 2>/dev/null) || true
+double_tracked=""
+if ! double_tracked=$(detect_double_tracked_notes "$TARGET_DIR" "$NOTES_DIR" 2>/dev/null); then
+  double_tracked=""
+fi
 double_tracked_count=0
 if [ -n "$double_tracked" ]; then
-  double_tracked_count=$(printf '%s\n' "$double_tracked" | grep -c . || true)
+  double_tracked_count=$(printf '%s\n' "$double_tracked" | wc -l | tr -d ' ')
 fi
 
 # --- Unmerged encrypted/obfuscated note content conflicts ---
 
-unmerged_content_conflicts=$(notes_conflict_records "$TARGET_DIR" "$NOTES_DIR" allow-unmapped 2>/dev/null) || true
+unmerged_content_conflicts=""
+if ! unmerged_content_conflicts=$(notes_conflict_records "$TARGET_DIR" "$NOTES_DIR" allow-unmapped 2>/dev/null); then
+  unmerged_content_conflicts=""
+fi
 unmerged_content_conflict_count=0
 if [ -n "$unmerged_content_conflicts" ]; then
-  unmerged_content_conflict_count=$(printf '%s\n' "$unmerged_content_conflicts" | grep -c . || true)
+  unmerged_content_conflict_count=$(printf '%s\n' "$unmerged_content_conflicts" | wc -l | tr -d ' ')
 fi
 
 # --- Changes (only when deobfuscated) ---


### PR DESCRIPTION
## Summary

Cleanup after review of Olavo's notes#139/#140 stack: replace newly introduced `|| true` fallbacks around double-tracked/status probes with explicit conditional fallbacks, and use `wc -l` inside non-empty guards for counts.

This keeps behavior unchanged while aligning the touched code with fold's `or-true` pattern.

## Validation

- `bash -n .mise/tasks/stage .mise/tasks/status`
- `git diff --check`
- no added `|| true` in this diff
- `mise run test test/status.bats test/changes.bats test/conflicts.bats` — 84/84 with expected skips
- `mise run test` — 320 BATS with expected skips + 9 pytest

Note: `mise exec shiv:codebase@0.3.0 -- codebase lint:or-true "$PWD"` still fails repo-wide on legacy occurrences; this PR intentionally cleans only the newly touched/introduced cases.
