### PR TITLE
feat: pre-commit guard against double-tracked notes (#51)

### DIFF
--- a/.mise/tasks/install-hooks
+++ b/.mise/tasks/install-hooks
@@ -21,12 +21,14 @@ confirm_destructive "notes install-hooks will install pre-commit, post-commit, p
 
 install_encryption_hook
 install_obfuscation_hook "$notes_dir"
+install_double_tracking_hook "$notes_dir"
 install_deobfuscation_hook "$notes_dir"
 install_manifest_merge_driver "$notes_dir"
 
 echo "Installed hooks:"
 echo "  pre-commit.d/encryption — rejects plaintext staged encrypted files"
 echo "  pre-commit.d/obfuscation — auto-obfuscates staged readable names"
+echo "  pre-commit.d/verify-double-tracking — refuses commits with double-tracked notes"
 echo "  post-commit.d/deobfuscation — restores readable names after commit"
 echo "  post-merge.d/deobfuscation — restores readable names after pull"
 echo "  post-checkout.d/deobfuscation — reconciles readable names after branch checkout"

--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -124,6 +124,7 @@ fi
 # --- Install hooks ---
 install_encryption_hook
 install_obfuscation_hook "$NOTES_DIR"
+install_double_tracking_hook "$NOTES_DIR"
 install_deobfuscation_hook "$NOTES_DIR"
 install_manifest_merge_driver "$NOTES_DIR"
 echo "  Installed hooks"

--- a/hooks/verify-double-tracking.template
+++ b/hooks/verify-double-tracking.template
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Refuse to commit when readable note names are tracked alongside their
+# obfuscated hex counterparts. See KnickKnackLabs/notes#51 — this state
+# silently drifts content on every subsequent commit.
+set -eo pipefail
+
+NOTES_ROOT="__NOTES_DIR__"
+NOTES_TOOL_ROOT="__NOTES_TOOL_ROOT__"
+
+# shellcheck disable=SC1091
+source "$NOTES_TOOL_ROOT/lib/common.sh"
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+double_tracked=""
+if ! double_tracked=$(detect_double_tracked_notes "$repo_root" "$NOTES_ROOT" 2>/dev/null); then
+  double_tracked=""
+fi
+[ -z "$double_tracked" ] && exit 0
+
+echo "ERROR: double-tracked notes detected; refusing to commit." >&2
+echo "Readable names are tracked in git alongside their obfuscated IDs (notes#51):" >&2
+while IFS=$'\t' read -r dt_id dt_relpath; do
+  [ -z "$dt_id" ] && continue
+  echo "  $NOTES_ROOT/$dt_relpath (also tracked as $NOTES_ROOT/$dt_id)" >&2
+done <<< "$double_tracked"
+echo "" >&2
+echo "This causes silent content drift. To fix:" >&2
+echo "  1. Decide which version is correct (readable vs hex)." >&2
+echo "  2. Run: git rm --cached $NOTES_ROOT/<readable>" >&2
+echo "  3. Commit the untrack, then retry your commit." >&2
+exit 1

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -58,6 +58,19 @@ install_obfuscation_hook() {
   chmod +x "$target"
 }
 
+# Install the double-tracking pre-commit guard.
+# Refuses commits while a readable note and its obfuscated counterpart are
+# both tracked in the index. See KnickKnackLabs/notes#51.
+install_double_tracking_hook() {
+  local notes_dir="${1:-notes}"
+  ensure_hook_dispatcher pre-commit
+  # Name sorts after `obfuscation` so the auto-obfuscation hook can fix a
+  # naively-staged readable before this guard runs.
+  local target="$TARGET_DIR/.git/hooks/pre-commit.d/verify-double-tracking"
+  _render_notes_hook_template "$HOOKS_DIR/verify-double-tracking.template" "$notes_dir" > "$target"
+  chmod +x "$target"
+}
+
 # Install the manifest merge driver.
 # Configures git to use our custom merge driver for .manifest files.
 install_manifest_merge_driver() {

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -546,3 +546,26 @@ run_double_tracking_hook() {
   [ -x "$TARGET_DIR/.git/hooks/pre-commit.d/verify-double-tracking" ]
   grep -q "double-tracked notes detected" "$TARGET_DIR/.git/hooks/pre-commit.d/verify-double-tracking"
 }
+
+@test "pre-commit dispatcher lets obfuscation fix staged readable before double-tracking check (#51)" {
+  notes setup --yes
+  local fpr
+  fpr=$(generate_test_key "$GNUPGHOME")
+  notes add-user -- --gpg-key "$fpr"
+
+  mkdir -p "$TARGET_DIR/notes"
+  printf '# Alpha\n' > "$TARGET_DIR/notes/alpha.md"
+  git -C "$TARGET_DIR" add notes/alpha.md
+
+  run git -C "$TARGET_DIR" commit -m "add alpha"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Auto-obfuscating 1 file(s)"* ]]
+  [[ "$output" != *"double-tracked notes detected"* ]]
+
+  local id
+  id=$(awk '$2 == "alpha.md" { print $1 }' "$TARGET_DIR/notes/.manifest")
+  [ -n "$id" ]
+  git -C "$TARGET_DIR" cat-file -e "HEAD:notes/$id"
+  git -C "$TARGET_DIR" cat-file -e "HEAD:notes/.manifest"
+  ! git -C "$TARGET_DIR" cat-file -e "HEAD:notes/alpha.md" 2>/dev/null
+}

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -497,3 +497,52 @@ run_encryption_hook() {
   run_encryption_hook
   [ "$status" -eq 0 ]
 }
+
+# --- double-tracking pre-commit hook (#51) ---
+run_double_tracking_hook() {
+  run bash -c "cd '$TARGET_DIR' && bash .git/hooks/pre-commit.d/verify-double-tracking"
+}
+
+@test "double-tracking hook passes when no manifest exists (#51)" {
+  notes setup --yes
+  # Fresh repo with .manifest absent: nothing to compare against.
+  rm -f "$TARGET_DIR/notes/.manifest"
+
+  run_double_tracking_hook
+  [ "$status" -eq 0 ]
+}
+
+@test "double-tracking hook passes when only obfuscated paths are tracked (#51)" {
+  notes setup --yes
+  printf 'aaaaaaaa\talpha.md\n' > "$TARGET_DIR/notes/.manifest"
+  echo "# Alpha" > "$TARGET_DIR/notes/aaaaaaaa"
+  git -C "$TARGET_DIR" add -A
+  git -C "$TARGET_DIR" commit -q --no-verify -m "init"
+
+  run_double_tracking_hook
+  [ "$status" -eq 0 ]
+}
+
+@test "double-tracking hook blocks commit when readable + obfuscated both tracked (#51)" {
+  notes setup --yes
+  printf 'aaaaaaaa\talpha.md\n' > "$TARGET_DIR/notes/.manifest"
+  echo "# Alpha readable" > "$TARGET_DIR/notes/alpha.md"
+  echo "# Alpha obfuscated" > "$TARGET_DIR/notes/aaaaaaaa"
+  # Force-add the readable past the local exclude rules to simulate the bug.
+  git -C "$TARGET_DIR" add -f notes/alpha.md
+  git -C "$TARGET_DIR" add notes/.manifest notes/aaaaaaaa
+  git -C "$TARGET_DIR" commit -q --no-verify -m "double-tracked baseline"
+
+  run_double_tracking_hook
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"double-tracked"* ]]
+  [[ "$output" == *"notes/alpha.md"* ]]
+  [[ "$output" == *"notes/aaaaaaaa"* ]]
+  [[ "$output" == *"git rm --cached"* ]]
+}
+
+@test "double-tracking hook is installed by setup (#51)" {
+  notes setup --yes
+  [ -x "$TARGET_DIR/.git/hooks/pre-commit.d/verify-double-tracking" ]
+  grep -q "double-tracked notes detected" "$TARGET_DIR/.git/hooks/pre-commit.d/verify-double-tracking"
+}


### PR DESCRIPTION
## Summary

Pre-commit guard that refuses commits while a readable note name and its obfuscated hex counterpart are both tracked in git's index — the silent-content-drift bug from #51.

This is the medium-term prevention slice from #51. The short-term detection (#139) surfaces double-tracking in `notes status` and refuses it in `notes stage`. Direct `git commit` still slipped through; this hook closes that gap.

## Changes

- **`hooks/verify-double-tracking.template`** — new pre-commit hook. Sources `lib/common.sh` for the existing `detect_double_tracked_notes()` helper and refuses with remediation steps if any double-tracking is in the index.
- **`lib/hooks.sh`** — adds `install_double_tracking_hook()`. The installed filename (`pre-commit.d/verify-double-tracking`) sorts after `obfuscation`, so the auto-obfuscation hook still gets to fix a naively-staged readable before this final guard fires.
- **`.mise/tasks/setup`** and **`.mise/tasks/install-hooks`** — wire in the new installer.
- **`test/integration.bats`** — 4 new tests: no-manifest pass, obfuscated-only pass, double-tracked block (with remediation message), installer assertion.

## Testing

- `mise run test test/integration.bats` — 4 new tests pass; 5 existing encryption-hook failures are pre-existing GPG-env issues on this machine (same set fails on `origin/main` without my changes).
- `mise run test test/obfuscate.bats` — `installed hooks run notes from installer, not PATH` (test 236) still passes; the hook-name sort order ensures obfuscation can auto-fix before this guard fires.
- Full suite: 323 ok / 22 pre-existing failures (identical set with or without this branch).

## Out of scope

The one-time cleanup audit mentioned in #51 (sweeping across affected repos for existing double-tracked pairs) is intentionally deferred to a follow-up. Detection from #139 already surfaces them in `notes status`; the manual remediation is `git rm --cached <readable>`.

## Related

- Closes the "medium-term prevention" piece of #51.
- Builds on #139 (detection helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)