### PR TITLE
Fix verify-blobs for large encrypted notes

### DIFF
--- a/.mise/tasks/verify-blobs
+++ b/.mise/tasks/verify-blobs
@@ -40,7 +40,14 @@ error_paths=()
 # ── Helper: check if a blob at <ref>:<path> has git-crypt magic bytes ──
 _check_encrypted() {
   local r="$1" p="$2" header_hex
-  if ! header_hex=$(git show "$r:$p" 2>/dev/null | dd bs=1 count=10 2>/dev/null | od -An -tx1 | tr -d ' \n'); then
+  # Drain the blob after capturing its header so large objects do not send the
+  # git producer SIGPIPE under this task's pipefail setting.
+  if ! header_hex=$(
+    git cat-file blob "$r:$p" 2>/dev/null |
+      { dd bs=1 count=10 2>/dev/null; cat >/dev/null; } |
+      od -An -tx1 |
+      tr -d ' \n'
+  ); then
     return 1
   fi
   [ "$header_hex" = "$gitcrypt_header_hex" ]

--- a/test/verify-blobs.bats
+++ b/test/verify-blobs.bats
@@ -20,6 +20,19 @@ load test_helper
   echo "$output" | grep -q "OK"
 }
 
+@test "verify-blobs: large encrypted blob passes" {
+  mkdir -p "$NOTES_CALLER_PWD/notes"
+  printf '\x00GITCRYPT\x00aaa00001\talpha.md\n' > "$NOTES_CALLER_PWD/notes/.manifest"
+  printf '\x00GITCRYPT\x00' > "$NOTES_CALLER_PWD/notes/aaa00001"
+  dd if=/dev/zero bs=1024 count=128 2>/dev/null >> "$NOTES_CALLER_PWD/notes/aaa00001"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "large encrypted blob"
+
+  run notes verify-blobs
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "OK"
+}
+
 @test "verify-blobs: plaintext manifest fails" {
   mkdir -p "$NOTES_CALLER_PWD/notes"
   echo -e "aaa00001\talpha.md" > "$NOTES_CALLER_PWD/notes/.manifest"


### PR DESCRIPTION
## Summary

Fix `notes verify-blobs` falsely reporting sufficiently large encrypted note blobs as plaintext.

With `set -o pipefail`, the existing `git show | dd count=10` header check lets `dd` exit after ten bytes. For blobs larger than the pipe buffer, Git then receives SIGPIPE (status 141), causing `_check_encrypted` to return failure even though the captured header is exactly `\0GITCRYPT\0`.

The check now captures the first ten bytes while draining the rest of the blob, preserving real producer failures without triggering SIGPIPE. A 128 KiB regression fixture fails on main and passes with this change.

## Validation

- `bats test/verify-blobs.bats` — 17/17 passed
- fixed task against `ricon-family/fold` — all 421 committed note blobs passed under `--strict`
- shellcheck (excluding the existing dynamic-source SC1091)
- `git diff --check`
- signed commit verified locally

## Full-suite note

A full `bats test` attempt reached test 237/364 before the 300-second local timeout. One unrelated date/tags test failed during that run, then passed in isolation. The targeted suite is green; hosted CI should provide the complete run.
