### PR TITLE
docs: retain publication verification guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ notes diff HEAD~1..HEAD
 - Join an existing encrypted repo with `notes setup --yes --unlock`.
 - `setup`, `lock`, `install-hooks`, and `unlock --force` require explicit confirmation.
 - Prefer `notes commit` for note-only work; use `notes stage` when you need manual Git control.
+- Before publishing a ref, run `notes verify-blobs --ref HEAD --strict` to prove its managed blobs are encrypted and local note changes are absent.
 - `notes lock` currently locks every git-crypt path in the repository, not only `notes/`.
 - Use `notes conflicts` or `notes merge --dry-run` to materialize readable conflict artifacts.
 

--- a/README.tsx
+++ b/README.tsx
@@ -131,6 +131,7 @@ notes diff HEAD~1..HEAD`}</CodeBlock>
         <Item>Join an existing encrypted repo with <Code>notes setup --yes --unlock</Code>.</Item>
         <Item><Code>setup</Code>, <Code>lock</Code>, <Code>install-hooks</Code>, and <Code>unlock --force</Code> require explicit confirmation.</Item>
         <Item>Prefer <Code>notes commit</Code> for note-only work; use <Code>notes stage</Code> when you need manual Git control.</Item>
+        <Item>Before publishing a ref, run <Code>notes verify-blobs --ref HEAD --strict</Code> to prove its managed blobs are encrypted and local note changes are absent.</Item>
         <Item><Code>notes lock</Code> currently locks every git-crypt path in the repository, not only <Code>notes/</Code>.</Item>
         <Item>Use <Code>notes conflicts</Code> or <Code>notes merge --dry-run</Code> to materialize readable conflict artifacts.</Item>
       </List>


### PR DESCRIPTION
## Summary

- retain the publication-time `verify-blobs --strict` safety check in the compact generated README
- regenerate the checked-in Markdown

## Why

The generated rewrite removes the old README's publication verification workflow entirely. `notes --help` can list the command, but it does not tell a user that this is the final proof to run before publishing an encrypted ref.

## Validation

- `readme build --check`
- `mise run test doctor` (5 passed)
- `git diff --check`
