### PR TITLE
chore: enable shellcheck convention lint

### DIFF
--- a/.mise/tasks/commit
+++ b/.mise/tasks/commit
@@ -92,7 +92,7 @@ require_no_preexisting_staged_changes() {
   staged=$(git -C "$TARGET_DIR" diff --cached --name-only)
   if [ -n "$staged" ]; then
     echo "Error: staged changes already exist; refusing to mix them into notes commit." >&2
-    echo "$staged" | sed 's/^/  /' >&2
+    printf '  %s\n' "${staged//$'\n'/$'\n  '}" >&2
     echo "Commit or unstage them first, then retry." >&2
     exit 1
   fi
@@ -147,7 +147,7 @@ verify_no_staged_residue() {
   staged=$(git -C "$TARGET_DIR" diff --cached --name-only)
   if [ -n "$staged" ]; then
     echo "Error: staged changes remain after notes commit:" >&2
-    echo "$staged" | sed 's/^/  /' >&2
+    printf '  %s\n' "${staged//$'\n'/$'\n  '}" >&2
     return 1
   fi
 }

--- a/.mise/tasks/deobfuscate
+++ b/.mise/tasks/deobfuscate
@@ -138,13 +138,13 @@ if [ ${#suppressed_ids[@]} -gt 0 ]; then
     || echo "Warning: failed to record deobfuscation base hashes" >&2
 fi
 
-if [ $rc -ne 0 ] && [ $rc -ne 2 ]; then
+if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then
   echo "Error: deobfuscation failed after restoring $restored file(s)" >&2
-  exit $rc
+  exit "$rc"
 fi
 
 stale_total=$((removed_stale + quarantined_stale))
-if [ $rc -eq 2 ] && [ "$restored" -eq 0 ] && [ "$stale_total" -eq 0 ]; then
+if [ "$rc" -eq 2 ] && [ "$restored" -eq 0 ] && [ "$stale_total" -eq 0 ]; then
   echo "Nothing to deobfuscate."
   exit 0
 fi

--- a/.mise/tasks/obfuscate
+++ b/.mise/tasks/obfuscate
@@ -87,12 +87,12 @@ fi
 # Exit codes: 0=success, 2=nothing to do, 1=error
 # Use && rc=0 || rc=$? to capture exit code without triggering errexit.
 output=$(rename_to_obfuscated "$abs_notes_dir" ${ARGS[@]+"${ARGS[@]}"}) && rc=0 || rc=$?
-if [ $rc -eq 2 ]; then
+if [ "$rc" -eq 2 ]; then
   echo "Nothing to obfuscate."
   exit 0
-elif [ $rc -ne 0 ]; then
+elif [ "$rc" -ne 0 ]; then
   echo "Error: obfuscation failed" >&2
-  exit $rc
+  exit "$rc"
 fi
 
 manifest_entry_matches_head() {

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -153,6 +153,8 @@ confirm_destructive() {
   fi
 
   if command -v gum >/dev/null 2>&1; then
+    # A terminal device intentionally carries prompt input, output, and errors.
+    # shellcheck disable=SC2094
     if gum confirm "$message" <"$tty_path" >"$tty_path" 2>"$tty_path"; then
       return 0
     fi

--- a/lib/conflicts.sh
+++ b/lib/conflicts.sh
@@ -76,6 +76,8 @@ _notes_conflict_lookup_readable_name() {
   if ! _notes_conflict_manifest_stage_to_file "$repo_root" "$notes_dir" 3 "$candidates"; then :; fi
   if ! _notes_conflict_manifest_stage_to_file "$repo_root" "$notes_dir" 1 "$candidates"; then :; fi
 
+  # Unsafe input unlinks temp files only while aborting; the open reader stays valid.
+  # shellcheck disable=SC2094
   while IFS=$'\t' read -r entry_id entry_name _extra; do
     [ "$entry_id" = "$id" ] || continue
     if ! _notes_conflict_guard_readable_path "$entry_name"; then

--- a/lib/diff.sh
+++ b/lib/diff.sh
@@ -66,6 +66,8 @@ materialize_readable_notes_ref() {
 
   local manifest_ids
   manifest_ids=$(mktemp) || { rm -f "$manifest"; return 1; }
+  # Failure paths may unlink these temp files before returning; open readers stay valid.
+  # shellcheck disable=SC2094
   while IFS=$'\t' read -r id relpath; do
     [ -z "$id" ] && continue
     _guard_manifest_path "id" "$id" || { rm -f "$manifest" "$manifest_ids"; return 1; }

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -3,6 +3,7 @@
 
 HOOKS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOOKS_REPO_DIR="$(cd "$HOOKS_LIB_DIR/.." && pwd)"
+HOOKS_DIR="$HOOKS_REPO_DIR/hooks"
 
 _hook_template_value() {
   printf '%s' "$1" | sed 's/[&|\\]/\\&/g'

--- a/lib/manifest-merge-driver.sh
+++ b/lib/manifest-merge-driver.sh
@@ -118,8 +118,8 @@ cut -f2 "$WORK/anc" "$WORK/ours" "$WORK/theirs" 2>/dev/null | sort -u > "$WORK/a
 
 # Merge
 has_conflict=false
-> "$WORK/merged"
-> "$WORK/conflicts"
+: > "$WORK/merged"
+: > "$WORK/conflicts"
 
 while IFS= read -r name; do
   [ -z "$name" ] && continue

--- a/lib/obfuscate.sh
+++ b/lib/obfuscate.sh
@@ -354,6 +354,8 @@ rename_to_readable() {
       esac
     done
   else
+    # The helper moves note files but does not modify the manifest being read.
+    # shellcheck disable=SC2094
     while IFS=$'\t' read -r id relpath; do
       [ -z "$id" ] && continue
       local _rc

--- a/mise.toml
+++ b/mise.toml
@@ -24,6 +24,7 @@ lint = [
   "mcr-scope",
   "caller-pwd-contract",
   "or-true",
+  "shellcheck",
   "gum-table",
   "github-actions",
 ]


### PR DESCRIPTION
## Summary

- fix or narrowly explain all 20 current ShellCheck findings and enable the repo-wide `shellcheck` convention rule
- quote captured status values, use explicit no-op redirections, and preserve multiline staged-path formatting without external `sed`
- make the hooks library self-contained about its asset directory
- document the few valid same-file-descriptor cases: terminal prompt I/O and unlink-on-abort temporary readers

This PR is stacked on #160 and completes the eight-rule convention set inherited from Template. It should follow #157 through #160; it requests no merge or reviewer contact.

## Validation

- full `mise run test` (376 BATS passed; 9 Python passed)
- focused `mise run test common changes conflicts diff merge-driver obfuscate` (195 passed)
- `codebase lint "$PWD"` (all 8 configured rules passed, including ShellCheck)
- Bash syntax checks for every changed shell surface
- `git diff --check`
