### PR TITLE
ci: check committed whitespace

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,9 @@ jobs:
         run: rudi install
 
       - name: Check whitespace
-        run: git diff --check
+        # A clean checkout has no working-tree diff. Compare the complete tree
+        # with Git's empty tree so committed whitespace errors still fail CI.
+        run: git diff --check "$(git hash-object -t tree /dev/null)" HEAD --
 
       - name: Run tests
         run: mise run test

--- a/test/ci.bats
+++ b/test/ci.bats
@@ -21,6 +21,11 @@ setup() {
   [ "$install_line" -lt "$test_line" ]
 }
 
+@test "hosted whitespace validation checks committed content" {
+  grep -Fq 'run: git diff --check "$(git hash-object -t tree /dev/null)" HEAD --' "$workflow"
+  ! grep -Eq 'run: git diff --check[[:space:]]*$' "$workflow"
+}
+
 @test "hosted validation runs the repository's configured convention lints" {
   grep -Fq 'run: codebase lint "$PWD"' "$workflow"
 }


### PR DESCRIPTION
## Summary

- make hosted whitespace validation inspect committed repository content instead of the necessarily clean checkout worktree
- add a regression that rejects the no-op `git diff --check` form

## Why

On a fresh Actions checkout, `git diff --check` compares the worktree and index and therefore succeeds even when the checked-out commit contains trailing whitespace. Comparing `HEAD` with Git's empty tree checks every tracked text line without needing base-ref history.

## Validation

- `mise run test ci` (4 passed)
- `codebase lint:github-actions "$PWD"`
- falsification in a temporary repo: plain `git diff --check` passed a clean checkout containing committed trailing whitespace; the whole-tree command rejected it
- `git diff --check`
