### PR TITLE
chore: add contributor health surface

### DIFF
--- a/.mise/tasks/doctor
+++ b/.mise/tasks/doctor
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#MISE description="Check local development setup"
+#USAGE example "mise run doctor" header="Check convention lints and local hook state"
+set -euo pipefail
+
+repo_dir="${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}"
+codebase_command="${CODEBASE_COMMAND:-codebase}"
+gum_command="${GUM_COMMAND:-gum}"
+separator='|'
+failures=0
+rows=()
+details=()
+
+command_available() {
+  case "$1" in
+    */*) [ -x "$1" ] ;;
+    *) command -v "$1" >/dev/null 2>&1 ;;
+  esac
+}
+
+add_row() {
+  rows+=("$1${separator}$2${separator}$3")
+}
+
+fail_check() {
+  local name="$1"
+  local message="$2"
+  local output="${3:-}"
+
+  add_row "$name" "✗" "$message"
+  if [ -n "$output" ]; then
+    details+=("$name failed output:${output//$'\n'/$'\n  '}")
+  fi
+  failures=$((failures + 1))
+}
+
+if command_available "$codebase_command"; then
+  if lint_output=$(cd "$repo_dir" && "$codebase_command" lint "$repo_dir" 2>&1); then
+    add_row "codebase" "✓" "configured convention lints pass"
+  else
+    fail_check "codebase" "configured convention lints failed" "$lint_output"
+  fi
+
+  if (cd "$repo_dir" && "$codebase_command" pre-commit --check >/dev/null 2>&1); then
+    add_row "pre-commit" "✓" "codebase pre-commit hook is installed"
+  else
+    add_row "pre-commit" "!" "optional local hook missing; run codebase pre-commit"
+  fi
+else
+  fail_check "codebase" "codebase command not found; run mise install"
+  add_row "pre-commit" "!" "codebase unavailable; hook check skipped"
+fi
+
+if command_available "$gum_command"; then
+  printf '%s\n' "${rows[@]}" |
+    "$gum_command" table -s "$separator" -c "CHECK,STATUS,DETAIL" -p --border normal
+else
+  for row in "${rows[@]}"; do
+    IFS="$separator" read -r name status message <<< "$row"
+    printf '%s %s - %s\n' "$status" "$name" "$message"
+  done
+fi
+
+if [ ${#details[@]} -gt 0 ]; then
+  printf '\n'
+  for detail in "${details[@]}"; do
+    printf '%s\n' "$detail"
+  done
+fi
+
+exit "$failures"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing to notes
+
+`notes` is a mise-backed CLI for encrypted Markdown repositories. Changes often
+cross Git, git-crypt, filename obfuscation, and local status-suppression
+boundaries, so preserve those contracts while keeping the command surface
+simple.
+
+## Structure
+
+```text
+notes/
+├── .mise/tasks/       # Public CLI commands and task-local orchestration
+├── hooks/             # Installed Git hook components and templates
+├── lib/               # Shared Bash and Python domain logic
+├── test/              # BATS behavior and integration tests
+├── test/python/       # Focused Python tests
+├── mise.toml          # Tools, settings, and convention lint configuration
+└── README.md          # User-facing command and workflow reference
+```
+
+Task scripts may use `$MISE_CONFIG_ROOT`. Shared libraries must locate their
+own files from `BASH_SOURCE`, and tests derive the repository from
+`$BATS_TEST_DIRNAME`; an agent shell can inherit an unrelated
+`MISE_CONFIG_ROOT` from its launcher.
+
+## Local setup
+
+```bash
+mise trust
+mise install
+mise run doctor
+mise run test
+```
+
+The optional local convention hook is clone-local. Install it when useful:
+
+```bash
+codebase pre-commit
+```
+
+## Tests
+
+Tests call Notes through `mise run` so they exercise Usage parsing, declared
+tools, and the package-scoped `NOTES_CALLER_PWD` contract.
+
+```bash
+mise run test                       # BATS and Python suites
+mise run test changes               # test/changes.bats and matching Python test, if present
+mise run test --filter suppression  # filter BATS test names
+mise run test test/python/test_audit.py
+```
+
+Notes intentionally uses eight BATS workers, including within-file
+parallelism. Several suites contain many independent Git fixtures, so the
+starter template's four-job files-only default is materially slower here.
+Keep mutable fixtures under `$BATS_TEST_TMPDIR`; do not introduce shared test
+repositories, fixed temporary paths, or ambient signing dependencies.
+
+## Encryption and Git safety
+
+Use throwaway repositories for tests. Never run setup, lock, obfuscation, hook,
+or commit tests against a real notes checkout. Keep commits and tags in test
+fixtures unsigned so an ambient agent signing policy cannot affect behavior.
+
+Changes to readable/obfuscated reconciliation must cover interrupted or stale
+states, custom notes directories, spaces and non-ASCII paths where relevant,
+and the Git index flags that hide readable working copies. A faster path is not
+correct if one stale entry can prevent valid entries from being reconciled.
+
+## Validation
+
+Before opening or updating a PR, run the checks that prove the touched surface:
+
+```bash
+mise run doctor
+mise run test
+codebase lint "$PWD"
+git diff --check
+```
+
+Use focused tests during iteration and the complete suite once the change shape
+is stable. Notes currently has no release step in ordinary contribution work;
+merging and tagging require separate maintainer authority.

--- a/README.md
+++ b/README.md
@@ -110,8 +110,14 @@ gh repo clone KnickKnackLabs/notes
 cd notes
 mise trust
 mise install
+mise run doctor
 mise run test
 ```
+
+`mise run doctor` checks the configured codebase conventions and reports the
+optional clone-local pre-commit hook. See [CONTRIBUTING.md](CONTRIBUTING.md) for
+the repository structure, encryption safety boundaries, and full validation
+workflow.
 
 The test suite is BATS-based. Target a subset with:
 

--- a/mise.toml
+++ b/mise.toml
@@ -12,6 +12,15 @@ gum = "0.17.0"
 uv = "0.11.19"
 "aqua:shenwei356/rush" = "0.9.0"
 "shiv:rudi" = "0.5"
+"shiv:codebase" = "0.3"
 # git-crypt has no macOS binary on GitHub releases.
 # macOS: brew install git-crypt
 # Linux: downloaded from GitHub releases by rudi install
+
+[_.codebase]
+lint = [
+  "mise-settings",
+  "bats-test-helper",
+  "mcr-scope",
+  "caller-pwd-contract",
+]

--- a/mise.toml
+++ b/mise.toml
@@ -12,12 +12,13 @@ gum = "0.17.0"
 uv = "0.11.19"
 "aqua:shenwei356/rush" = "0.9.0"
 "shiv:rudi" = "0.5"
-"shiv:codebase" = "0.3"
+"shiv:codebase" = "0.4"
 # git-crypt has no macOS binary on GitHub releases.
 # macOS: brew install git-crypt
 # Linux: downloaded from GitHub releases by rudi install
 
 [_.codebase]
+name = "notes"
 lint = [
   "mise-settings",
   "bats-test-helper",

--- a/test/doctor.bats
+++ b/test/doctor.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+
+load test_helper
+bats_require_minimum_version 1.5.0
+
+setup() {
+  export NOTES_CALLER_PWD="$BATS_TEST_TMPDIR"
+  mock_dir="$BATS_TEST_TMPDIR/mock-bin"
+  codebase_log="$BATS_TEST_TMPDIR/codebase.log"
+  mkdir -p "$mock_dir"
+  export codebase_log
+
+  cat > "$mock_dir/codebase" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$codebase_log"
+case "$1" in
+  lint)
+    printf '%s\n' "${MOCK_LINT_OUTPUT:-configured lints pass}"
+    exit "${MOCK_LINT_STATUS:-0}"
+    ;;
+  pre-commit)
+    exit "${MOCK_HOOK_STATUS:-1}"
+    ;;
+  *) exit 2 ;;
+esac
+SH
+  chmod +x "$mock_dir/codebase"
+
+  export CODEBASE_COMMAND="$mock_dir/codebase"
+  export GUM_COMMAND="$mock_dir/missing-gum"
+  unset MOCK_LINT_OUTPUT MOCK_LINT_STATUS MOCK_HOOK_STATUS
+}
+
+@test "doctor passes with green lints and treats the local hook as optional" {
+  run notes doctor
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✓ codebase - configured convention lints pass"* ]]
+  [[ "$output" == *"! pre-commit - optional local hook missing"* ]]
+  grep -Fx "lint $REPO_DIR" "$codebase_log"
+  grep -Fx "pre-commit --check" "$codebase_log"
+}
+
+@test "doctor reports configured lint failures with their output" {
+  export MOCK_LINT_STATUS=1
+  export MOCK_LINT_OUTPUT="lint failed at example.sh:7"
+
+  run notes doctor
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"✗ codebase - configured convention lints failed"* ]]
+  [[ "$output" == *"codebase failed output:lint failed at example.sh:7"* ]]
+}
+
+@test "doctor fails clearly when the declared checker is unavailable" {
+  export CODEBASE_COMMAND="$mock_dir/missing-codebase"
+
+  run notes doctor
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"✗ codebase - codebase command not found; run mise install"* ]]
+  [[ "$output" == *"! pre-commit - codebase unavailable; hook check skipped"* ]]
+}


### PR DESCRIPTION
## Summary

- add a Notes-specific `CONTRIBUTING.md` with repository structure, test-parallelism rationale, encryption safety boundaries, and validation guidance
- declare `shiv:codebase` locally and enable the four convention rules already clean on current Notes
- add a regression-tested `mise run doctor` surface for configured lints and the optional clone-local pre-commit hook
- link the contributor health path from the README

This is the first gradual Notes-versus-Template parity slice. It deliberately does not pretend the remaining Template rules are already green: `or-true`, `shellcheck`, `gum-table`, and `github-actions` will be enabled by follow-up cleanup and CI slices rather than omitted from the parity destination.

The Template files-only four-job BATS default was also tested rather than copied. On exact Notes base `42f47bcd`, the existing eight-job shape completed in 146.74s, while four jobs with within-file parallelism took 210.39s and Template's files-only shape took 236.53s. Notes therefore documents and preserves its suite-specific parallel contract.

## Validation

- `mise run test doctor` (3 passed)
- `codebase lint "$PWD"` (4 configured rules passed)
- `mise run doctor` (lints pass; optional local hook correctly reported absent)
- full `mise run test` (370 BATS passed; 9 Python passed)
- `bash -n .mise/tasks/doctor`
- `git diff --check`

One full-suite run took an anomalous 331.89s. A focused `changes` repeat was 28.72s on this branch versus 27.20s on main after warm-up, so the large result was not treated as an unsupported performance regression or improvement claim.
