### PR TITLE
perf: batch note membership checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 397](https://img.shields.io/badge/tests-397-brightgreen?style=flat)](test/)
+[![tests: 398](https://img.shields.io/badge/tests-398-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/lib/changes.sh
+++ b/lib/changes.sh
@@ -39,7 +39,7 @@ detect_changes() {
   local repo_root="$RESOLVED_REPO_ROOT"
   local notes_dir="$RESOLVED_NOTES_DIR"
 
-  local tmp_dir head_in head_out disk_in disk_out manifest_ids manifest_names stale_readables
+  local tmp_dir head_in head_out disk_in disk_out manifest_ids manifest_names stale_readables all_files
   local tracked_attr_in readable_attr_in tracked_attr_out readable_attr_out
   tmp_dir=$(mktemp -d) || return
   head_in="$tmp_dir/head-in"
@@ -49,6 +49,7 @@ detect_changes() {
   manifest_ids="$tmp_dir/manifest-ids"
   manifest_names="$tmp_dir/manifest-names"
   stale_readables="$tmp_dir/stale-readables"
+  all_files="$tmp_dir/all-files"
   tracked_attr_in="$tmp_dir/tracked-attr-in"
   readable_attr_in="$tmp_dir/readable-attr-in"
   tracked_attr_out="$tmp_dir/tracked-attr-out"
@@ -58,6 +59,7 @@ detect_changes() {
   : > "$manifest_ids"
   : > "$manifest_names"
   : > "$stale_readables"
+  : > "$all_files"
   : > "$tracked_attr_in"
   : > "$readable_attr_in"
 
@@ -167,29 +169,36 @@ detect_changes() {
   exec 3<&-
   exec 4<&-
 
-  # Scan for new files not yet in the manifest.
-  while IFS= read -r f; do
-    [ ! -f "$f" ] && continue
-    local relpath="${f#"$abs_notes_dir"/}"
-    [[ "$relpath" == ".manifest" ]] && continue
+  # Classify files not represented by the current manifest in one set pass.
+  # Per-file grep and basename processes dominate this path at repository scale.
+  if ! find "$abs_notes_dir" -type f | sort > "$all_files"; then
+    rm -rf "$tmp_dir"
+    return
+  fi
+  awk \
+    -v ids_file="$manifest_ids" \
+    -v names_file="$manifest_names" \
+    -v stale_file="$stale_readables" \
+    -v files_file="$all_files" \
+    -v root="$abs_notes_dir/" '
+      FILENAME == ids_file   { ids[$0] = 1; next }
+      FILENAME == names_file { names[$0] = 1; next }
+      FILENAME == stale_file { stale[$0] = 1; next }
+      FILENAME == files_file {
+        relpath = substr($0, length(root) + 1)
+        if (relpath == ".manifest") next
 
-    # Skip obfuscated IDs that are in the manifest.
-    local base
-    base=$(basename "$relpath")
-    grep -Fxq "$base" "$manifest_ids" && continue
+        count = split(relpath, parts, "/")
+        base = parts[count]
+        if (base in ids || relpath in names) next
 
-    # Skip files already in the manifest by readable name.
-    grep -Fxq "$relpath" "$manifest_names" && continue
-
-    # Stale generated readables are a reconciliation issue, not author intent.
-    if grep -Fxq "$relpath" "$stale_readables"; then
-      printf 'stale-readable\t%s\n' "$relpath"
-      continue
-    fi
-
-    # This is a genuinely new file.
-    printf 'new\t%s\n' "$relpath"
-  done < <(find "$abs_notes_dir" -type f | sort)
+        if (relpath in stale) {
+          print "stale-readable\t" relpath
+        } else {
+          print "new\t" relpath
+        }
+      }
+    ' "$manifest_ids" "$manifest_names" "$stale_readables" "$all_files"
 
   rm -rf "$tmp_dir"
 }

--- a/lib/suppress.sh
+++ b/lib/suppress.sh
@@ -389,12 +389,16 @@ detect_stale_readable_notes() {
 
   local relpaths relpath file known_hash current_hash state_label
   relpaths="$tmp_dir/relpaths"
-  cut -f1 "$candidates" | sort -u > "$relpaths"
+  awk -F '\t' \
+    -v current_names_file="$current_names" \
+    -v candidates_file="$candidates" '
+      FILENAME == current_names_file { current[$0] = 1; next }
+      FILENAME == candidates_file && $1 != "" && !($1 in current) { print $1 }
+    ' "$current_names" "$candidates" | sort -u > "$relpaths"
 
   while IFS= read -r relpath; do
     [ -n "$relpath" ] || continue
     _note_relpath_is_safe "$relpath" || continue
-    grep -Fxq "$relpath" "$current_names" && continue
 
     file="$abs_notes_dir/$relpath"
     [ -f "$file" ] || continue

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -30,6 +30,50 @@ setup() {
   set_status_suppression "$NOTES_CALLER_PWD/notes"
 }
 
+add_clean_numbered_notes() {
+  local count="$1"
+  local i=1 name
+  while [ "$i" -le "$count" ]; do
+    name=$(printf 'note-%02d.md' "$i")
+    printf '# Note %02d\n' "$i" > "$NOTES_CALLER_PWD/notes/$name"
+    i=$((i + 1))
+  done
+
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "add many notes"
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
+  set_status_suppression "$NOTES_CALLER_PWD/notes"
+}
+
+install_process_counter() {
+  local command="$1"
+  local real_command
+  real_command=$(command -v "$command")
+  cat > "$PROCESS_COUNTER_BIN/$command" <<SH
+#!/usr/bin/env bash
+printf '1\\n' >> "\${NOTES_PROCESS_COUNTER_DIR:?}/$command.calls"
+exec '$real_command' "\$@"
+SH
+  chmod +x "$PROCESS_COUNTER_BIN/$command"
+}
+
+setup_membership_process_counters() {
+  PROCESS_COUNTER_BIN="$BATS_TEST_TMPDIR/process-counter-bin"
+  NOTES_PROCESS_COUNTER_DIR="$BATS_TEST_TMPDIR/process-counter-results"
+  mkdir -p "$PROCESS_COUNTER_BIN" "$NOTES_PROCESS_COUNTER_DIR"
+  export NOTES_PROCESS_COUNTER_DIR
+  install_process_counter grep
+  install_process_counter basename
+}
+
+run_with_process_counters() {
+  local function_name="$1"
+  shift
+  PATH="$PROCESS_COUNTER_BIN:$PATH"
+  "$function_name" "$@"
+}
+
 record_deobfuscation_state_for_manifest() {
   local ids=()
   while IFS=$'\t' read -r id relpath; do
@@ -152,34 +196,36 @@ SH
   [ -z "$output" ]
 }
 
-@test "detect_changes: handles many notes with mixed changes" {
-  local i name delete_id
-
-  i=1
-  while [ "$i" -le 40 ]; do
-    name=$(printf 'note-%02d.md' "$i")
-    printf '# Note %02d\n' "$i" > "$NOTES_CALLER_PWD/notes/$name"
-    i=$((i + 1))
-  done
-
-  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
-  git -C "$NOTES_CALLER_PWD" add -A
-  git -C "$NOTES_CALLER_PWD" commit -q -m "add many notes"
-  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
-  set_status_suppression "$NOTES_CALLER_PWD/notes"
+@test "detect_changes: handles many notes without per-note membership processes" {
+  local delete_id
+  add_clean_numbered_notes 40
 
   printf '# Note 10 edited\n' > "$NOTES_CALLER_PWD/notes/note-10.md"
   printf '# New\n' > "$NOTES_CALLER_PWD/notes/new.md"
   rm "$NOTES_CALLER_PWD/notes/note-20.md"
   delete_id=$(manifest_id_for_name "$MANIFEST" "note-20.md")
   rm -f "$NOTES_CALLER_PWD/notes/$delete_id"
+  setup_membership_process_counters
 
-  run detect_changes "$NOTES_CALLER_PWD/notes"
+  run run_with_process_counters detect_changes "$NOTES_CALLER_PWD/notes"
   [ "$status" -eq 0 ]
   [[ "$output" == *"modified"*"note-10.md"* ]]
   [[ "$output" == *"deleted"*"note-20.md"* ]]
   [[ "$output" == *"new"*"new.md"* ]]
   [[ "$output" != *"note-30.md"* ]]
+  [ ! -e "$NOTES_PROCESS_COUNTER_DIR/grep.calls" ]
+  [ ! -e "$NOTES_PROCESS_COUNTER_DIR/basename.calls" ]
+}
+
+@test "detect_stale_readable_notes: current notes do not launch membership processes" {
+  add_clean_numbered_notes 40
+  setup_membership_process_counters
+
+  run run_with_process_counters detect_stale_readable_notes "$NOTES_CALLER_PWD/notes"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  [ ! -e "$NOTES_PROCESS_COUNTER_DIR/grep.calls" ]
+  [ ! -e "$NOTES_PROCESS_COUNTER_DIR/basename.calls" ]
 }
 
 @test "detect_changes: preserves tracked-path filter semantics when attrs differ" {


### PR DESCRIPTION
## Summary

- classify manifest IDs, readable names, stale readables, and discovered files in one `awk` set pass
- remove per-current-note `grep` membership checks from stale-readable detection
- add process-count regressions proving note count does not launch `grep` or `basename`

## Evidence

On Fold's clean 535-note corpus, one comparable warm run of current main took 25.519s. One post-change run took 7.700s. These single samples show the expected large change; they are not a repeated benchmark claim.

The removed loops account for roughly 535 `basename` and 1,605 `grep` processes, matching the previous hosted process trace.

## Validation

- `mise run test test/changes.bats` (53/53)
- `mise run test` (390 BATS, 9 Python)
- `codebase lint .` (8/8)
- `git diff --check`
- Fold `git:pre-commit`
- Fold `git:pre-push`
