### PR TITLE
fix: fail closed on encryption inspection errors

### DIFF
--- a/hooks/encryption
+++ b/hooks/encryption
@@ -32,11 +32,19 @@ done < <(git check-attr --cached -z filter -- "${staged[@]}")
 bad_files=()
 for file in "${encrypted_staged[@]}"; do
   status_output=""
-  if ! status_output=$(git-crypt status -- "$file" 2>&1); then
-    : # git-crypt reports plaintext paths through output and a non-zero status.
+  status=0
+  if status_output=$(git-crypt status -- "$file" 2>&1); then
+    :
+  else
+    status=$?
   fi
+
   if grep -qi "not encrypted" <<< "$status_output"; then
     bad_files+=("$file")
+  elif [ "$status" -ne 0 ]; then
+    echo "ERROR: git-crypt could not inspect staged encrypted path: $file" >&2
+    [ -z "$status_output" ] || printf '%s\n' "$status_output" >&2
+    exit 1
   fi
 done
 

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -498,6 +498,32 @@ run_encryption_hook() {
   [ "$status" -eq 0 ]
 }
 
+@test "encryption hook fails closed when git-crypt cannot inspect a staged path (#49)" {
+  notes setup --yes
+  local fpr
+  fpr=$(generate_test_key "$GNUPGHOME")
+  notes add-user -- --gpg-key "$fpr"
+
+  mkdir -p "$TARGET_DIR/notes"
+  echo "secret" > "$TARGET_DIR/notes/ok.md"
+  git -C "$TARGET_DIR" add notes/ok.md
+
+  local mock_bin="$BATS_TEST_TMPDIR/mock-git-crypt-bin"
+  mkdir -p "$mock_bin"
+  cat > "$mock_bin/git-crypt" <<'SH'
+#!/usr/bin/env bash
+echo "backend inspection failed" >&2
+exit 73
+SH
+  chmod +x "$mock_bin/git-crypt"
+  export PATH="$mock_bin:$PATH"
+
+  run_encryption_hook
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"could not inspect staged encrypted path: notes/ok.md"* ]]
+  [[ "$output" == *"backend inspection failed"* ]]
+}
+
 # --- double-tracking pre-commit hook (#51) ---
 run_double_tracking_hook() {
   run bash -c "cd '$TARGET_DIR' && bash .git/hooks/pre-commit.d/verify-double-tracking"


### PR DESCRIPTION
## Summary

- distinguish git-crypt's recognized plaintext report from an unexpected inspection failure
- fail the encryption pre-commit hook closed when `git-crypt status` cannot inspect a staged encrypted path
- add an integration regression for a failing git-crypt backend

## Why

The lint cleanup made the previously broad suppression explicit, but it still treated every nonzero `git-crypt status` as expected. An operational failure whose output did not contain `not encrypted` therefore let the hook succeed without checking the staged path.

## Validation

- `mise run test integration --filter 'encryption hook'` (6 passed)
- `codebase lint:or-true "$PWD"`
- `bash -n hooks/encryption test/integration.bats`
- `git diff --check`
