### PR TITLE
test: separate canonical mixed-suite runner

### DIFF
--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,62 +1,19 @@
 #!/usr/bin/env bash
-#MISE description="Run test suite"
-#MISE hide=true
-#USAGE arg "[args]" var=#true default="" help="Test files or bats flags (e.g., test/obfuscate.bats, --filter 'pattern')"
-#USAGE example "mise run test" header="Run all tests"
+#MISE description="Run BATS and Python tests"
+#MISE dir="{{config_root}}"
+#USAGE arg "[args]" var=#true default="" help="Test suites, Python files, or BATS arguments"
+#USAGE example "mise run test" header="Run all BATS and Python tests"
 #USAGE example "mise run test list" header="Run test/list.bats"
-#USAGE example "mise run test --filter rejects" header="Filter tests by name"
+#USAGE example "mise run test test/python/test_audit.py" header="Run one Python test file"
+#USAGE example "mise run test --filter rejects" header="Filter BATS tests by name"
+#USAGE example "mise run test --jobs 1" header="Run BATS serially for debugging"
 set -euo pipefail
 
-REPO_DIR="${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}"
-TEST_DIR="$REPO_DIR/test"
-
-args=()
+arguments=()
 if [ -n "${usage_args:-}" ]; then
-  while IFS= read -r arg; do
-    [ -z "$arg" ] && continue
-    args+=("$arg")
-  done < <(printf '%s' "${usage_args}" | xargs printf '%s\n')
+  while IFS= read -r argument; do
+    [ -z "$argument" ] || arguments+=("$argument")
+  done < <(printf '%s' "$usage_args" | xargs printf '%s\n')
 fi
 
-bats_args=()
-pytest_args=()
-has_bats_target=false
-has_pytest_target=false
-has_bats_flag=false
-
-for arg in ${args[@]+"${args[@]}"}; do
-  if [[ "$arg" == -* ]]; then
-    has_bats_flag=true
-    bats_args+=("$arg")
-  elif [[ "$arg" == *.py || "$arg" == test/python/* || "$arg" == "$TEST_DIR/python/"* ]]; then
-    pytest_args+=("$arg")
-    has_pytest_target=true
-  elif [[ "$arg" != *.bats && -f "$TEST_DIR/$arg.bats" ]]; then
-    bats_args+=("$TEST_DIR/$arg.bats")
-    has_bats_target=true
-    if [ -f "$TEST_DIR/python/test_${arg}.py" ]; then
-      pytest_args+=("$TEST_DIR/python/test_${arg}.py")
-      has_pytest_target=true
-    fi
-  else
-    [[ "$arg" == *.bats || -d "$arg" ]] && has_bats_target=true
-    bats_args+=("$arg")
-  fi
-done
-
-if [ ${#args[@]} -eq 0 ]; then
-  bats_args+=("$TEST_DIR/")
-  pytest_args+=("$TEST_DIR/python")
-elif ! $has_bats_target && ! $has_pytest_target; then
-  bats_args+=("$TEST_DIR/")
-fi
-
-if [ ${#bats_args[@]} -gt 0 ] && ! $has_pytest_target; then
-  bats --jobs 8 --parallel-binary-name rush ${bats_args[@]+"${bats_args[@]}"}
-elif [ ${#bats_args[@]} -gt 0 ] && ! $has_bats_flag; then
-  bats --jobs 8 --parallel-binary-name rush ${bats_args[@]+"${bats_args[@]}"}
-fi
-
-if [ ${#pytest_args[@]} -gt 0 ]; then
-  uv run --with pytest pytest ${pytest_args[@]+"${pytest_args[@]}"}
-fi
+exec "$MISE_CONFIG_ROOT/libexec/test" ${arguments[@]+"${arguments[@]}"}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ notes/
 ├── .mise/tasks/       # Public CLI commands and task-local orchestration
 ├── hooks/             # Installed Git hook components and templates
 ├── lib/               # Shared Bash and Python domain logic
+├── libexec/test       # Canonical mixed BATS/Python test workflow
 ├── test/              # BATS behavior and integration tests
 ├── test/python/       # Focused Python tests
 ├── mise.toml          # Tools, settings, and convention lint configuration
@@ -49,7 +50,13 @@ mise run test                       # BATS and Python suites
 mise run test changes               # test/changes.bats and matching Python test, if present
 mise run test --filter suppression  # filter BATS test names
 mise run test test/python/test_audit.py
+mise run test --jobs 1              # serial BATS debugging
 ```
+
+The public test task only translates Usage arguments. `libexec/test` owns target
+classification and execution, while `test/setup_suite.bash` establishes the
+repo-local tool environment and deterministic fixture Git identity once per
+BATS invocation.
 
 Notes intentionally uses eight BATS workers, including within-file
 parallelism. Several suites contain many independent Git fixtures, so the

--- a/libexec/test
+++ b/libexec/test
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+
+# Canonical mixed-suite workflow. The public mise task only translates Usage
+# arguments; this file owns test target classification and execution.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+test_directory="$repo_root/test"
+default_parallel_jobs=8
+bats_command="${BATS_COMMAND:-bats}"
+parallel_command="${RUSH_COMMAND:-rush}"
+uv_command="${UV_COMMAND:-uv}"
+
+bats_arguments=()
+pytest_arguments=()
+has_bats_target=false
+bats_requested=false
+pytest_requested=false
+cli_jobs=""
+cli_parallel_command=""
+
+fail() {
+  printf 'Error: %s\n' "$*" >&2
+  exit 2
+}
+
+command_available() {
+  case "$1" in
+    */*) [ -x "$1" ] ;;
+    *) command -v "$1" >/dev/null 2>&1 ;;
+  esac
+}
+
+option_value_kind() {
+  case "$1" in
+    -j|--jobs) printf 'jobs\n' ;;
+    --parallel-binary-name) printf 'parallel-command\n' ;;
+    --code-quote-style|--line-reference-format|-f|--filter|--negative-filter|\
+      --filter-status|--filter-tags|-F|--formatter|\
+      --gather-test-outputs-in|--report-formatter|-o|--output)
+      printf 'bats-option\n'
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+is_python_target() {
+  case "$1" in
+    *.py|test/python/*|"$test_directory/python/"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+append_bats_target() {
+  local argument="$1"
+
+  bats_requested=true
+  if [[ "$argument" != *.bats && -f "$test_directory/$argument.bats" ]]; then
+    bats_arguments+=("$test_directory/$argument.bats")
+    has_bats_target=true
+    if [ -f "$test_directory/python/test_${argument}.py" ]; then
+      pytest_arguments+=("$test_directory/python/test_${argument}.py")
+      pytest_requested=true
+    fi
+  else
+    bats_arguments+=("$argument")
+    if [[ "$argument" == *.bats || -d "$argument" ]]; then
+      has_bats_target=true
+    fi
+  fi
+}
+
+resolve_arguments() {
+  local argument value_kind pending_value_kind=""
+
+  if [ "$#" -eq 0 ]; then
+    bats_requested=true
+    has_bats_target=true
+    bats_arguments+=("$test_directory/")
+    pytest_requested=true
+    pytest_arguments+=("$test_directory/python")
+    return
+  fi
+
+  for argument in ${@+"$@"}; do
+    if [ -n "$pending_value_kind" ]; then
+      case "$pending_value_kind" in
+        jobs) cli_jobs="$argument" ;;
+        parallel-command) cli_parallel_command="$argument" ;;
+        bats-option) bats_arguments+=("$argument") ;;
+      esac
+      pending_value_kind=""
+      continue
+    fi
+
+    case "$argument" in
+      --jobs=*)
+        bats_requested=true
+        cli_jobs="${argument#*=}"
+        continue
+        ;;
+      --parallel-binary-name=*)
+        bats_requested=true
+        cli_parallel_command="${argument#*=}"
+        continue
+        ;;
+    esac
+
+    if value_kind="$(option_value_kind "$argument")"; then
+      bats_requested=true
+      case "$value_kind" in
+        jobs|parallel-command) ;;
+        bats-option) bats_arguments+=("$argument") ;;
+      esac
+      pending_value_kind="$value_kind"
+      continue
+    fi
+
+    if is_python_target "$argument"; then
+      pytest_arguments+=("$argument")
+      pytest_requested=true
+    else
+      append_bats_target "$argument"
+    fi
+  done
+
+  case "$pending_value_kind" in
+    jobs) fail "--jobs requires a positive integer" ;;
+    parallel-command) fail "--parallel-binary-name requires a command" ;;
+    bats-option) fail "the final BATS option requires a value" ;;
+  esac
+
+  if $bats_requested && ! $has_bats_target; then
+    bats_arguments+=("$test_directory/")
+  fi
+}
+
+select_parallelism() {
+  if [ -n "$cli_jobs" ]; then
+    effective_jobs="$cli_jobs"
+  elif [ -n "${BATS_NUMBER_OF_PARALLEL_JOBS:-}" ]; then
+    effective_jobs="$BATS_NUMBER_OF_PARALLEL_JOBS"
+  else
+    effective_jobs="$default_parallel_jobs"
+  fi
+
+  [[ "$effective_jobs" =~ ^[1-9][0-9]*$ ]] ||
+    fail "BATS parallel jobs must be a positive integer, got '$effective_jobs'."
+
+  if [ -n "$cli_parallel_command" ]; then
+    effective_parallel_command="$cli_parallel_command"
+  elif [ -n "${BATS_PARALLEL_BINARY_NAME:-}" ]; then
+    effective_parallel_command="$BATS_PARALLEL_BINARY_NAME"
+  else
+    effective_parallel_command="$parallel_command"
+  fi
+}
+
+require_commands() {
+  if $bats_requested && ! command_available "$bats_command"; then
+    printf "Error: BATS executable '%s' is unavailable; run 'mise install'.\n" \
+      "$bats_command" >&2
+    exit 127
+  fi
+
+  if $bats_requested && [ "$effective_jobs" -gt 1 ] &&
+      ! command_available "$effective_parallel_command"; then
+    printf "Error: BATS parallel runner '%s' is unavailable for %s jobs; run 'mise install' or use --jobs 1.\n" \
+      "$effective_parallel_command" "$effective_jobs" >&2
+    exit 127
+  fi
+
+  if $pytest_requested && ! command_available "$uv_command"; then
+    printf "Error: uv executable '%s' is unavailable; run 'mise install'.\n" \
+      "$uv_command" >&2
+    exit 127
+  fi
+}
+
+run_bats() {
+  local call_arguments=(--jobs "$effective_jobs")
+
+  if [ "$effective_jobs" -gt 1 ]; then
+    call_arguments+=(--parallel-binary-name "$effective_parallel_command")
+    printf 'BATS parallelism: %s jobs within files via %s\n' \
+      "$effective_jobs" "$effective_parallel_command"
+  else
+    printf 'BATS parallelism: serial\n'
+  fi
+
+  call_arguments+=(${bats_arguments[@]+"${bats_arguments[@]}"})
+  "$bats_command" "${call_arguments[@]}"
+}
+
+run_pytest() {
+  "$uv_command" run --with pytest pytest \
+    ${pytest_arguments[@]+"${pytest_arguments[@]}"}
+}
+
+main() {
+  cd "$repo_root"
+  resolve_arguments "$@"
+  if $bats_requested; then
+    select_parallelism
+  fi
+  require_commands
+
+  if $bats_requested; then
+    run_bats
+  fi
+  if $pytest_requested; then
+    run_pytest
+  fi
+}
+
+main "$@"

--- a/test/setup_suite.bash
+++ b/test/setup_suite.bash
@@ -1,0 +1,32 @@
+setup_suite() {
+  REPO_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  export REPO_DIR
+
+  # Load this repo's declared tools even when a developer invokes BATS
+  # directly. Preserve BATS' own libexec path across mise's PATH rebuild.
+  local bats_libexec="${BATS_LIBEXEC:-}"
+  eval "$(cd "$REPO_DIR" && mise env)"
+  if [ -n "$bats_libexec" ]; then
+    export PATH="$bats_libexec:$PATH"
+  fi
+
+  # Agent sessions inject signing policy while clean CI has no author identity.
+  # Give every fixture one deterministic unsigned command-scope identity.
+  local name _value
+  unset GIT_CONFIG_COUNT GIT_CONFIG_PARAMETERS
+  while IFS='=' read -r name _value; do
+    case "$name" in
+      GIT_CONFIG_KEY_*|GIT_CONFIG_VALUE_*) unset "$name" ;;
+    esac
+  done < <(env)
+
+  export GIT_CONFIG_COUNT=4
+  export GIT_CONFIG_KEY_0=commit.gpgsign
+  export GIT_CONFIG_VALUE_0=false
+  export GIT_CONFIG_KEY_1=tag.gpgsign
+  export GIT_CONFIG_VALUE_1=false
+  export GIT_CONFIG_KEY_2=user.name
+  export GIT_CONFIG_VALUE_2="Notes tests"
+  export GIT_CONFIG_KEY_3=user.email
+  export GIT_CONFIG_VALUE_3=notes-tests@example.invalid
+}

--- a/test/test-task.bats
+++ b/test/test-task.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+
+load test_helper
+bats_require_minimum_version 1.5.0
+
+setup() {
+  export NOTES_CALLER_PWD="$BATS_TEST_TMPDIR"
+  mock_dir="$BATS_TEST_TMPDIR/mock-bin"
+  bats_log="$BATS_TEST_TMPDIR/bats.log"
+  uv_log="$BATS_TEST_TMPDIR/uv.log"
+  mkdir -p "$mock_dir"
+  export bats_log uv_log
+
+  cat > "$mock_dir/bats" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+for argument in "$@"; do
+  printf 'arg=%s\n' "$argument"
+done > "$bats_log"
+SH
+
+  cat > "$mock_dir/uv" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+for argument in "$@"; do
+  printf 'arg=%s\n' "$argument"
+done > "$uv_log"
+SH
+
+  cat > "$mock_dir/rush" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+
+  chmod +x "$mock_dir/bats" "$mock_dir/uv" "$mock_dir/rush"
+  export BATS_COMMAND="$mock_dir/bats"
+  export UV_COMMAND="$mock_dir/uv"
+  export RUSH_COMMAND="$mock_dir/rush"
+  unset BATS_NUMBER_OF_PARALLEL_JOBS BATS_PARALLEL_BINARY_NAME
+}
+
+arg_count() {
+  local log="$1"
+  local expected="$2"
+  awk -F= -v expected="$expected" \
+    '$1 == "arg" && substr($0, 5) == expected { count++ } END { print count + 0 }' \
+    "$log"
+}
+
+logged_arguments() {
+  sed -n 's/^arg=//p' "$1"
+}
+
+@test "test task preserves Notes' eight-worker within-file default" {
+  run notes test changes
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"8 jobs within files"* ]]
+  [ "$(arg_count "$bats_log" --jobs)" -eq 1 ]
+  [ "$(arg_count "$bats_log" 8)" -eq 1 ]
+  [ "$(arg_count "$bats_log" --parallel-binary-name)" -eq 1 ]
+  [ "$(arg_count "$bats_log" "$mock_dir/rush")" -eq 1 ]
+  [ "$(arg_count "$bats_log" --no-parallelize-within-files)" -eq 0 ]
+  [ "$(arg_count "$bats_log" "$REPO_DIR/test/changes.bats")" -eq 1 ]
+  [ ! -e "$uv_log" ]
+}
+
+@test "default test task runs the complete BATS and Python suites" {
+  run notes test
+
+  [ "$status" -eq 0 ]
+  [ "$(arg_count "$bats_log" "$REPO_DIR/test/")" -eq 1 ]
+  [ "$(logged_arguments "$uv_log")" = "$(printf '%s\n' \
+    run --with pytest pytest "$REPO_DIR/test/python")" ]
+}
+
+@test "bare suite name runs matching BATS and Python tests" {
+  run notes test audit
+
+  [ "$status" -eq 0 ]
+  [ "$(arg_count "$bats_log" "$REPO_DIR/test/audit.bats")" -eq 1 ]
+  [ "$(arg_count "$uv_log" "$REPO_DIR/test/python/test_audit.py")" -eq 1 ]
+}
+
+@test "explicit Python target does not start BATS" {
+  run notes test test/python/test_audit.py
+
+  [ "$status" -eq 0 ]
+  [ ! -e "$bats_log" ]
+  [ "$(arg_count "$uv_log" test/python/test_audit.py)" -eq 1 ]
+}
+
+@test "Python-only runs ignore irrelevant BATS parallelism state" {
+  export BATS_NUMBER_OF_PARALLEL_JOBS=invalid
+  export RUSH_COMMAND="$mock_dir/missing-rush"
+
+  run notes test test/python/test_audit.py
+
+  [ "$status" -eq 0 ]
+  [ ! -e "$bats_log" ]
+  [ "$(arg_count "$uv_log" test/python/test_audit.py)" -eq 1 ]
+}
+
+@test "BATS option values that look like Python paths stay BATS option values" {
+  run notes test --filter test/python/test_audit.py
+
+  [ "$status" -eq 0 ]
+  [ "$(logged_arguments "$bats_log")" = "$(printf '%s\n' \
+    --jobs 8 \
+    --parallel-binary-name "$mock_dir/rush" \
+    --filter test/python/test_audit.py \
+    "$REPO_DIR/test/")" ]
+  [ ! -e "$uv_log" ]
+}
+
+@test "explicit jobs override is forwarded once" {
+  run notes test --jobs 3 changes
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"3 jobs within files"* ]]
+  [ "$(arg_count "$bats_log" --jobs)" -eq 1 ]
+  [ "$(arg_count "$bats_log" 3)" -eq 1 ]
+  [ "$(arg_count "$bats_log" 8)" -eq 0 ]
+}
+
+@test "serial override does not require Rush" {
+  export RUSH_COMMAND="$mock_dir/missing-rush"
+
+  run notes test --jobs 1 changes
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BATS parallelism: serial"* ]]
+  [ "$(arg_count "$bats_log" --parallel-binary-name)" -eq 0 ]
+}
+
+@test "missing selected BATS executable fails before running either suite" {
+  export BATS_COMMAND="$mock_dir/missing-bats"
+
+  run -127 notes test
+
+  [ "$status" -eq 127 ]
+  [[ "$output" == *"BATS executable '$mock_dir/missing-bats' is unavailable"* ]]
+  [ ! -e "$bats_log" ]
+  [ ! -e "$uv_log" ]
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,36 +1,8 @@
-# Derive the repo root from BATS, not MISE_CONFIG_ROOT. Agent sessions can
-# inherit a stale MISE_CONFIG_ROOT from the launcher repo.
+# BATS loads helpers while discovering tests, before setup_suite runs. Derive
+# the repo root here so shared libraries can be sourced during discovery;
+# setup_suite owns the expensive tool environment and fixture Git identity.
 REPO_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
 export REPO_DIR
-
-# Load this repo's declared tools even when a developer runs `bats test/foo.bats`
-# directly instead of going through `mise run test`.
-eval "$(cd "$REPO_DIR" && mise env)"
-
-# Agent sessions inject command-scope git config so real workspace commits are
-# signed, while clean CI has no author identity at all. Tests should exercise
-# Git behavior without depending on either ambient state. Give every fixture a
-# deterministic unsigned identity at the same command scope.
-_disable_git_signing_for_tests() {
-  local name _value
-  unset GIT_CONFIG_COUNT GIT_CONFIG_PARAMETERS
-  while IFS='=' read -r name _value; do
-    case "$name" in
-      GIT_CONFIG_KEY_*|GIT_CONFIG_VALUE_*) unset "$name" ;;
-    esac
-  done < <(env)
-
-  export GIT_CONFIG_COUNT=4
-  export GIT_CONFIG_KEY_0=commit.gpgsign
-  export GIT_CONFIG_VALUE_0=false
-  export GIT_CONFIG_KEY_1=tag.gpgsign
-  export GIT_CONFIG_VALUE_1=false
-  export GIT_CONFIG_KEY_2=user.name
-  export GIT_CONFIG_VALUE_2="Notes tests"
-  export GIT_CONFIG_KEY_3=user.email
-  export GIT_CONFIG_VALUE_3=notes-tests@example.invalid
-}
-_disable_git_signing_for_tests
 
 # Source lib files at file-load time, not inside setup(). Most .bats files in
 # this suite override setup() to set their own NOTES_CALLER_PWD/fixtures, which


### PR DESCRIPTION
## Summary

- reduce the public mise task to Usage argument translation and move the mixed BATS/Python workflow into `libexec/test`
- preserve Notes' measured eight-worker, within-file BATS contract while adding explicit serial, environment, and CLI overrides
- classify BATS option values separately from Python targets, so a filter value ending in `.py` cannot silently select pytest
- run repo tool activation and deterministic fixture Git identity once in `setup_suite.bash` instead of once for every loaded test process
- add nine runner regressions covering default and targeted mixed suites, Python-only execution, option values, parallel overrides, and missing tools

This PR is stacked on #161. It intentionally does not copy Template's four-job files-only behavior, which was materially slower for Notes' large suites.

## Validation

- `mise run test test-task` (9 passed)
- `mise run test changes` (52 passed)
- `mise run test audit` (7 BATS and 9 Python passed)
- direct `bats test/common.bats` (18 passed)
- complete suite before the final narrow Python-only guard: 384 BATS and 9 Python passed
- all 8 configured codebase lints passed
- Bash syntax and `git diff --check` passed

## Measurement

The same complete-suite command was timed on the exact #161 parent and this branch. Cold/noisy runs were 259.93s before and 122.47s after. Repeats were 172.19s before and 150.14s after. The ranges do not justify one precise percentage, but both pairs improved while preserving eight-worker behavior and full correctness.

The final edit after the complete run only skips irrelevant BATS parallelism validation for an explicit Python-only target; its focused regression and the runner suite pass. The stacked hosted matrix is the intended final full integration proof.
