### PR TITLE
test: remove undeclared round-trip dependency

### DIFF
--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -383,14 +383,17 @@ setup() {
 }
 
 @test "round-trip preserves all content and metadata" {
+  local alpha_before beta_before gamma_before
+  alpha_before=$(git -C "$NOTES_CALLER_PWD" hash-object notes/alpha.md)
+  beta_before=$(git -C "$NOTES_CALLER_PWD" hash-object notes/beta.md)
+  gamma_before=$(git -C "$NOTES_CALLER_PWD" hash-object notes/gamma.txt)
+
   notes obfuscate
   notes deobfuscate
 
-  run farts get title "$NOTES_CALLER_PWD/notes/alpha.md"
-  [ "$output" = "Alpha" ]
-
-  run farts get title "$NOTES_CALLER_PWD/notes/beta.md"
-  [ "$output" = "Beta" ]
+  [ "$(git -C "$NOTES_CALLER_PWD" hash-object notes/alpha.md)" = "$alpha_before" ]
+  [ "$(git -C "$NOTES_CALLER_PWD" hash-object notes/beta.md)" = "$beta_before" ]
+  [ "$(git -C "$NOTES_CALLER_PWD" hash-object notes/gamma.txt)" = "$gamma_before" ]
 }
 
 # --- Pre-commit hook ---


### PR DESCRIPTION
## Summary

- remove the round-trip test's undeclared `farts` dependency
- compare exact before/after Git blob hashes for all three fixture notes
- make the assertion match the test's content-and-metadata claim

## Evidence

On unchanged `main` (`b27fa7d47d6bdcbb371a162306f2038d3ce89d33`), the test fails in a clean hosted environment because the `farts` mise shim has no selected version. The failure reproduces both in the full suite and when the test runs alone.

## Validation

- focused `round-trip preserves all content and metadata`: passed
- full `test/obfuscate.bats`: 74/74 passed
- `git diff --check`: passed
