### PR TITLE
refactor: make ignored shell failures explicit

### DIFF
--- a/.mise/tasks/changes
+++ b/.mise/tasks/changes
@@ -31,8 +31,10 @@ if [ -n "${usage_files:-}" ]; then
 fi
 
 if [ "${usage_summary:-}" = "true" ]; then
-  # Summary mode: just list changes
-  changes=$(detect_changes "$abs_notes_dir") || true
+  # Summary mode: just list changes. An unavailable manifest is a clean result.
+  if ! changes=$(detect_changes "$abs_notes_dir"); then
+    changes=""
+  fi
 
   if [ -z "$changes" ]; then
     echo "No changes."
@@ -62,10 +64,10 @@ if [ "${usage_summary:-}" = "true" ]; then
     fi
 
     case "$status" in
-      modified)       echo "  modified:  $relpath"; ((modified++)) || true ;;
-      new)            echo "  new:       $relpath"; ((new++)) || true ;;
-      deleted)        echo "  deleted:   $relpath"; ((deleted++)) || true ;;
-      stale-readable) echo "  stale-readable: $relpath"; ((stale++)) || true ;;
+      modified)       echo "  modified:  $relpath"; modified=$((modified + 1)) ;;
+      new)            echo "  new:       $relpath"; new=$((new + 1)) ;;
+      deleted)        echo "  deleted:   $relpath"; deleted=$((deleted + 1)) ;;
+      stale-readable) echo "  stale-readable: $relpath"; stale=$((stale + 1)) ;;
     esac
   done <<< "$changes"
 
@@ -77,8 +79,10 @@ if [ "${usage_summary:-}" = "true" ]; then
     echo "$total change(s): $modified modified, $new new, $deleted deleted, $stale stale-readable"
   fi
 else
-  # Diff mode: show full diffs
-  changes=$(detect_changes "$abs_notes_dir") || true
+  # Diff mode: show full diffs. An unavailable manifest is a clean result.
+  if ! changes=$(detect_changes "$abs_notes_dir"); then
+    changes=""
+  fi
 
   if [ -z "$changes" ]; then
     echo "No changes."

--- a/.mise/tasks/commit
+++ b/.mise/tasks/commit
@@ -177,7 +177,9 @@ verify_commit_touched_only_notes() {
 
 verify_selected_changes_clean() {
   local remaining bad_selected=() status relpath
-  remaining=$(detect_changes "$abs_notes_dir") || true
+  if ! remaining=$(detect_changes "$abs_notes_dir"); then
+    remaining=""
+  fi
 
   if [ -z "$remaining" ]; then
     echo "Notes changes: clean."

--- a/.mise/tasks/conflicts
+++ b/.mise/tasks/conflicts
@@ -21,7 +21,9 @@ if [ -z "$records" ]; then
   exit 0
 fi
 
-record_count=$(printf '%s\n' "$records" | grep -c . || true)
+if ! record_count=$(printf '%s\n' "$records" | grep -c .); then
+  record_count=0
+fi
 
 if [ -n "$out_arg" ]; then
   out_dir="$out_arg"

--- a/.mise/tasks/deobfuscate
+++ b/.mise/tasks/deobfuscate
@@ -84,7 +84,7 @@ if [ -n "$output" ]; then
     [ -z "$id" ] && continue
     echo "  $id → $relpath"
     suppressed_ids+=("$id")
-    ((restored++)) || true
+    restored=$((restored + 1))
   done <<< "$output"
 fi
 
@@ -96,11 +96,11 @@ if [ -n "$stale_output" ]; then
     case "$action" in
       removed)
         echo "  removed stale readable: $relpath" >&2
-        ((removed_stale++)) || true
+        removed_stale=$((removed_stale + 1))
         ;;
       quarantined)
         echo "Warning: quarantined stale readable note: $relpath → $quarantine_path" >&2
-        ((quarantined_stale++)) || true
+        quarantined_stale=$((quarantined_stale + 1))
         ;;
     esac
   done <<< "$stale_output"

--- a/.mise/tasks/diff
+++ b/.mise/tasks/diff
@@ -37,7 +37,9 @@ if [ -z "$pr_number" ] && [ ${#ARGS[@]} -eq 0 ]; then
     exit 1
   fi
 
-  changes=$(detect_changes "$abs_notes_dir") || true
+  if ! changes=$(detect_changes "$abs_notes_dir"); then
+    changes=""
+  fi
   if [ -z "$changes" ]; then
     echo "No changes."
     exit 0
@@ -54,7 +56,10 @@ temp_refs=()
 cleanup_temp_refs() {
   local ref
   for ref in ${temp_refs[@]+"${temp_refs[@]}"}; do
-    git -C "$repo_root" update-ref -d "$ref" 2>/dev/null || true
+    # Cleanup must not replace the command's real result during the EXIT trap.
+    if ! git -C "$repo_root" update-ref -d "$ref" 2>/dev/null; then
+      :
+    fi
   done
 }
 trap cleanup_temp_refs EXIT

--- a/.mise/tasks/obfuscate
+++ b/.mise/tasks/obfuscate
@@ -39,7 +39,9 @@ if [ "${usage_dry_run:-}" = "true" ]; then
       [ ! -f "$abs_notes_dir/$relpath" ] && continue
       base=$(basename "$relpath")
       manifest_has_id "$manifest" "$base" && continue
-      existing_id=$(manifest_id_for_name "$manifest" "$relpath" || true)
+      if ! existing_id=$(manifest_id_for_name "$manifest" "$relpath"); then
+        existing_id=""
+      fi
       if [ -n "$existing_id" ]; then
         echo "  $relpath → $existing_id"
       else
@@ -53,7 +55,9 @@ if [ "${usage_dry_run:-}" = "true" ]; then
       [[ "$relpath" == ".manifest" ]] && continue
       base=$(basename "$f")
       manifest_has_id "$manifest" "$base" && continue
-      existing_id=$(manifest_id_for_name "$manifest" "$relpath" || true)
+      if ! existing_id=$(manifest_id_for_name "$manifest" "$relpath"); then
+        existing_id=""
+      fi
       if [ -n "$existing_id" ]; then
         echo "  $relpath → $existing_id"
       else
@@ -69,7 +73,9 @@ fi
 if [ ${#ARGS[@]} -gt 0 ]; then
   scoped_ids=()
   for relpath in ${ARGS[@]+"${ARGS[@]}"}; do
-    id=$(manifest_id_for_name "$manifest" "$relpath" || true)
+    if ! id=$(manifest_id_for_name "$manifest" "$relpath"); then
+      id=""
+    fi
     [ -n "$id" ] && scoped_ids+=("$id")
   done
   [ ${#scoped_ids[@]} -gt 0 ] && clear_status_suppression "$abs_notes_dir" ${scoped_ids[@]+"${scoped_ids[@]}"}
@@ -108,12 +114,15 @@ stage_manifest=false
 [ ${#ARGS[@]} -eq 0 ] && stage_manifest=true
 while IFS=$'\t' read -r relpath id; do
   git -C "$TARGET_DIR" add "$notes_dir/$id"
-  git -C "$TARGET_DIR" rm --cached --quiet "$notes_dir/$relpath" 2>/dev/null || true
+  # A readable path can already be absent from the index on repeated runs.
+  if ! git -C "$TARGET_DIR" rm --cached --quiet "$notes_dir/$relpath" 2>/dev/null; then
+    :
+  fi
   if ! manifest_entry_matches_head "$id" "$relpath"; then
     stage_manifest=true
   fi
   echo "  $relpath → $id"
-  ((new_count++)) || true
+  new_count=$((new_count + 1))
 done <<< "$output"
 
 if $stage_manifest; then

--- a/.mise/tasks/pull
+++ b/.mise/tasks/pull
@@ -89,8 +89,10 @@ fi
 if [ "$obf_status" = "deobfuscated" ]; then
   echo "Reconciling notes state after pull..."
 
-  # Reconcile stale readable files from upstream deletions/renames
-  stale_output=$(reconcile_stale_readable_notes "$abs_notes_dir" 2>/dev/null) || true
+  # Reconciliation is best-effort here; pull already completed before this repair.
+  if ! stale_output=$(reconcile_stale_readable_notes "$abs_notes_dir" 2>/dev/null); then
+    stale_output=""
+  fi
   if [ -n "$stale_output" ]; then
     while IFS=$'\t' read -r action relpath quarantine_path; do
       [ -n "$action" ] || continue

--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -59,8 +59,10 @@ scope_matches() {
   return 1
 }
 
-# Detect changes
-changes=$(detect_changes "$abs_notes_dir") || true
+# Detect changes. An unavailable manifest is a clean result.
+if ! changes=$(detect_changes "$abs_notes_dir"); then
+  changes=""
+fi
 
 if [ "$scope_all" != "true" ]; then
   unknown=()
@@ -109,7 +111,9 @@ if [ ${#stale_notes[@]} -gt 0 ]; then
   exit 1
 fi
 
-conflicting_notes=$(detect_dual_present_conflicts "$abs_notes_dir") || true
+if ! conflicting_notes=$(detect_dual_present_conflicts "$abs_notes_dir"); then
+  conflicting_notes=""
+fi
 if [ -n "$conflicting_notes" ]; then
   blocked_conflicts=()
   while IFS=$'\t' read -r conflict_id conflict_relpath; do
@@ -228,7 +232,7 @@ for relpath in ${to_stage[@]+"${to_stage[@]}"}; do
       echo "  staged (delete): $relpath"
     fi
   fi
-  ((staged++)) || true
+  staged=$((staged + 1))
 done
 
 echo ""

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -58,7 +58,9 @@ fi
 incomplete_deobfuscation=""
 incomplete_conflicts=0
 if [ "$enc_status" != "locked" ] && [ -f "$NOTES_DIR/.manifest" ]; then
-  incomplete_deobfuscation=$(detect_dual_present_conflicts "$TARGET_DIR/$NOTES_DIR" 2>/dev/null) || true
+  if ! incomplete_deobfuscation=$(detect_dual_present_conflicts "$TARGET_DIR/$NOTES_DIR" 2>/dev/null); then
+    incomplete_deobfuscation=""
+  fi
   if [ -n "$incomplete_deobfuscation" ]; then
     incomplete_conflicts=$(printf '%s\n' "$incomplete_deobfuscation" | wc -l | tr -d ' ')
   fi
@@ -94,14 +96,16 @@ changes_deleted=0
 changes_stale=0
 
 if [ "$obf_status" = "deobfuscated" ]; then
-  changes=$(detect_changes "$TARGET_DIR/$NOTES_DIR" 2>/dev/null) || true
+  if ! changes=$(detect_changes "$TARGET_DIR/$NOTES_DIR" 2>/dev/null); then
+    changes=""
+  fi
   if [ -n "$changes" ]; then
     while IFS=$'\t' read -r chg_status chg_relpath; do
       case "$chg_status" in
-        modified)       ((changes_modified++)) || true ;;
-        new)            ((changes_new++)) || true ;;
-        deleted)        ((changes_deleted++)) || true ;;
-        stale-readable) ((changes_stale++)) || true ;;
+        modified)       changes_modified=$((changes_modified + 1)) ;;
+        new)            changes_new=$((changes_new + 1)) ;;
+        deleted)        changes_deleted=$((changes_deleted + 1)) ;;
+        stale-readable) changes_stale=$((changes_stale + 1)) ;;
       esac
     done <<< "$changes"
   fi

--- a/hooks/encryption
+++ b/hooks/encryption
@@ -31,7 +31,11 @@ done < <(git check-attr --cached -z filter -- "${staged[@]}")
 # Flag any that are currently plaintext (e.g. git-crypt locked at stage time).
 bad_files=()
 for file in "${encrypted_staged[@]}"; do
-  if { git-crypt status -- "$file" 2>&1 || true; } | grep -qi "not encrypted"; then
+  status_output=""
+  if ! status_output=$(git-crypt status -- "$file" 2>&1); then
+    : # git-crypt reports plaintext paths through output and a non-zero status.
+  fi
+  if grep -qi "not encrypted" <<< "$status_output"; then
     bad_files+=("$file")
   fi
 done

--- a/hooks/encryption
+++ b/hooks/encryption
@@ -32,11 +32,19 @@ done < <(git check-attr --cached -z filter -- "${staged[@]}")
 bad_files=()
 for file in "${encrypted_staged[@]}"; do
   status_output=""
-  if ! status_output=$(git-crypt status -- "$file" 2>&1); then
-    : # git-crypt reports plaintext paths through output and a non-zero status.
+  status=0
+  if status_output=$(git-crypt status -- "$file" 2>&1); then
+    :
+  else
+    status=$?
   fi
+
   if grep -qi "not encrypted" <<< "$status_output"; then
     bad_files+=("$file")
+  elif [ "$status" -ne 0 ]; then
+    echo "ERROR: git-crypt could not inspect staged encrypted path: $file" >&2
+    [ -z "$status_output" ] || printf '%s\n' "$status_output" >&2
+    exit 1
   fi
 done
 

--- a/lib/changes.sh
+++ b/lib/changes.sh
@@ -75,10 +75,13 @@ detect_changes() {
   done < "$manifest"
 
   if declare -F detect_stale_readable_notes >/dev/null 2>&1; then
-    detect_stale_readable_notes "$abs_notes_dir" 2>/dev/null \
+    # Stale-state discovery is advisory during change classification.
+    if ! detect_stale_readable_notes "$abs_notes_dir" 2>/dev/null \
       | while IFS=$'\t' read -r _stale_state stale_relpath; do
           [ -n "$stale_relpath" ] && printf '%s\n' "$stale_relpath"
-        done > "$stale_readables" || true
+        done > "$stale_readables"; then
+      :
+    fi
   fi
 
   git -C "$repo_root" cat-file --batch-check='%(objectname)' < "$head_in" > "$head_out" 2>/dev/null || {
@@ -136,7 +139,9 @@ detect_changes() {
       if ! $head_exists; then
         printf 'new\t%s\n' "$relpath"
         if $use_batch_hash; then
-          IFS= read -r _disk_hash <&4 || true
+          if ! IFS= read -r _disk_hash <&4; then
+            _disk_hash=""
+          fi
         fi
         continue
       fi
@@ -189,6 +194,21 @@ detect_changes() {
   rm -rf "$tmp_dir"
 }
 
+# Print ordinary diff output while preserving genuine diff execution failures.
+_emit_notes_diff() {
+  local status
+  if diff "$@"; then
+    return 0
+  else
+    status=$?
+  fi
+
+  case "$status" in
+    1) return 0 ;; # differences found
+    *) return "$status" ;;
+  esac
+}
+
 # Show diffs for changed notes.
 # Usage: show_diffs <abs_notes_dir> [file...]
 #   Without files: diffs all changed notes
@@ -233,13 +253,13 @@ show_diffs() {
         local tmp
         tmp=$(mktemp) || continue
         git -C "$repo_root" cat-file --filters "HEAD:$git_path" > "$tmp" 2>/dev/null
-        diff -u --label "a/$relpath" --label "b/$relpath" "$tmp" "$readable_file" || true
+        _emit_notes_diff -u --label "a/$relpath" --label "b/$relpath" "$tmp" "$readable_file"
         rm -f "$tmp"
         echo ""
         ;;
       new)
         echo "=== $relpath (new) ==="
-        diff -u --label /dev/null --label "b/$relpath" /dev/null "$readable_file" || true
+        _emit_notes_diff -u --label /dev/null --label "b/$relpath" /dev/null "$readable_file"
         echo ""
         ;;
       deleted)
@@ -247,7 +267,7 @@ show_diffs() {
         local tmp
         tmp=$(mktemp) || continue
         git -C "$repo_root" cat-file --filters "HEAD:$git_path" > "$tmp" 2>/dev/null
-        diff -u --label "a/$relpath" --label /dev/null "$tmp" /dev/null || true
+        _emit_notes_diff -u --label "a/$relpath" --label /dev/null "$tmp" /dev/null
         rm -f "$tmp"
         echo ""
         ;;

--- a/lib/conflicts.sh
+++ b/lib/conflicts.sh
@@ -71,10 +71,10 @@ _notes_conflict_lookup_readable_name() {
   # Prefer the current index entry when present, then ours/theirs/base for a
   # conflicted manifest. This is enough to map stable obfuscated IDs while
   # still refusing ambiguous or unproven mappings.
-  _notes_conflict_manifest_stage_to_file "$repo_root" "$notes_dir" 0 "$candidates" || true
-  _notes_conflict_manifest_stage_to_file "$repo_root" "$notes_dir" 2 "$candidates" || true
-  _notes_conflict_manifest_stage_to_file "$repo_root" "$notes_dir" 3 "$candidates" || true
-  _notes_conflict_manifest_stage_to_file "$repo_root" "$notes_dir" 1 "$candidates" || true
+  if ! _notes_conflict_manifest_stage_to_file "$repo_root" "$notes_dir" 0 "$candidates"; then :; fi
+  if ! _notes_conflict_manifest_stage_to_file "$repo_root" "$notes_dir" 2 "$candidates"; then :; fi
+  if ! _notes_conflict_manifest_stage_to_file "$repo_root" "$notes_dir" 3 "$candidates"; then :; fi
+  if ! _notes_conflict_manifest_stage_to_file "$repo_root" "$notes_dir" 1 "$candidates"; then :; fi
 
   while IFS=$'\t' read -r entry_id entry_name _extra; do
     [ "$entry_id" = "$id" ] || continue
@@ -89,7 +89,9 @@ _notes_conflict_lookup_readable_name() {
   sorted_matches=$(mktemp) || { rm -f "$candidates" "$matches"; return 1; }
   sort -u "$matches" > "$sorted_matches"
   mv -f "$sorted_matches" "$matches"
-  count=$(grep -c . "$matches" 2>/dev/null || true)
+  if ! count=$(grep -c . "$matches" 2>/dev/null); then
+    count=0
+  fi
   case "$count" in
     0)
       rm -f "$candidates" "$matches"
@@ -127,7 +129,11 @@ notes_conflict_unmerged_paths() {
         printf '%s\n' "$git_path" >> "$tmp"
         ;;
     esac
-  done < <(git -C "$repo_root" ls-files -u -- "$notes_dir" 2>/dev/null || true)
+  done < <(
+    if ! git -C "$repo_root" ls-files -u -- "$notes_dir" 2>/dev/null; then
+      :
+    fi
+  )
 
   sort -u "$tmp"
   rm -f "$tmp"

--- a/lib/diff.sh
+++ b/lib/diff.sh
@@ -91,7 +91,11 @@ materialize_readable_notes_ref() {
     if ! $has_manifest || ! grep -Fxq -- "$relpath" "$manifest_ids"; then
       unmapped_count=$((unmapped_count + 1))
     fi
-  done < <(git -C "$repo_root" ls-tree -r -z --name-only "$ref" -- "$notes_dir" 2>/dev/null || true)
+  done < <(
+    if ! git -C "$repo_root" ls-tree -r -z --name-only "$ref" -- "$notes_dir" 2>/dev/null; then
+      :
+    fi
+  )
 
   rm -f "$manifest" "$manifest_ids"
   if [ "$unmapped_count" -gt 0 ]; then

--- a/lib/manifest-merge-driver.sh
+++ b/lib/manifest-merge-driver.sh
@@ -93,7 +93,7 @@ normalize() {
   local src="$1" plaintext
   plaintext=$(mktemp "$WORK/plain.XXXXXX")
   decrypt_if_needed "$src" "$plaintext" || return 1
-  grep -v '^$' "$plaintext" 2>/dev/null | sort -t$'\t' -k2 || true
+  awk 'NF' "$plaintext" 2>/dev/null | sort -t$'\t' -k2
 }
 
 normalize "$ANCESTOR" > "$WORK/anc"
@@ -124,9 +124,9 @@ has_conflict=false
 while IFS= read -r name; do
   [ -z "$name" ] && continue
 
-  a_id=$(id_for_name "$WORK/anc" "$name") || true
-  o_id=$(id_for_name "$WORK/ours" "$name") || true
-  t_id=$(id_for_name "$WORK/theirs" "$name") || true
+  a_id=$(id_for_name "$WORK/anc" "$name")
+  o_id=$(id_for_name "$WORK/ours" "$name")
+  t_id=$(id_for_name "$WORK/theirs" "$name")
 
   if [ -n "$o_id" ] && [ -n "$t_id" ]; then
     if [ "$o_id" = "$t_id" ]; then

--- a/lib/obfuscate.sh
+++ b/lib/obfuscate.sh
@@ -73,7 +73,9 @@ rename_to_obfuscated() {
       refuse_if_hex_basename "$relpath" || return 1
 
       local existing_id
-      existing_id=$(manifest_id_for_name "$manifest" "$relpath" || true)
+      if ! existing_id=$(manifest_id_for_name "$manifest" "$relpath"); then
+        existing_id=""
+      fi
       if [ -n "$existing_id" ]; then
         to_restore+=("$relpath")
       else
@@ -95,7 +97,9 @@ rename_to_obfuscated() {
       refuse_if_hex_basename "$relpath" || return 1
 
       local existing_id
-      existing_id=$(manifest_id_for_name "$manifest" "$relpath" || true)
+      if ! existing_id=$(manifest_id_for_name "$manifest" "$relpath"); then
+        existing_id=""
+      fi
       if [ -n "$existing_id" ]; then
         to_restore+=("$relpath")
       else
@@ -115,7 +119,9 @@ rename_to_obfuscated() {
   # Restore files to their known IDs
   for relpath in ${to_restore[@]+"${to_restore[@]}"}; do
     local id
-    id=$(manifest_id_for_name "$manifest" "$relpath" || true)
+    if ! id=$(manifest_id_for_name "$manifest" "$relpath"); then
+      id=""
+    fi
     if ! mv "$notes_dir/$relpath" "$notes_dir/$id"; then
       echo "Error: failed to rename $relpath → $id" >&2
       rm -f "$new_entries"
@@ -143,8 +149,10 @@ rename_to_obfuscated() {
     printf '%s\t%s\n' "$relpath" "$id"
   done
 
-  # Clean up empty directories after flattening
-  find "$notes_dir" -mindepth 1 -type d -empty -delete 2>/dev/null || true
+  # Empty-directory cleanup is cosmetic and must not invalidate completed renames.
+  if ! find "$notes_dir" -mindepth 1 -type d -empty -delete 2>/dev/null; then
+    :
+  fi
 
   # Scoped re-obfuscation of existing manifest entries should not rewrite the
   # manifest at all. Re-sorting a valid but differently-ordered manifest creates
@@ -283,7 +291,9 @@ _rename_one_to_readable() {
   if [ -e "$notes_dir/$relpath" ] && ! cmp -s "$notes_dir/$id" "$notes_dir/$relpath"; then
     local current_hash base_hash state_file dirty_readable=false
     state_file=$(_deobfuscation_state_file "$notes_dir" 2>/dev/null) || state_file=""
-    current_hash=$(git -C "$notes_dir" hash-object -- "$notes_dir/$relpath" 2>/dev/null || true)
+    if ! current_hash=$(git -C "$notes_dir" hash-object -- "$notes_dir/$relpath" 2>/dev/null); then
+      current_hash=""
+    fi
     base_hash=$(_deobfuscation_base_hash_for_id "$notes_dir" "$id")
 
     # No state file (fresh clone or pre-safety upgrade) -> trust the readable
@@ -338,8 +348,8 @@ rename_to_readable() {
       local _rc
       _rename_one_to_readable "$notes_dir" "$manifest" "$id" && _rc=0 || _rc=$?
       case $_rc in
-        0) ((count++)) || true ;;
-        3) ((dirty_count++)) || true ;;
+        0) count=$((count + 1)) ;;
+        3) dirty_count=$((dirty_count + 1)) ;;
         1) return 1 ;;
       esac
     done
@@ -349,8 +359,8 @@ rename_to_readable() {
       local _rc
       _rename_one_to_readable "$notes_dir" "$manifest" "$id" && _rc=0 || _rc=$?
       case $_rc in
-        0) ((count++)) || true ;;
-        3) ((dirty_count++)) || true ;;
+        0) count=$((count + 1)) ;;
+        3) dirty_count=$((dirty_count + 1)) ;;
         1) return 1 ;;
       esac
     done < "$manifest"

--- a/lib/suppress.sh
+++ b/lib/suppress.sh
@@ -212,7 +212,7 @@ _update_index_paths() {
   [ ${#paths[@]} -gt 0 ] || return 0
 
   GIT_LITERAL_PATHSPECS=1 git -C "$repo_root" ls-files -z -- "${paths[@]}" |
-    git -C "$repo_root" update-index "$flag" -z --stdin 2>/dev/null || true
+    git -C "$repo_root" update-index "$flag" -z --stdin 2>/dev/null
 }
 
 # Set assume-unchanged on obfuscated paths + add exclude entries for readable names.
@@ -233,10 +233,15 @@ set_status_suppression() {
 
   # Set assume-unchanged flags in one index update.
   if [ ${#scoped_ids[@]} -gt 0 ] && [ -n "${scoped_ids[0]}" ]; then
-    printf '%s\n' "${scoped_ids[@]/#/$notes_dir/}" | _update_index_paths "$repo_root" --assume-unchanged
+    if ! printf '%s\n' "${scoped_ids[@]/#/$notes_dir/}" |
+      _update_index_paths "$repo_root" --assume-unchanged; then
+      return 1
+    fi
   else
-    awk -F '\t' -v prefix="$notes_dir/" '$1 != "" { print prefix $1 }' "$manifest" |
-      _update_index_paths "$repo_root" --assume-unchanged
+    if ! awk -F '\t' -v prefix="$notes_dir/" '$1 != "" { print prefix $1 }' "$manifest" |
+      _update_index_paths "$repo_root" --assume-unchanged; then
+      return 1
+    fi
   fi
 
   # Add exclude entries for readable names
@@ -261,10 +266,15 @@ clear_status_suppression() {
 
   # Clear assume-unchanged flags in one index update.
   if [ ${#scoped_ids[@]} -gt 0 ] && [ -n "${scoped_ids[0]}" ]; then
-    printf '%s\n' "${scoped_ids[@]/#/$notes_dir/}" | _update_index_paths "$repo_root" --no-assume-unchanged
+    if ! printf '%s\n' "${scoped_ids[@]/#/$notes_dir/}" |
+      _update_index_paths "$repo_root" --no-assume-unchanged; then
+      return 1
+    fi
   else
-    awk -F '\t' -v prefix="$notes_dir/" '$1 != "" { print prefix $1 }' "$manifest" |
-      _update_index_paths "$repo_root" --no-assume-unchanged
+    if ! awk -F '\t' -v prefix="$notes_dir/" '$1 != "" { print prefix $1 }' "$manifest" |
+      _update_index_paths "$repo_root" --no-assume-unchanged; then
+      return 1
+    fi
   fi
 
   # Remove exclude entries for readable names
@@ -349,7 +359,9 @@ detect_stale_readable_notes() {
 
   state=""
   if declare -F _deobfuscation_state_file >/dev/null 2>&1; then
-    state=$(_deobfuscation_state_file "$abs_notes_dir" 2>/dev/null || true)
+    if ! state=$(_deobfuscation_state_file "$abs_notes_dir" 2>/dev/null); then
+      state=""
+    fi
   fi
 
   if [ -n "$state" ] && [ -f "$state" ]; then
@@ -457,7 +469,10 @@ reconcile_stale_readable_notes() {
     esac
   done <<< "$stale"
 
-  find "$abs_notes_dir" -mindepth 1 -type d -empty -delete 2>/dev/null || true
+  # Empty-directory cleanup is cosmetic after stale files are reconciled.
+  if ! find "$abs_notes_dir" -mindepth 1 -type d -empty -delete 2>/dev/null; then
+    :
+  fi
 }
 
 # Rebuild all derived git-status suppression from the current manifest. Unlike
@@ -475,11 +490,15 @@ rebuild_status_suppression() {
   local state=""
 
   if declare -F _deobfuscation_state_file >/dev/null 2>&1; then
-    state=$(_deobfuscation_state_file "$abs_notes_dir" 2>/dev/null || true)
+    if ! state=$(_deobfuscation_state_file "$abs_notes_dir" 2>/dev/null); then
+      state=""
+    fi
   fi
   if [ -n "$state" ] && [ -f "$state" ]; then
-    awk -F '\t' -v prefix="$notes_dir/" '$1 != "" { print prefix $1 }' "$state" | sort -u |
-      _update_index_paths "$repo_root" --no-assume-unchanged
+    if ! awk -F '\t' -v prefix="$notes_dir/" '$1 != "" { print prefix $1 }' "$state" | sort -u |
+      _update_index_paths "$repo_root" --no-assume-unchanged; then
+      return 1
+    fi
   fi
 
   mkdir -p "$(dirname "$exclude_file")"

--- a/mise.toml
+++ b/mise.toml
@@ -23,6 +23,7 @@ lint = [
   "bats-test-helper",
   "mcr-scope",
   "caller-pwd-contract",
+  "or-true",
   "gum-table",
   "github-actions",
 ]

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -87,6 +87,22 @@ rename_manifest_entry_in_head() {
   [[ "$output" != *"beta.md"* ]]
 }
 
+@test "notes changes propagates diff execution failures" {
+  echo "# Alpha modified" > "$NOTES_CALLER_PWD/notes/alpha.md"
+
+  local mock_bin="$BATS_TEST_TMPDIR/mock-diff-bin"
+  mkdir -p "$mock_bin"
+  cat > "$mock_bin/diff" <<'SH'
+#!/usr/bin/env bash
+exit 73
+SH
+  chmod +x "$mock_bin/diff"
+
+  PATH="$mock_bin:$PATH" run notes changes
+
+  [ "$status" -eq 73 ]
+}
+
 @test "detect_changes: detects new file not in manifest" {
   echo "# Gamma" > "$NOTES_CALLER_PWD/notes/gamma.md"
 

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -498,6 +498,32 @@ run_encryption_hook() {
   [ "$status" -eq 0 ]
 }
 
+@test "encryption hook fails closed when git-crypt cannot inspect a staged path (#49)" {
+  notes setup --yes
+  local fpr
+  fpr=$(generate_test_key "$GNUPGHOME")
+  notes add-user -- --gpg-key "$fpr"
+
+  mkdir -p "$TARGET_DIR/notes"
+  echo "secret" > "$TARGET_DIR/notes/ok.md"
+  git -C "$TARGET_DIR" add notes/ok.md
+
+  local mock_bin="$BATS_TEST_TMPDIR/mock-git-crypt-bin"
+  mkdir -p "$mock_bin"
+  cat > "$mock_bin/git-crypt" <<'SH'
+#!/usr/bin/env bash
+echo "backend inspection failed" >&2
+exit 73
+SH
+  chmod +x "$mock_bin/git-crypt"
+  export PATH="$mock_bin:$PATH"
+
+  run_encryption_hook
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"could not inspect staged encrypted path: notes/ok.md"* ]]
+  [[ "$output" == *"backend inspection failed"* ]]
+}
+
 # --- double-tracking pre-commit hook (#51) ---
 run_double_tracking_hook() {
   run bash -c "cd '$TARGET_DIR' && bash .git/hooks/pre-commit.d/verify-double-tracking"

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -1093,6 +1093,37 @@ EOT
   [[ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" == *"local edit"* ]]
 }
 
+@test "deobfuscate reports suppression index failures" {
+  notes obfuscate
+  git -C "$NOTES_CALLER_PWD" add -A notes
+  git -C "$NOTES_CALLER_PWD" commit -q -m "obfuscate"
+
+  local mock_bin="$BATS_TEST_TMPDIR/failing-index-bin"
+  local real_git
+  real_git=$(command -v git)
+  mkdir -p "$mock_bin"
+  cat > "$mock_bin/git" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GIT_MOCK_LOG"
+for arg in "$@"; do
+  if [ "$arg" = "update-index" ]; then
+    exit 73
+  fi
+done
+exec "$REAL_GIT" "$@"
+SH
+  chmod +x "$mock_bin/git"
+
+  export PATH="$mock_bin:$PATH"
+  export REAL_GIT="$real_git"
+  export GIT_MOCK_LOG="$BATS_TEST_TMPDIR/git-mock.log"
+  run notes deobfuscate
+
+  grep -Fq "update-index" "$GIT_MOCK_LOG"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Warning: failed to rebuild status suppression"* ]]
+}
+
 @test "deobfuscate batches full suppression index updates" {
   notes obfuscate
   git -C "$NOTES_CALLER_PWD" add -A notes


### PR DESCRIPTION
## Summary

- audit all 58 existing `|| true` / `|| :` suppressions and enable the repo-wide `or-true` convention rule
- replace arithmetic-status workarounds and optional lookups with explicit Bash 3.2-compatible control flow
- keep genuinely best-effort cleanup and reporting behavior explicit at its call site instead of hiding it behind a success literal
- stop swallowing real `diff` execution errors while continuing to treat ordinary diff status 1 as output
- preserve suppression-index failures through nested function and pipeline boundaries so `deobfuscate` can emit its existing warning
- add regressions for the two newly visible failure paths

This PR is stacked on #159 and should follow #157, #158, and #159. It changes no merge/release authority and requests no reviewer contact.

## Validation

- full `mise run test` on the exact combined stack (376 BATS passed; 9 Python passed)
- `codebase lint "$PWD"` (all 7 configured rules passed, including `or-true`)
- Bash syntax checks for every changed task, hook, and library
- `git diff --check`

During test design, the first suppression regression showed that removing the inner `|| true` alone was insufficient: an outer `|| warn` disabled `errexit` through nested functions, allowing later exclude-file work to replace the failed index status with success. The final implementation checks each index pipeline explicitly, returns failure from the suppression owner, and proves the existing top-level warning is reached.
