### PR TITLE
ci: validate Notes on macOS and Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,9 @@ jobs:
         run: rudi install
 
       - name: Check whitespace
-        run: git diff --check
+        # A clean checkout has no working-tree diff. Compare the complete tree
+        # with Git's empty tree so committed whitespace errors still fail CI.
+        run: git diff --check "$(git hash-object -t tree /dev/null)" HEAD --
 
       - name: Run tests
         run: mise run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,52 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  GH_TOKEN: ${{ github.token }}
+  GITHUB_TOKEN: ${{ github.token }}
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve mise cache epoch
+        id: mise-cache-epoch
+        run: echo "value=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up mise
+        uses: jdx/mise-action@v4
+        with:
+          install: true
+          cache: true
+          # Bound floating tool and plugin staleness while preserving warm runs.
+          cache_key: mise-v2-${{ steps.mise-cache-epoch.outputs.value }}-{{platform}}-{{file_hash}}
+        env:
+          # Serialize installation without changing test and lint behavior.
+          MISE_JOBS: 1
+
+      - name: Install git-crypt
+        run: rudi install
+
+      - name: Check whitespace
+        run: git diff --check
+
+      - name: Run tests
+        run: mise run test
+
+      - name: Run codebase lints
+        run: codebase lint "$PWD"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ simple.
 
 ```text
 notes/
+├── .github/workflows/ # Hosted macOS and Linux validation
 ├── .mise/tasks/       # Public CLI commands and task-local orchestration
 ├── hooks/             # Installed Git hook components and templates
 ├── lib/               # Shared Bash and Python domain logic
@@ -79,5 +80,6 @@ git diff --check
 ```
 
 Use focused tests during iteration and the complete suite once the change shape
-is stable. Notes currently has no release step in ordinary contribution work;
-merging and tagging require separate maintainer authority.
+is stable. Pull requests and main run the same suite and configured lints on
+macOS and Linux. Notes currently has no release step in ordinary contribution
+work; merging and tagging require separate maintainer authority.

--- a/mise.toml
+++ b/mise.toml
@@ -23,4 +23,5 @@ lint = [
   "bats-test-helper",
   "mcr-scope",
   "caller-pwd-contract",
+  "github-actions",
 ]

--- a/test/ci.bats
+++ b/test/ci.bats
@@ -21,6 +21,11 @@ setup() {
   [ "$install_line" -lt "$test_line" ]
 }
 
+@test "hosted whitespace validation checks committed content" {
+  grep -Fq 'run: git diff --check "$(git hash-object -t tree /dev/null)" HEAD --' "$workflow"
+  ! grep -Eq 'run: git diff --check[[:space:]]*$' "$workflow"
+}
+
 @test "hosted validation runs the repository's configured convention lints" {
   grep -Fq 'run: codebase lint "$PWD"' "$workflow"
 }

--- a/test/ci.bats
+++ b/test/ci.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+load test_helper
+bats_require_minimum_version 1.5.0
+
+setup() {
+  workflow="$REPO_DIR/.github/workflows/test.yml"
+}
+
+@test "hosted validation covers Linux and macOS" {
+  grep -Fq 'os: [ubuntu-latest, macos-latest]' "$workflow"
+  grep -Fq 'runs-on: ${{ matrix.os }}' "$workflow"
+}
+
+@test "hosted tests provision git-crypt through Notes' declared owner" {
+  install_line=$(grep -nF 'run: rudi install' "$workflow" | cut -d: -f1)
+  test_line=$(grep -nF 'run: mise run test' "$workflow" | cut -d: -f1)
+
+  [ -n "$install_line" ]
+  [ -n "$test_line" ]
+  [ "$install_line" -lt "$test_line" ]
+}
+
+@test "hosted validation runs the repository's configured convention lints" {
+  grep -Fq 'run: codebase lint "$PWD"' "$workflow"
+}

--- a/test/common.bats
+++ b/test/common.bats
@@ -61,6 +61,16 @@ EOF
   [[ "$output" != *"Stale Repo"* ]]
 }
 
+@test "test harness supplies deterministic Git identity without ambient config" {
+  run git config --get user.name
+  [ "$status" -eq 0 ]
+  [ "$output" = "Notes tests" ]
+
+  run git config --get user.email
+  [ "$status" -eq 0 ]
+  [ "$output" = "notes-tests@example.invalid" ]
+}
+
 # ── Confirmation helpers ─────────────────────────────────────
 
 @test "confirm_destructive accepts --yes flag" {

--- a/test/new.bats
+++ b/test/new.bats
@@ -19,22 +19,30 @@ setup() {
 @test "new sets tags and dates" {
   notes new -- --slug beta --title "Beta" --tags "a, b" --created "2026-01-01" --updated "2026-03-20"
 
-  run farts get tags "$NOTES_CALLER_PWD/notes/beta.md"
-  [ "${lines[0]}" = "a" ]
-  [ "${lines[1]}" = "b" ]
+  run notes parse beta
+  [ "$status" -eq 0 ]
+  PARSED_NOTE="$output" python3 - <<'PY'
+import json
+import os
 
-  run farts get created "$NOTES_CALLER_PWD/notes/beta.md"
-  [ "$output" = "2026-01-01" ]
-
-  run farts get updated "$NOTES_CALLER_PWD/notes/beta.md"
-  [ "$output" = "2026-03-20" ]
+frontmatter = json.loads(os.environ["PARSED_NOTE"])["frontmatter"]
+assert frontmatter["tags"] == ["a", "b"]
+assert frontmatter["created"] == "2026-01-01"
+assert frontmatter["updated"] == "2026-03-20"
+PY
 }
 
 @test "new appends body text" {
   notes new -- --slug with-body --title "Body Note" --body "Some content here."
 
-  run farts body "$NOTES_CALLER_PWD/notes/with-body.md"
-  [[ "$output" == *"Some content here."* ]]
+  run notes parse with-body
+  [ "$status" -eq 0 ]
+  PARSED_NOTE="$output" python3 - <<'PY'
+import json
+import os
+
+assert "Some content here." in json.loads(os.environ["PARSED_NOTE"])["body"]
+PY
 }
 
 @test "new fails if note already exists" {
@@ -49,6 +57,12 @@ setup() {
   notes new -- --slug today-note --title "Today"
   today=$(date +%Y-%m-%d)
 
-  run farts get created "$NOTES_CALLER_PWD/notes/today-note.md"
-  [ "$output" = "$today" ]
+  run notes parse today-note
+  [ "$status" -eq 0 ]
+  PARSED_NOTE="$output" TODAY="$today" python3 - <<'PY'
+import json
+import os
+
+assert json.loads(os.environ["PARSED_NOTE"])["frontmatter"]["created"] == os.environ["TODAY"]
+PY
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -8,11 +8,9 @@ export REPO_DIR
 eval "$(cd "$REPO_DIR" && mise env)"
 
 # Agent sessions inject command-scope git config so real workspace commits are
-# signed. That command-scope config outranks a throwaway test repo's local
-# `commit.gpgsign=false`, so integration tests can fail when the agent's signing
-# key is unavailable. Tests should exercise git behavior, not the launcher's
-# ambient signing policy; keep commits/tags unsigned while preserving normal
-# global/local user identity resolution.
+# signed, while clean CI has no author identity at all. Tests should exercise
+# Git behavior without depending on either ambient state. Give every fixture a
+# deterministic unsigned identity at the same command scope.
 _disable_git_signing_for_tests() {
   local name _value
   unset GIT_CONFIG_COUNT GIT_CONFIG_PARAMETERS
@@ -22,11 +20,15 @@ _disable_git_signing_for_tests() {
     esac
   done < <(env)
 
-  export GIT_CONFIG_COUNT=2
+  export GIT_CONFIG_COUNT=4
   export GIT_CONFIG_KEY_0=commit.gpgsign
   export GIT_CONFIG_VALUE_0=false
   export GIT_CONFIG_KEY_1=tag.gpgsign
   export GIT_CONFIG_VALUE_1=false
+  export GIT_CONFIG_KEY_2=user.name
+  export GIT_CONFIG_VALUE_2="Notes tests"
+  export GIT_CONFIG_KEY_3=user.email
+  export GIT_CONFIG_VALUE_3=notes-tests@example.invalid
 }
 _disable_git_signing_for_tests
 


### PR DESCRIPTION
## Summary

- add the Template-shaped pull request, main, and manual test workflow on Ubuntu and macOS
- provision git-crypt through Notes' declared `rudi install` owner before running the suite
- run whitespace, complete tests, and repo-configured codebase lints in each hosted environment
- enable the `github-actions` convention rule now that the repository has a real workflow
- add architectural regressions for platform coverage, dependency ordering, and lint execution
- make the suite independent of ambient developer state by supplying deterministic unsigned fixture Git identity and replacing undeclared `farts` reads with Notes' own parser

This PR is stacked on #157 so its diff contains only the CI parity slice. It should be merged only after that contributor-health base; no merge or reviewer contact is requested by this PR.

## Validation

- `mise run test ci` (3 passed)
- `mise run test common new` (23 passed)
- full `mise run test` (374 BATS passed; 9 Python passed)
- `codebase lint "$PWD"` (5 configured rules passed, including actionlint)
- `mise run doctor`
- `git diff --check`

The first hosted run correctly exposed two ambient-state dependencies: clean Ubuntu had no Git author for fixture commits, and both runners lacked the undeclared `farts` command used by three `new` tests. The branch now owns deterministic unsigned fixture identity and verifies new-note output through `notes parse`; the updated hosted matrix is the final integration proof.
