### PR TITLE
chore: enable presentation convention lint

### DIFF
--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -105,7 +105,8 @@ if [ ${#missing_patterns[@]} -gt 0 ]; then
       # rudi treats an existing pattern with disabled attributes (for example
       # "notes/** -filter=git-crypt") as already assigned. Append an explicit
       # positive assignment so the requested pattern is actually encrypted.
-      printf '%-40s filter=git-crypt diff=git-crypt\n' "$p" >> "$GITATTRIBUTES"
+      # Fixed width here serializes .gitattributes; it is not a rendered table.
+      printf '%-40s filter=git-crypt diff=git-crypt\n' "$p" >> "$GITATTRIBUTES"  # codebase:ignore
     fi
   done
   echo "  Updated .gitattributes"

--- a/mise.toml
+++ b/mise.toml
@@ -23,5 +23,6 @@ lint = [
   "bats-test-helper",
   "mcr-scope",
   "caller-pwd-contract",
+  "gum-table",
   "github-actions",
 ]


### PR DESCRIPTION
## Summary

- enable Template's `gum-table` convention rule for Notes
- document and narrowly annotate the one false positive: fixed-width formatting in `setup` serializes a `.gitattributes` record and is not a human-facing table

This PR is stacked on #158 and should follow #157 and #158. The annotation stays on the exact exceptional line rather than weakening or omitting the repo-wide rule.

## Validation

- `codebase lint "$PWD"` (all 6 configured rules passed)
- `mise run test encrypt` (22 passed)
- `bash -n .mise/tasks/setup`
- `git diff --check`
