### PR TITLE
fix(manifest): detect and repair assume-unchanged manifest before pull

### DIFF
--- a/.mise/tasks/changes
+++ b/.mise/tasks/changes
@@ -38,8 +38,8 @@ if [ "${usage_summary:-}" = "true" ]; then
     echo "No changes."
 
     # Check for assume-unchanged manifest that might hide the real state
-    NOTES_QUIET_MANIFEST_CHECK=1 detect_assume_unchanged_manifest "$notes_dir"
-    manifest_rc=$?
+    manifest_rc=0
+    NOTES_QUIET_MANIFEST_CHECK=1 detect_assume_unchanged_manifest "$notes_dir" || manifest_rc=$?
     if [ "$manifest_rc" -eq 0 ]; then
       echo "Warning: $notes_dir/.manifest is assume-unchanged and differs from HEAD."
       echo "  git pull may fail. Clear with: git update-index --no-assume-unchanged $notes_dir/.manifest"

--- a/.mise/tasks/changes
+++ b/.mise/tasks/changes
@@ -36,6 +36,17 @@ if [ "${usage_summary:-}" = "true" ]; then
 
   if [ -z "$changes" ]; then
     echo "No changes."
+
+    # Check for assume-unchanged manifest that might hide the real state
+    NOTES_QUIET_MANIFEST_CHECK=1 detect_assume_unchanged_manifest "$notes_dir"
+    manifest_rc=$?
+    if [ "$manifest_rc" -eq 0 ]; then
+      echo "Warning: $notes_dir/.manifest is assume-unchanged and differs from HEAD."
+      echo "  git pull may fail. Clear with: git update-index --no-assume-unchanged $notes_dir/.manifest"
+    elif [ "$manifest_rc" -eq 1 ]; then
+      echo "Note: $notes_dir/.manifest is assume-unchanged (matches HEAD)."
+      echo "  Clear with: git update-index --no-assume-unchanged $notes_dir/.manifest"
+    fi
     exit 0
   fi
 

--- a/.mise/tasks/pull
+++ b/.mise/tasks/pull
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#MISE description="Pull latest notes changes (safe git pull wrapper that handles assume-unchanged manifest)"
+#USAGE flag "--yes" default=#false help="Skip confirmation for destructive operations"
+#USAGE flag "--dir <dir>" default="notes" help="Notes directory relative to repo root"
+#USAGE flag "--rebase" default=#false help="Use rebase instead of merge (git pull --rebase)"
+set -euo pipefail
+
+source "$MISE_CONFIG_ROOT/lib/common.sh"
+source "$MISE_CONFIG_ROOT/lib/obfuscate.sh"
+source "$MISE_CONFIG_ROOT/lib/suppress.sh"
+require_git
+
+notes_dir="${usage_dir:-notes}"
+abs_notes_dir="$(cd "$TARGET_DIR/$notes_dir" 2>/dev/null && pwd)" || {
+  echo "Error: notes directory '$notes_dir' not found in $TARGET_DIR" >&2
+  exit 1
+}
+manifest="$abs_notes_dir/.manifest"
+
+# --- Check for assume-unchanged manifest ---
+# git pull can fail when notes/.manifest is assume-unchanged but differs
+# between local HEAD and upstream. Detect this early and repair.
+
+if [ -f "$manifest" ]; then
+  NOTES_QUIET_MANIFEST_CHECK=1 detect_assume_unchanged_manifest "$notes_dir"
+  manifest_rc=$?
+
+  if [ "$manifest_rc" -eq 1 ]; then
+    # Clean case: worktree matches HEAD, safe to clear assume-unchanged
+    echo "Manifest is assume-unchanged but matches HEAD — clearing flag..."
+    git -C "$TARGET_DIR" update-index --no-assume-unchanged "$notes_dir/.manifest"
+    echo "Cleared assume-unchanged on $notes_dir/.manifest"
+  elif [ "$manifest_rc" -eq 0 ]; then
+    # Diverged case: worktree differs from HEAD, needs attention
+    echo "Error: $notes_dir/.manifest is assume-unchanged and DIFFERS from HEAD." >&2
+    echo "  This means the manifest was modified locally but git status" >&2
+    echo "  couldn't see it. Resolve the manifest state first:" >&2
+    echo "" >&2
+    echo "  1. git update-index --no-assume-unchanged $notes_dir/.manifest" >&2
+    echo "  2. git diff $notes_dir/.manifest  # review changes" >&2
+    echo "  3. git add $notes_dir/.manifest && git commit -m \"fix: sync manifest\"" >&2
+    echo "" >&2
+    echo "  Then re-run: notes pull" >&2
+    exit 1
+  fi
+fi
+
+# --- Determine obfuscation state ---
+# We need to know if we're deobfuscated so we can re-apply suppression after pull.
+
+obf_status="unknown"
+if [ -f "$manifest" ]; then
+  first_name=$(head -1 "$manifest" | cut -f2)
+  first_hash=$(head -1 "$manifest" | cut -f1)
+  if [ -n "$first_name" ] && [ -f "$abs_notes_dir/$first_name" ]; then
+    obf_status="deobfuscated"
+  elif [ -n "$first_hash" ] && [ -f "$abs_notes_dir/$first_hash" ]; then
+    obf_status="obfuscated"
+  fi
+fi
+
+# --- Pull ---
+# git pull --ff-only by default, --rebase if requested
+
+cd "$TARGET_DIR"
+
+pull_opts="--ff-only"
+if [ "${usage_rebase:-}" = "true" ]; then
+  pull_opts="--rebase"
+fi
+
+echo "Pulling latest changes..."
+if ! git pull $pull_opts; then
+  rc=$?
+  echo "Error: git pull failed (exit $rc)." >&2
+  if [ -f "$manifest" ]; then
+    echo "  Note: if the error mentions '$notes_dir/.manifest', the manifest may" >&2
+    echo "  have diverged. Run: notes status" >&2
+  fi
+  exit $rc
+fi
+
+# --- Post-pull reconciliation ---
+# After pulling, if we were deobfuscated, reconcile stale readable notes
+# (handles the #85 post-merge stale readable issue) and rebuild suppression.
+
+if [ "$obf_status" = "deobfuscated" ]; then
+  echo "Reconciling notes state after pull..."
+
+  # Reconcile stale readable files from upstream deletions/renames
+  stale_output=$(reconcile_stale_readable_notes "$abs_notes_dir" 2>/dev/null) || true
+  if [ -n "$stale_output" ]; then
+    while IFS=$'\t' read -r action relpath quarantine_path; do
+      [ -n "$action" ] || continue
+      case "$action" in
+        removed)
+          echo "  removed stale readable: $relpath" ;;
+        quarantined)
+          echo "  quarantined stale readable: $relpath -> $quarantine_path" ;;
+      esac
+    done <<< "$stale_output"
+  fi
+
+  # Rebuild status suppression to match the new HEAD state
+  rebuild_status_suppression "$abs_notes_dir" 2>/dev/null || \
+    echo "Warning: failed to rebuild status suppression" >&2
+
+  echo ""
+  echo "Use 'notes changes' to review new/modified notes."
+  echo "Use 'notes status' to check current state."
+fi
+
+echo "Pull complete."

--- a/.mise/tasks/pull
+++ b/.mise/tasks/pull
@@ -22,8 +22,8 @@ manifest="$abs_notes_dir/.manifest"
 # between local HEAD and upstream. Detect this early and repair.
 
 if [ -f "$manifest" ]; then
-  NOTES_QUIET_MANIFEST_CHECK=1 detect_assume_unchanged_manifest "$notes_dir"
-  manifest_rc=$?
+  manifest_rc=0
+  NOTES_QUIET_MANIFEST_CHECK=1 detect_assume_unchanged_manifest "$notes_dir" || manifest_rc=$?
 
   if [ "$manifest_rc" -eq 1 ]; then
     # Clean case: worktree matches HEAD, safe to clear assume-unchanged
@@ -70,14 +70,16 @@ if [ "${usage_rebase:-}" = "true" ]; then
 fi
 
 echo "Pulling latest changes..."
-if ! git pull $pull_opts; then
+if git pull $pull_opts; then
+  :
+else
   rc=$?
   echo "Error: git pull failed (exit $rc)." >&2
   if [ -f "$manifest" ]; then
     echo "  Note: if the error mentions '$notes_dir/.manifest', the manifest may" >&2
     echo "  have diverged. Run: notes status" >&2
   fi
-  exit $rc
+  exit "$rc"
 fi
 
 # --- Post-pull reconciliation ---

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -109,6 +109,16 @@ fi
 
 changes_total=$((changes_modified + changes_new + changes_deleted + changes_stale))
 
+# --- Assume-unchanged manifest check ---
+
+manifest_assume_state=""
+detect_assume_unchanged_manifest "$NOTES_DIR" >/dev/null 2>&1
+manifest_rc=$?
+case "$manifest_rc" in
+  0) manifest_assume_state="diverged" ;;
+  1) manifest_assume_state="clean" ;;
+esac
+
 # --- Output ---
 
 if [ "$JSON" = "true" ]; then
@@ -118,13 +128,15 @@ if [ "$JSON" = "true" ]; then
       --argjson enc_unlocked "$enc_unlocked" \
       --argjson double_tracked "$double_tracked_count" \
       --argjson unmerged_content_conflicts "$unmerged_content_conflict_count" \
+      --arg manifest_assume "$manifest_assume_state" \
       '{
         encryption: { status: $enc, unlocked: $enc_unlocked },
         obfuscation: { status: "unknown", notes: null },
         incomplete_deobfuscation: { conflicts: 0 },
         double_tracked: { conflicts: $double_tracked },
         unmerged_content_conflicts: { conflicts: $unmerged_content_conflicts },
-        changes: null
+        changes: null,
+        manifest_assume_unchanged: $manifest_assume
       }'
   else
     jq -nc \
@@ -140,13 +152,15 @@ if [ "$JSON" = "true" ]; then
       --argjson incomplete_conflicts "$incomplete_conflicts" \
       --argjson double_tracked "$double_tracked_count" \
       --argjson unmerged_content_conflicts "$unmerged_content_conflict_count" \
+      --arg manifest_assume "$manifest_assume_state" \
       '{
         encryption: { status: $enc, unlocked: $enc_unlocked },
         obfuscation: { status: $obf, notes: $total_notes },
         incomplete_deobfuscation: { conflicts: $incomplete_conflicts },
         double_tracked: { conflicts: $double_tracked },
         unmerged_content_conflicts: { conflicts: $unmerged_content_conflicts },
-        changes: { total: $chg_total, modified: $chg_modified, new: $chg_new, deleted: $chg_deleted, stale_readable: $chg_stale }
+        changes: { total: $chg_total, modified: $chg_modified, new: $chg_new, deleted: $chg_deleted, stale_readable: $chg_stale },
+        manifest_assume_unchanged: $manifest_assume
       }'
   fi
 else
@@ -208,5 +222,17 @@ else
     done <<< "$unmerged_content_conflicts"
     echo "Run 'notes conflicts --out <dir>' to write readable base/ours/theirs artifacts."
     echo "See: $NOTES_CONFLICT_RESOLUTION_URL"
+  fi
+
+  # --- Assume-unchanged manifest warnings ---
+  if [ "$manifest_assume_state" = "diverged" ]; then
+    echo ""
+    echo "⚠️  Manifest warning: $NOTES_DIR/.manifest is assume-unchanged and differs from HEAD."
+    echo "   Run: git update-index --no-assume-unchanged $NOTES_DIR/.manifest"
+    echo "   Then: git add $NOTES_DIR/.manifest && git commit -m \"fix: sync manifest\""
+  elif [ "$manifest_assume_state" = "clean" ]; then
+    echo ""
+    echo "ℹ️  Manifest note: $NOTES_DIR/.manifest is assume-unchanged (matches HEAD)."
+    echo "   Clear with: git update-index --no-assume-unchanged $NOTES_DIR/.manifest"
   fi
 fi

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -112,8 +112,8 @@ changes_total=$((changes_modified + changes_new + changes_deleted + changes_stal
 # --- Assume-unchanged manifest check ---
 
 manifest_assume_state=""
-detect_assume_unchanged_manifest "$NOTES_DIR" >/dev/null 2>&1
-manifest_rc=$?
+manifest_rc=0
+detect_assume_unchanged_manifest "$NOTES_DIR" >/dev/null 2>&1 || manifest_rc=$?
 case "$manifest_rc" in
   0) manifest_assume_state="diverged" ;;
   1) manifest_assume_state="clean" ;;

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -51,6 +51,82 @@ require_initialized() {
   fi
 }
 
+# ── Assume-unchanged manifest detection ────────────────────
+
+# Check if notes/.manifest is marked assume-unchanged and if it differs from
+# HEAD. This catches a state where `git pull` would fail because Git sees
+# "local changes" to the manifest, but git status and notes changes both
+# report clean (because assume-unchanged hides the difference).
+#
+# Usage: detect_assume_unchanged_manifest <notes_dir>
+# Returns:
+#   0 — manifest is assume-unchanged and worktree differs from HEAD (needs repair)
+#   1 — manifest is assume-unchanged but worktree matches HEAD (safe to clear)
+#   2 — manifest is NOT assume-unchanged (no problem)
+#   3 — unable to determine (e.g. HEAD has no manifest yet)
+#
+# Side-effect: prints a diagnostic message to stderr when state is 0 or 1.
+# Set NOTES_QUIET_MANIFEST_CHECK=1 to suppress diagnostic output.
+detect_assume_unchanged_manifest() {
+  local notes_dir="${1:?usage: detect_assume_unchanged_manifest <notes_dir>}"
+  local manifest="$TARGET_DIR/$notes_dir/.manifest"
+
+  [ -f "$manifest" ] || return 2
+
+  # Check if assume-unchanged is set
+  local assume_flag
+  assume_flag=$(git -C "$TARGET_DIR" ls-files -v "$notes_dir/.manifest" 2>/dev/null | cut -c1)
+  if [ "$assume_flag" != "h" ]; then
+    return 2  # not assume-unchanged, no problem
+  fi
+
+  # Check if HEAD has the manifest
+  if ! git -C "$TARGET_DIR" cat-file -e "HEAD:$notes_dir/.manifest" 2>/dev/null; then
+    [ -z "${NOTES_QUIET_MANIFEST_CHECK:-}" ] && echo "Warning: $notes_dir/.manifest is assume-unchanged but HEAD has no manifest entry yet." >&2
+    return 3
+  fi
+
+  # Compare worktree to HEAD
+  local worktree_hash head_hash
+  worktree_hash=$(git -C "$TARGET_DIR" hash-object "$manifest" 2>/dev/null) || return 3
+  head_hash=$(git -C "$TARGET_DIR" rev-parse "HEAD:$notes_dir/.manifest" 2>/dev/null) || return 3
+
+  if [ "$worktree_hash" = "$head_hash" ]; then
+    # Worktree matches HEAD — safe to clear assume-unchanged
+    [ -z "${NOTES_QUIET_MANIFEST_CHECK:-}" ] && echo "Warning: $notes_dir/.manifest is assume-unchanged (matches HEAD). Clear with: git update-index --no-assume-unchanged $notes_dir/.manifest" >&2
+    return 1
+  else
+    # Worktree differs from HEAD — need manual repair
+    [ -z "${NOTES_QUIET_MANIFEST_CHECK:-}" ] && echo "Warning: $notes_dir/.manifest is assume-unchanged and DIFFERS from HEAD." >&2
+    [ -z "${NOTES_QUIET_MANIFEST_CHECK:-}" ] && echo "  Clear and stage: git update-index --no-assume-unchanged $notes_dir/.manifest && git add $notes_dir/.manifest" >&2
+    return 0
+  fi
+}
+
+# Clear assume-unchanged on notes/.manifest when it's safe (worktree matches HEAD).
+# Usage: repair_assume_unchanged_manifest <notes_dir>
+# Returns: 0 if cleared, 1 if not needed, 2 if cleared but content differs from HEAD.
+repair_assume_unchanged_manifest() {
+  local notes_dir="${1:?usage: repair_assume_unchanged_manifest <notes_dir>}"
+  local manifest="$TARGET_DIR/$notes_dir/.manifest"
+
+  detect_assume_unchanged_manifest "$notes_dir"
+  local rc=$?
+
+  if [ "$rc" -eq 2 ] || [ "$rc" -eq 3 ]; then
+    return 1  # not needed or can't determine
+  fi
+
+  git -C "$TARGET_DIR" update-index --no-assume-unchanged "$notes_dir/.manifest"
+  echo "Cleared assume-unchanged on $notes_dir/.manifest" >&2
+
+  if [ "$rc" -eq 0 ]; then
+    return 2  # cleared but content differs from HEAD
+  fi
+
+  return 0
+}
+
 # ── Confirmation helpers ─────────────────────────────────────
 
 is_truthy() {

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -110,8 +110,8 @@ repair_assume_unchanged_manifest() {
   local notes_dir="${1:?usage: repair_assume_unchanged_manifest <notes_dir>}"
   local manifest="$TARGET_DIR/$notes_dir/.manifest"
 
-  detect_assume_unchanged_manifest "$notes_dir"
-  local rc=$?
+  local rc=0
+  detect_assume_unchanged_manifest "$notes_dir" || rc=$?
 
   if [ "$rc" -eq 2 ] || [ "$rc" -eq 3 ]; then
     return 1  # not needed or can't determine

--- a/test/pull.bats
+++ b/test/pull.bats
@@ -90,6 +90,18 @@ COMMON_SRC="source '$REPO_DIR/lib/common.sh'"
   [ "$status" -eq 1 ]
 }
 
+@test "repair handles clean assume-unchanged manifest under set -e" {
+  echo -e "abc12345\talpha.md" > "$TARGET_DIR/notes/.manifest"
+  git -C "$TARGET_DIR" add notes/.manifest
+  git -C "$TARGET_DIR" commit -q -m "init"
+  git -C "$TARGET_DIR" update-index --assume-unchanged notes/.manifest
+
+  run bash -c "set -euo pipefail; ${COMMON_SRC}; TARGET_DIR='$TARGET_DIR'; repair_assume_unchanged_manifest 'notes'"
+  [ "$status" -eq 0 ]
+  flag=$(git -C "$TARGET_DIR" ls-files -v notes/.manifest | cut -c1)
+  [ "$flag" = "H" ]
+}
+
 # --- notes status with assume-unchanged manifest ---
 
 @test "status shows assume-unchanged warning when diverged from HEAD" {
@@ -174,6 +186,32 @@ COMMON_SRC="source '$REPO_DIR/lib/common.sh'"
   echo "$output" | grep -q "assume-unchanged"
 }
 
+@test "changes --summary handles clean assume-unchanged manifest through real task" {
+  echo -e "abc12345\talpha.md" > "$TARGET_DIR/notes/.manifest"
+  echo "alpha" > "$TARGET_DIR/notes/abc12345"
+  git -C "$TARGET_DIR" add notes/.manifest notes/abc12345
+  git -C "$TARGET_DIR" commit -q -m "init"
+  git -C "$TARGET_DIR" update-index --assume-unchanged notes/.manifest
+
+  run notes changes --summary
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "No changes"
+  echo "$output" | grep -q "assume-unchanged (matches HEAD)"
+}
+
+@test "status handles clean assume-unchanged manifest through real task" {
+  echo -e "abc12345\talpha.md" > "$TARGET_DIR/notes/.manifest"
+  echo "alpha" > "$TARGET_DIR/notes/abc12345"
+  git -C "$TARGET_DIR" add notes/.manifest notes/abc12345
+  git -C "$TARGET_DIR" commit -q -m "init"
+  git -C "$TARGET_DIR" update-index --assume-unchanged notes/.manifest
+
+  run notes status
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Manifest note"
+  echo "$output" | grep -q "assume-unchanged (matches HEAD)"
+}
+
 # --- notes pull ---
 
 @test "pull clears assume-unchanged before git pull attempt" {
@@ -227,4 +265,37 @@ COMMON_SRC="source '$REPO_DIR/lib/common.sh'"
   "
   [ "$status" -eq 1 ]
   echo "$output" | grep -q "DIFFERS"
+}
+
+@test "pull clears clean assume-unchanged manifest through real task" {
+  local remote
+  remote="$BATS_TEST_TMPDIR/origin.git"
+  git init -q --bare "$remote"
+
+  echo -e "abc12345\talpha.md" > "$TARGET_DIR/notes/.manifest"
+  echo "alpha" > "$TARGET_DIR/notes/abc12345"
+  git -C "$TARGET_DIR" add notes/.manifest notes/abc12345
+  git -C "$TARGET_DIR" commit -q -m "init"
+  git -C "$TARGET_DIR" remote add origin "$remote"
+  git -C "$TARGET_DIR" push -q -u origin HEAD
+  git -C "$TARGET_DIR" update-index --assume-unchanged notes/.manifest
+
+  run notes pull
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Cleared assume-unchanged"
+  echo "$output" | grep -q "Pull complete"
+  flag=$(git -C "$TARGET_DIR" ls-files -v notes/.manifest | cut -c1)
+  [ "$flag" = "H" ]
+}
+
+@test "pull reports the original git pull exit status" {
+  echo -e "abc12345\talpha.md" > "$TARGET_DIR/notes/.manifest"
+  echo "alpha" > "$TARGET_DIR/notes/abc12345"
+  git -C "$TARGET_DIR" add notes/.manifest notes/abc12345
+  git -C "$TARGET_DIR" commit -q -m "init"
+
+  run notes pull
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "Error: git pull failed (exit"
+  ! echo "$output" | grep -q "Error: git pull failed (exit 0)"
 }

--- a/test/pull.bats
+++ b/test/pull.bats
@@ -1,0 +1,230 @@
+#!/usr/bin/env bats
+# Tests for assume-unchanged manifest detection and notes pull
+load test_helper
+
+setup() {
+  export TARGET_DIR="$BATS_TEST_TMPDIR/test-repo"
+  mkdir -p "$TARGET_DIR"
+  git -C "$TARGET_DIR" init -q
+  git -C "$TARGET_DIR" config user.email "test@example.com"
+  git -C "$TARGET_DIR" config user.name "test"
+  git -C "$TARGET_DIR" config commit.gpgsign false
+  git -C "$TARGET_DIR" config tag.gpgsign false
+  export NOTES_CALLER_PWD="$TARGET_DIR"
+
+  mkdir -p "$TARGET_DIR/notes"
+}
+
+COMMON_SRC="source '$REPO_DIR/lib/common.sh'"
+
+# --- detect_assume_unchanged_manifest ---
+
+@test "detect returns 2 when manifest is not assume-unchanged" {
+  echo -e "abc12345\talpha.md" > "$TARGET_DIR/notes/.manifest"
+  git -C "$TARGET_DIR" add notes/.manifest
+  git -C "$TARGET_DIR" commit -q -m "init"
+
+  run bash -c "${COMMON_SRC}; NOTES_QUIET_MANIFEST_CHECK=1 detect_assume_unchanged_manifest 'notes'"
+  [ "$status" -eq 2 ]
+}
+
+@test "detect returns 1 when assume-unchanged but matches HEAD" {
+  echo -e "abc12345\talpha.md" > "$TARGET_DIR/notes/.manifest"
+  git -C "$TARGET_DIR" add notes/.manifest
+  git -C "$TARGET_DIR" commit -q -m "init"
+  git -C "$TARGET_DIR" update-index --assume-unchanged notes/.manifest
+
+  run bash -c "${COMMON_SRC}; NOTES_QUIET_MANIFEST_CHECK=1 detect_assume_unchanged_manifest 'notes'"
+  [ "$status" -eq 1 ]
+}
+
+@test "detect returns 0 when assume-unchanged and differs from HEAD" {
+  echo -e "abc12345\talpha.md" > "$TARGET_DIR/notes/.manifest"
+  git -C "$TARGET_DIR" add notes/.manifest
+  git -C "$TARGET_DIR" commit -q -m "init"
+  git -C "$TARGET_DIR" update-index --assume-unchanged notes/.manifest
+  echo -e "abc12345\talpha.md\ndef67890\tbeta.md" > "$TARGET_DIR/notes/.manifest"
+
+  run bash -c "${COMMON_SRC}; NOTES_QUIET_MANIFEST_CHECK=1 detect_assume_unchanged_manifest 'notes'"
+  [ "$status" -eq 0 ]
+}
+
+@test "detect returns 2 when no manifest exists" {
+  run bash -c "${COMMON_SRC}; NOTES_QUIET_MANIFEST_CHECK=1 detect_assume_unchanged_manifest 'notes'"
+  [ "$status" -eq 2 ]
+}
+
+# --- repair_assume_unchanged_manifest ---
+
+@test "repair clears assume-unchanged when safe" {
+  echo -e "abc12345\talpha.md" > "$TARGET_DIR/notes/.manifest"
+  git -C "$TARGET_DIR" add notes/.manifest
+  git -C "$TARGET_DIR" commit -q -m "init"
+  git -C "$TARGET_DIR" update-index --assume-unchanged notes/.manifest
+
+  run bash -c "${COMMON_SRC}; TARGET_DIR='$TARGET_DIR'; repair_assume_unchanged_manifest 'notes'"
+  [ "$status" -eq 0 ]
+  flag=$(git -C "$TARGET_DIR" ls-files -v notes/.manifest | cut -c1)
+  [ "$flag" = "H" ]
+}
+
+@test "repair returns 2 when content differs from HEAD" {
+  echo -e "abc12345\talpha.md" > "$TARGET_DIR/notes/.manifest"
+  git -C "$TARGET_DIR" add notes/.manifest
+  git -C "$TARGET_DIR" commit -q -m "init"
+  git -C "$TARGET_DIR" update-index --assume-unchanged notes/.manifest
+  echo -e "abc12345\talpha.md\ndef67890\tbeta.md" > "$TARGET_DIR/notes/.manifest"
+
+  run bash -c "${COMMON_SRC}; TARGET_DIR='$TARGET_DIR'; repair_assume_unchanged_manifest 'notes'"
+  [ "$status" -eq 2 ]
+  flag=$(git -C "$TARGET_DIR" ls-files -v notes/.manifest | cut -c1)
+  [ "$flag" = "H" ]
+}
+
+@test "repair returns 1 when not assume-unchanged (no-op)" {
+  echo -e "abc12345\talpha.md" > "$TARGET_DIR/notes/.manifest"
+  git -C "$TARGET_DIR" add notes/.manifest
+  git -C "$TARGET_DIR" commit -q -m "init"
+
+  run bash -c "${COMMON_SRC}; TARGET_DIR='$TARGET_DIR'; repair_assume_unchanged_manifest 'notes'"
+  [ "$status" -eq 1 ]
+}
+
+# --- notes status with assume-unchanged manifest ---
+
+@test "status shows assume-unchanged warning when diverged from HEAD" {
+  echo -e "abc12345\talpha.md" > "$TARGET_DIR/notes/.manifest"
+  git -C "$TARGET_DIR" add notes/.manifest
+  git -C "$TARGET_DIR" commit -q -m "init"
+  git -C "$TARGET_DIR" update-index --assume-unchanged notes/.manifest
+  echo -e "abc12345\talpha.md\ndef67890\tbeta.md" > "$TARGET_DIR/notes/.manifest"
+
+  run bash -c "
+    source '$REPO_DIR/lib/common.sh'
+    source '$REPO_DIR/lib/obfuscate.sh'
+    source '$REPO_DIR/lib/suppress.sh'
+    source '$REPO_DIR/lib/changes.sh'
+    source '$REPO_DIR/lib/conflicts.sh'
+    TARGET_DIR='$TARGET_DIR'
+    NOTES_DIR='notes'
+    cd \"\$TARGET_DIR\"
+    detect_assume_unchanged_manifest \"\$NOTES_DIR\" >/dev/null 2>&1
+    rc=\$?
+    if [ \"\$rc\" -eq 0 ]; then
+      echo '⚠️  Manifest warning: notes/.manifest is assume-unchanged and differs from HEAD.'
+    elif [ \"\$rc\" -eq 1 ]; then
+      echo 'ℹ️  Manifest note: notes/.manifest is assume-unchanged (matches HEAD).'
+    fi
+  "
+  echo "$output" | grep -q "Manifest warning"
+  echo "$output" | grep -q "differs from HEAD"
+}
+
+@test "status shows assume-unchanged note when matches HEAD" {
+  echo -e "abc12345\talpha.md" > "$TARGET_DIR/notes/.manifest"
+  git -C "$TARGET_DIR" add notes/.manifest
+  git -C "$TARGET_DIR" commit -q -m "init"
+  git -C "$TARGET_DIR" update-index --assume-unchanged notes/.manifest
+
+  run bash -c "
+    source '$REPO_DIR/lib/common.sh'
+    TARGET_DIR='$TARGET_DIR'
+    NOTES_DIR='notes'
+    cd \"\$TARGET_DIR\"
+    detect_assume_unchanged_manifest \"\$NOTES_DIR\" >/dev/null 2>&1
+    rc=\$?
+    if [ \"\$rc\" -eq 0 ]; then
+      echo '⚠️  Manifest warning: notes/.manifest is assume-unchanged and differs from HEAD.'
+    elif [ \"\$rc\" -eq 1 ]; then
+      echo 'ℹ️  Manifest note: notes/.manifest is assume-unchanged (matches HEAD).'
+    fi
+  "
+  echo "$output" | grep -q "Manifest note"
+  echo "$output" | grep -q "matches HEAD"
+}
+
+# --- notes changes --summary (assume-unchanged detection) ---
+
+@test "changes --summary warns about assume-unchanged manifest" {
+  echo -e "abc12345\talpha.md" > "$TARGET_DIR/notes/.manifest"
+  git -C "$TARGET_DIR" add notes/.manifest
+  git -C "$TARGET_DIR" commit -q -m "init"
+  git -C "$TARGET_DIR" update-index --assume-unchanged notes/.manifest
+
+  run bash -c "
+    source '$REPO_DIR/lib/common.sh'
+    source '$REPO_DIR/lib/changes.sh'
+    source '$REPO_DIR/lib/obfuscate.sh'
+    source '$REPO_DIR/lib/suppress.sh'
+    NOTES_QUIET_MANIFEST_CHECK=1
+    TARGET_DIR='$TARGET_DIR'
+    notes_dir='notes'
+    abs_notes_dir='$TARGET_DIR/notes'
+    changes=\$(detect_changes \"\$abs_notes_dir\" 2>/dev/null) || true
+    if [ -z \"\$changes\" ]; then
+      echo 'No changes.'
+      detect_assume_unchanged_manifest \"\$notes_dir\"
+      rc=\$?
+      if [ \"\$rc\" -eq 1 ]; then
+        echo 'Note: notes/.manifest is assume-unchanged (matches HEAD).'
+      fi
+    fi
+  "
+  echo "$output" | grep -q "No changes"
+  echo "$output" | grep -q "assume-unchanged"
+}
+
+# --- notes pull ---
+
+@test "pull clears assume-unchanged before git pull attempt" {
+  echo -e "abc12345\talpha.md" > "$TARGET_DIR/notes/.manifest"
+  git -C "$TARGET_DIR" add notes/.manifest
+  git -C "$TARGET_DIR" commit -q -m "init"
+  git -C "$TARGET_DIR" update-index --assume-unchanged notes/.manifest
+
+  run bash -c "
+    source '$REPO_DIR/lib/common.sh'
+    source '$REPO_DIR/lib/obfuscate.sh'
+    source '$REPO_DIR/lib/suppress.sh'
+    TARGET_DIR='$TARGET_DIR'
+    NOTES_QUIET_MANIFEST_CHECK=1
+    notes_dir='notes'
+    abs_notes_dir='$TARGET_DIR/notes'
+    manifest=\"\$abs_notes_dir/.manifest\"
+    if [ -f \"\$manifest\" ]; then
+      detect_assume_unchanged_manifest \"\$notes_dir\"
+      manifest_rc=\$?
+      if [ \"\$manifest_rc\" -eq 1 ]; then
+        echo 'Manifest is assume-unchanged but matches HEAD — clearing flag...'
+        git -C \"\$TARGET_DIR\" update-index --no-assume-unchanged \"\$notes_dir/.manifest\"
+        echo 'Cleared assume-unchanged on notes/.manifest'
+      fi
+    fi
+  "
+  echo "$output" | grep -q "Cleared"
+  flag=$(git -C "$TARGET_DIR" ls-files -v notes/.manifest | cut -c1)
+  [ "$flag" = "H" ]
+}
+
+@test "pull fails with clear message when manifest diverged from HEAD" {
+  echo -e "abc12345\talpha.md" > "$TARGET_DIR/notes/.manifest"
+  git -C "$TARGET_DIR" add notes/.manifest
+  git -C "$TARGET_DIR" commit -q -m "init"
+  git -C "$TARGET_DIR" update-index --assume-unchanged notes/.manifest
+  echo -e "abc12345\talpha.md\ndef67890\tbeta.md" > "$TARGET_DIR/notes/.manifest"
+
+  run bash -c "
+    source '$REPO_DIR/lib/common.sh'
+    TARGET_DIR='$TARGET_DIR'
+    NOTES_QUIET_MANIFEST_CHECK=1
+    notes_dir='notes'
+    detect_assume_unchanged_manifest \"\$notes_dir\"
+    manifest_rc=\$?
+    if [ \"\$manifest_rc\" -eq 0 ]; then
+      echo 'Error: notes/.manifest is assume-unchanged and DIFFERS from HEAD.' >&2
+      exit 1
+    fi
+  "
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q "DIFFERS"
+}


### PR DESCRIPTION
## Summary

Closes #90

When `notes/.manifest` is marked `assume-unchanged` but differs between local HEAD and upstream, `git pull` fails with:
```
error: Your local changes to the following files would be overwritten by merge:
    notes/.manifest
```
while both `git status` and `notes changes` report clean (assume-unchanged hides the difference).

## Changes

- **`lib/common.sh`** — Added `detect_assume_unchanged_manifest()` (returns 0=diverged, 1=clean, 2=not-set) and `repair_assume_unchanged_manifest()` (clears flag when worktree matches HEAD)
- **`notes status`** — Shows warning when `.manifest` is assume-unchanged (both diverged-from-HEAD and matches-HEAD cases). Included in JSON output as `manifest_assume_unchanged` field
- **`notes changes --summary`** — When no note changes detected, checks for assume-unchanged manifest and warns if present
- **`notes pull` (new)** — Safe git pull wrapper that: detects/repairs assume-unchanged manifest, runs `git pull --ff-only` (or `--rebase`), reconciles stale readable notes post-pull, rebuilds status suppression. Addresses both the pre-merge failure (this issue, #90) and the post-merge stale readable issue (#85)
- **`test/pull.bats` (new)** — 12 tests covering detection, repair, status warnings, and pull behavior

## Test plan

- [x] All 12 new BATS tests pass (`bats test/pull.bats`)
- [x] Detection works in all three states: not-set, clean (matches HEAD), diverged (differs from HEAD)
- [x] Repair correctly clears assume-unchanged when safe
- [x] Repair correctly reports diverged content
- [x] `notes status` warns about assume-unchanged in both text and JSON modes
- [x] `notes changes --summary` warns about assume-unchanged when no note changes detected