### PR TITLE
perf: batch status suppression index updates

### DIFF
--- a/lib/suppress.sh
+++ b/lib/suppress.sh
@@ -197,6 +197,14 @@ _rewrite_exclude_block() {
   mv -f "$tmp" "$exclude_file"
 }
 
+# Apply an index flag to newline-delimited paths in one Git process. Managed
+# obfuscated IDs cannot contain newlines, so update-index --stdin is safe here.
+_update_index_paths() {
+  local repo_root="${1:?usage: _update_index_paths <repo_root> <flag>}"
+  local flag="${2:?usage: _update_index_paths <repo_root> <flag>}"
+  git -C "$repo_root" update-index "$flag" --stdin 2>/dev/null || true
+}
+
 # Set assume-unchanged on obfuscated paths + add exclude entries for readable names.
 # Call after deobfuscating.
 # Usage: set_status_suppression <abs_notes_dir> [id...]
@@ -213,16 +221,12 @@ set_status_suppression() {
   local repo_root="$RESOLVED_REPO_ROOT"
   local notes_dir="$RESOLVED_NOTES_DIR"
 
-  # Set assume-unchanged flags
+  # Set assume-unchanged flags in one index update.
   if [ ${#scoped_ids[@]} -gt 0 ] && [ -n "${scoped_ids[0]}" ]; then
-    for id in "${scoped_ids[@]}"; do
-      git -C "$repo_root" update-index --assume-unchanged "$notes_dir/$id" 2>/dev/null || true
-    done
+    printf '%s\n' "${scoped_ids[@]/#/$notes_dir/}" | _update_index_paths "$repo_root" --assume-unchanged
   else
-    while IFS=$'\t' read -r id relpath; do
-      [ -z "$id" ] && continue
-      git -C "$repo_root" update-index --assume-unchanged "$notes_dir/$id" 2>/dev/null || true
-    done < "$manifest"
+    awk -F '\t' -v prefix="$notes_dir/" '$1 != "" { print prefix $1 }' "$manifest" |
+      _update_index_paths "$repo_root" --assume-unchanged
   fi
 
   # Add exclude entries for readable names
@@ -245,16 +249,12 @@ clear_status_suppression() {
   local repo_root="$RESOLVED_REPO_ROOT"
   local notes_dir="$RESOLVED_NOTES_DIR"
 
-  # Clear assume-unchanged flags
+  # Clear assume-unchanged flags in one index update.
   if [ ${#scoped_ids[@]} -gt 0 ] && [ -n "${scoped_ids[0]}" ]; then
-    for id in "${scoped_ids[@]}"; do
-      git -C "$repo_root" update-index --no-assume-unchanged "$notes_dir/$id" 2>/dev/null || true
-    done
+    printf '%s\n' "${scoped_ids[@]/#/$notes_dir/}" | _update_index_paths "$repo_root" --no-assume-unchanged
   else
-    while IFS=$'\t' read -r id relpath; do
-      [ -z "$id" ] && continue
-      git -C "$repo_root" update-index --no-assume-unchanged "$notes_dir/$id" 2>/dev/null || true
-    done < "$manifest"
+    awk -F '\t' -v prefix="$notes_dir/" '$1 != "" { print prefix $1 }' "$manifest" |
+      _update_index_paths "$repo_root" --no-assume-unchanged
   fi
 
   # Remove exclude entries for readable names
@@ -468,10 +468,8 @@ rebuild_status_suppression() {
     state=$(_deobfuscation_state_file "$abs_notes_dir" 2>/dev/null || true)
   fi
   if [ -n "$state" ] && [ -f "$state" ]; then
-    while IFS= read -r id; do
-      [ -n "$id" ] || continue
-      git -C "$repo_root" update-index --no-assume-unchanged "$notes_dir/$id" 2>/dev/null || true
-    done < <(awk -F '\t' '$1 != "" { print $1 }' "$state" | sort -u)
+    awk -F '\t' -v prefix="$notes_dir/" '$1 != "" { print prefix $1 }' "$state" | sort -u |
+      _update_index_paths "$repo_root" --no-assume-unchanged
   fi
 
   mkdir -p "$(dirname "$exclude_file")"

--- a/lib/suppress.sh
+++ b/lib/suppress.sh
@@ -197,15 +197,22 @@ _rewrite_exclude_block() {
   mv -f "$tmp" "$exclude_file"
 }
 
-# Apply an index flag to newline-delimited paths in one Git process. Managed
-# obfuscated IDs cannot contain newlines, so update-index --stdin is safe here.
-# Filter stale paths first: one missing index entry rejects the entire batch.
+# Apply an index flag to newline-delimited managed paths in one update-index process.
+# Resolve candidates through NUL-delimited Git output so quoted non-ASCII paths
+# stay exact, while missing stale-state paths are omitted from the batch.
 _update_index_paths() {
   local repo_root="${1:?usage: _update_index_paths <repo_root> <flag>}"
   local flag="${2:?usage: _update_index_paths <repo_root> <flag>}"
-  awk 'FILENAME != "-" { indexed[$0]=1; next } indexed[$0]' \
-    <(git -C "$repo_root" ls-files) - |
-    git -C "$repo_root" update-index "$flag" --stdin 2>/dev/null || true
+  local path
+  local paths=()
+
+  while IFS= read -r path; do
+    [ -n "$path" ] && paths+=("$path")
+  done
+  [ ${#paths[@]} -gt 0 ] || return 0
+
+  GIT_LITERAL_PATHSPECS=1 git -C "$repo_root" ls-files -z -- "${paths[@]}" |
+    git -C "$repo_root" update-index "$flag" -z --stdin 2>/dev/null || true
 }
 
 # Set assume-unchanged on obfuscated paths + add exclude entries for readable names.

--- a/lib/suppress.sh
+++ b/lib/suppress.sh
@@ -199,10 +199,13 @@ _rewrite_exclude_block() {
 
 # Apply an index flag to newline-delimited paths in one Git process. Managed
 # obfuscated IDs cannot contain newlines, so update-index --stdin is safe here.
+# Filter stale paths first: one missing index entry rejects the entire batch.
 _update_index_paths() {
   local repo_root="${1:?usage: _update_index_paths <repo_root> <flag>}"
   local flag="${2:?usage: _update_index_paths <repo_root> <flag>}"
-  git -C "$repo_root" update-index "$flag" --stdin 2>/dev/null || true
+  awk 'FILENAME != "-" { indexed[$0]=1; next } indexed[$0]' \
+    <(git -C "$repo_root" ls-files) - |
+    git -C "$repo_root" update-index "$flag" --stdin 2>/dev/null || true
 }
 
 # Set assume-unchanged on obfuscated paths + add exclude entries for readable names.

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -1090,6 +1090,37 @@ EOT
   [[ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" == *"local edit"* ]]
 }
 
+@test "deobfuscate batches full suppression index updates" {
+  notes obfuscate
+  git -C "$NOTES_CALLER_PWD" add -A notes
+  git -C "$NOTES_CALLER_PWD" commit -q -m "obfuscate"
+  notes deobfuscate
+  notes obfuscate
+
+  local mock_bin="$BATS_TEST_TMPDIR/mock-bin"
+  local count_file="$BATS_TEST_TMPDIR/update-index-count"
+  local real_git
+  real_git=$(command -v git)
+  mkdir -p "$mock_bin"
+  cat > "$mock_bin/git" <<'SH'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  if [ "$arg" = "update-index" ]; then
+    printf '.\n' >> "$GIT_UPDATE_INDEX_COUNT"
+    break
+  fi
+done
+exec "$REAL_GIT" "$@"
+SH
+  chmod +x "$mock_bin/git"
+  : > "$count_file"
+
+  PATH="$mock_bin:$PATH" REAL_GIT="$real_git" GIT_UPDATE_INDEX_COUNT="$count_file" notes deobfuscate
+
+  # One batch clears IDs recorded in state and one sets all manifest IDs.
+  [ "$(wc -l < "$count_file" | tr -d ' ')" -eq 2 ]
+}
+
 @test "deobfuscate allows identical readable note copy" {
   notes obfuscate
   local alpha_id

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -1121,6 +1121,29 @@ SH
   [ "$(wc -l < "$count_file" | tr -d ' ')" -eq 2 ]
 }
 
+@test "deobfuscate clears stale indexed IDs when state also names missing IDs" {
+  notes obfuscate
+  git -C "$NOTES_CALLER_PWD" add -A notes
+  git -C "$NOTES_CALLER_PWD" commit -q -m "obfuscate"
+  notes deobfuscate
+
+  local alpha_id state
+  alpha_id=$(grep $'\talpha\.md$' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  state="$NOTES_CALLER_PWD/.git/info/notes-obfuscation-state"
+
+  # Simulate an upstream deletion plus an older state row whose ID is no
+  # longer in the index. The stale alpha ID is still indexed and suppressed.
+  grep -v "^${alpha_id}"$'\t' "$NOTES_CALLER_PWD/notes/.manifest" > "$NOTES_CALLER_PWD/notes/.manifest.tmp"
+  mv "$NOTES_CALLER_PWD/notes/.manifest.tmp" "$NOTES_CALLER_PWD/notes/.manifest"
+  printf 'deadbeef\tmissing.md\tmissing-hash\n' >> "$state"
+
+  notes deobfuscate
+
+  run git -C "$NOTES_CALLER_PWD" ls-files -v "notes/$alpha_id"
+  [[ "$output" == H* ]]
+  [ ! -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+}
+
 @test "deobfuscate allows identical readable note copy" {
   notes obfuscate
   local alpha_id

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -1119,6 +1119,29 @@ SH
 
   # One batch clears IDs recorded in state and one sets all manifest IDs.
   [ "$(wc -l < "$count_file" | tr -d ' ')" -eq 2 ]
+
+  local id relpath
+  while IFS=$'\t' read -r id relpath; do
+    run git -C "$NOTES_CALLER_PWD" ls-files -v "notes/$id"
+    [[ "$output" == h* ]]
+  done < "$NOTES_CALLER_PWD/notes/.manifest"
+}
+
+@test "deobfuscate suppresses indexed IDs under a non-ASCII notes directory" {
+  local notes_dir="nøtes"
+  mv "$NOTES_CALLER_PWD/notes" "$NOTES_CALLER_PWD/$notes_dir"
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "use non-ASCII notes directory"
+
+  notes obfuscate --dir "$notes_dir"
+  git -C "$NOTES_CALLER_PWD" commit -q -m "obfuscate custom directory"
+  notes deobfuscate --dir "$notes_dir"
+
+  local id relpath
+  while IFS=$'\t' read -r id relpath; do
+    run git -C "$NOTES_CALLER_PWD" ls-files -v "$notes_dir/$id"
+    [[ "$output" == h* ]]
+  done < "$NOTES_CALLER_PWD/$notes_dir/.manifest"
 }
 
 @test "deobfuscate clears stale indexed IDs when state also names missing IDs" {


### PR DESCRIPTION
## Summary

- batch `assume-unchanged` index updates through `git update-index --stdin`
- apply the same bounded process shape to scoped/full set, clear, and stale-state rebuild paths
- filter batches against the index so missing/stale state IDs do not reject valid updates
- add process-count and stale/missing-state regressions

## Evidence

Fold currently has 533 manifest IDs and 533 append-only state IDs. The old full post-commit rebuild launched one `git update-index` per state ID to clear suppression, then one per manifest ID to restore it: 1,066 `update-index` processes for this helper alone. The new path makes one `update-index` call for each set and uses one fixed-cost `git ls-files` pass per batch to preserve the old skip-missing behavior.

The process regression creates a three-note lifecycle with prior deobfuscation state and wraps Git to count actual `update-index` executions. It asserts two calls, not elapsed time.

Adversarial validation found that raw `update-index --stdin` aborts the whole batch when one path is absent from the index. The correction filters candidates against the current index first. Its end-to-end regression simulates an upstream deletion plus an append-only state row for an ID absent from the index, and proves a stale indexed ID is still cleared. The regression fails on the original PR head and passes on the corrected head.

## Validation

- focused process-count and missing/stale-state regressions: 2/2 passed
- adjacent scoped, pre/post-commit, dirty/stale-readable, interrupted-batch, and append-only-state tests: 9/9 passed
- `bash -n lib/suppress.sh`: passed
- `git diff --check`: passed
- full `test/obfuscate.bats`: 75/76 passed; the sole failure reproduces on unchanged main and is fixed separately by #156

## Scope

This does not address clean-filter fanout, per-file membership greps, repeated full change detection, unscoped post-commit deobfuscation, exclusion-block O(N²) work, or per-manifest `ls-files` checks. Those are independently causal and should not be conflated with this patch.
