### PR TITLE
perf: reuse plaintext change baselines

### DIFF
--- a/.mise/tasks/lock
+++ b/.mise/tasks/lock
@@ -37,3 +37,8 @@ else
   # files, not just notes. Tracked in KnickKnackLabs/rudi#5.
   echo "Note: lock re-encrypts all encrypted files in this repo (rudi#5)."
 fi
+
+# Raw plaintext hashes accelerate change detection only while readable notes
+# exist. Do not retain those offline-verifiable fingerprints after locking.
+state_file=$(git rev-parse --git-path info/notes-obfuscation-state)
+rm -f "$state_file"

--- a/.mise/tasks/lock
+++ b/.mise/tasks/lock
@@ -29,6 +29,12 @@ if [ -f "$TARGET_DIR/notes/.manifest" ]; then
   git -C "$TARGET_DIR" add notes/
 fi
 
+# Raw plaintext hashes accelerate change detection only while readable notes
+# exist. Remove those offline-verifiable fingerprints before encryption so an
+# interrupted lock cannot leave them behind in an otherwise locked checkout.
+state_file=$(git rev-parse --git-path info/notes-obfuscation-state)
+rm -f "$state_file"
+
 if [ -n "${usage_key:-}" ]; then
   rudi lock --key "$usage_key"
 else
@@ -37,8 +43,3 @@ else
   # files, not just notes. Tracked in KnickKnackLabs/rudi#5.
   echo "Note: lock re-encrypts all encrypted files in this repo (rudi#5)."
 fi
-
-# Raw plaintext hashes accelerate change detection only while readable notes
-# exist. Do not retain those offline-verifiable fingerprints after locking.
-state_file=$(git rev-parse --git-path info/notes-obfuscation-state)
-rm -f "$state_file"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 398](https://img.shields.io/badge/tests-398-brightgreen?style=flat)](test/)
+[![tests: 402](https://img.shields.io/badge/tests-402-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 403](https://img.shields.io/badge/tests-403-brightgreen?style=flat)](test/)
+[![tests: 404](https://img.shields.io/badge/tests-404-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 402](https://img.shields.io/badge/tests-402-brightgreen?style=flat)](test/)
+[![tests: 403](https://img.shields.io/badge/tests-403-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/lib/changes.sh
+++ b/lib/changes.sh
@@ -39,13 +39,19 @@ detect_changes() {
   local repo_root="$RESOLVED_REPO_ROOT"
   local notes_dir="$RESOLVED_NOTES_DIR"
 
-  local tmp_dir head_in head_out disk_in disk_out manifest_ids manifest_names stale_readables all_files
+  local tmp_dir head_in head_out raw_in raw_out state_aligned detected
+  local fallback_in fallback_meta fallback_out manifest_ids manifest_names stale_readables all_files
   local tracked_attr_in readable_attr_in tracked_attr_out readable_attr_out
   tmp_dir=$(mktemp -d) || return
   head_in="$tmp_dir/head-in"
   head_out="$tmp_dir/head-out"
-  disk_in="$tmp_dir/disk-in"
-  disk_out="$tmp_dir/disk-out"
+  raw_in="$tmp_dir/raw-in"
+  raw_out="$tmp_dir/raw-out"
+  state_aligned="$tmp_dir/state-aligned"
+  detected="$tmp_dir/detected"
+  fallback_in="$tmp_dir/fallback-in"
+  fallback_meta="$tmp_dir/fallback-meta"
+  fallback_out="$tmp_dir/fallback-out"
   manifest_ids="$tmp_dir/manifest-ids"
   manifest_names="$tmp_dir/manifest-names"
   stale_readables="$tmp_dir/stale-readables"
@@ -55,7 +61,11 @@ detect_changes() {
   tracked_attr_out="$tmp_dir/tracked-attr-out"
   readable_attr_out="$tmp_dir/readable-attr-out"
   : > "$head_in"
-  : > "$disk_in"
+  : > "$raw_in"
+  : > "$detected"
+  : > "$fallback_in"
+  : > "$fallback_meta"
+  : > "$fallback_out"
   : > "$manifest_ids"
   : > "$manifest_names"
   : > "$stale_readables"
@@ -70,9 +80,7 @@ detect_changes() {
     printf '%s\n' "$relpath" >> "$manifest_names"
 
     if [ -f "$abs_notes_dir/$relpath" ]; then
-      printf '%s/%s\n' "$notes_dir" "$relpath" >> "$disk_in"
-      printf '%s/%s\n' "$notes_dir" "$id" >> "$tracked_attr_in"
-      printf '%s/%s\n' "$notes_dir" "$relpath" >> "$readable_attr_in"
+      printf '%s/%s\n' "$notes_dir" "$relpath" >> "$raw_in"
     fi
   done < "$manifest"
 
@@ -90,13 +98,92 @@ detect_changes() {
     rm -rf "$tmp_dir"
     return
   }
+  if [ -s "$raw_in" ]; then
+    git -C "$repo_root" hash-object --no-filters --stdin-paths \
+      < "$raw_in" > "$raw_out" 2>/dev/null || {
+        rm -rf "$tmp_dir"
+        return
+      }
+  else
+    : > "$raw_out"
+  fi
 
-  local use_batch_hash=true
-  if [ -s "$disk_in" ]; then
-    # `hash-object --stdin-paths` hashes each readable file using attributes for
-    # that readable path. The old per-file implementation hashes readable bytes
-    # as the tracked obfuscated path (`--path=$notes_dir/$id`). Preserve that
-    # behavior by batching only when clean-filter-relevant attributes match.
+  local state_file=""
+  if declare -F _deobfuscation_state_file >/dev/null 2>&1; then
+    state_file=$(_deobfuscation_state_file "$abs_notes_dir" 2>/dev/null) || state_file=""
+  fi
+  if [ -n "$state_file" ] && [ -f "$state_file" ]; then
+    awk -F '\t' '
+      FNR == NR {
+        if (NF >= 4) {
+          path[$1] = $2
+          tracked[$1] = $3
+          raw[$1] = $4
+        } else {
+          delete path[$1]
+          delete tracked[$1]
+          delete raw[$1]
+        }
+        next
+      }
+      {
+        if ($1 in path && path[$1] == $2) {
+          print tracked[$1] "|" raw[$1]
+        } else {
+          print "|"
+        }
+      }
+    ' "$state_file" "$manifest" > "$state_aligned"
+  else
+    awk '$1 != "" { print "|" }' "$manifest" > "$state_aligned"
+  fi
+
+  exec 3< "$head_out"
+  exec 4< "$raw_out"
+  exec 5< "$state_aligned"
+  while IFS=$'\t' read -r id relpath; do
+    [ -z "$id" ] && continue
+
+    local readable_file="$abs_notes_dir/$relpath"
+    local head_hash head_exists=true state_pair state_tracked state_raw raw_hash
+    IFS= read -r head_hash <&3 || head_hash=""
+    IFS= read -r state_pair <&5 || state_pair="|"
+    state_tracked="${state_pair%%|*}"
+    state_raw="${state_pair#*|}"
+    case "$head_hash" in
+      *" missing") head_exists=false ;;
+    esac
+
+    if [ -f "$readable_file" ]; then
+      IFS= read -r raw_hash <&4 || raw_hash=""
+
+      if ! $head_exists; then
+        printf 'new\t%s\n' "$relpath" >> "$detected"
+      elif [ -n "$state_raw" ] && [ "$state_tracked" = "$head_hash" ]; then
+        [ "$state_raw" != "$raw_hash" ] && printf 'modified\t%s\n' "$relpath" >> "$detected"
+      else
+        printf '%s/%s\n' "$notes_dir" "$relpath" >> "$fallback_in"
+        printf '%s\t%s\t%s\n' "$id" "$relpath" "$head_hash" >> "$fallback_meta"
+        printf '%s/%s\n' "$notes_dir" "$id" >> "$tracked_attr_in"
+        printf '%s/%s\n' "$notes_dir" "$relpath" >> "$readable_attr_in"
+      fi
+    else
+      # Readable name not on disk — check if obfuscated form exists. If neither
+      # exists and HEAD has the obfuscated blob, the note was deleted. If the
+      # obfuscated form exists on disk, the file isn't deobfuscated — skip.
+      if [ ! -f "$abs_notes_dir/$id" ] && $head_exists; then
+        printf 'deleted\t%s\n' "$relpath" >> "$detected"
+      fi
+    fi
+  done < "$manifest"
+  exec 3<&-
+  exec 4<&-
+  exec 5<&-
+
+  if [ -s "$fallback_in" ]; then
+    local use_batch_hash=true
+    # Preserve tracked-path filter semantics for legacy, missing, or stale
+    # state rows. Current four-field rows bypass filters through raw hashes.
     if git -C "$repo_root" check-attr --stdin \
       filter text eol ident working-tree-encoding \
       < "$tracked_attr_in" > "$tracked_attr_out.raw" 2>/dev/null; then
@@ -111,63 +198,32 @@ detect_changes() {
     else
       use_batch_hash=false
     fi
+
     if $use_batch_hash && cmp -s "$tracked_attr_out" "$readable_attr_out"; then
-      git -C "$repo_root" hash-object --stdin-paths < "$disk_in" > "$disk_out" 2>/dev/null || {
-        rm -rf "$tmp_dir"
-        return
-      }
+      git -C "$repo_root" hash-object --stdin-paths \
+        < "$fallback_in" > "$fallback_out" 2>/dev/null || {
+          rm -rf "$tmp_dir"
+          return
+        }
+
+      exec 6< "$fallback_out"
+      while IFS=$'\t' read -r id relpath head_hash; do
+        local disk_hash
+        IFS= read -r disk_hash <&6 || disk_hash=""
+        [ "$head_hash" != "$disk_hash" ] && printf 'modified\t%s\n' "$relpath" >> "$detected"
+      done < "$fallback_meta"
+      exec 6<&-
     else
-      use_batch_hash=false
-      : > "$disk_out"
+      while IFS=$'\t' read -r id relpath head_hash; do
+        local disk_hash
+        disk_hash=$(git -C "$repo_root" hash-object \
+          --path="$notes_dir/$id" "$abs_notes_dir/$relpath" 2>/dev/null) || continue
+        [ "$head_hash" != "$disk_hash" ] && printf 'modified\t%s\n' "$relpath" >> "$detected"
+      done < "$fallback_meta"
     fi
-  else
-    : > "$disk_out"
   fi
 
-  exec 3< "$head_out"
-  exec 4< "$disk_out"
-  while IFS=$'\t' read -r id relpath; do
-    [ -z "$id" ] && continue
-
-    local readable_file="$abs_notes_dir/$relpath"
-    local head_hash head_exists=true
-    IFS= read -r head_hash <&3 || head_hash=""
-    case "$head_hash" in
-      *" missing") head_exists=false ;;
-    esac
-
-    if [ -f "$readable_file" ]; then
-      # File exists on disk — check if it's new or modified.
-      if ! $head_exists; then
-        printf 'new\t%s\n' "$relpath"
-        if $use_batch_hash; then
-          if ! IFS= read -r _disk_hash <&4; then
-            _disk_hash=""
-          fi
-        fi
-        continue
-      fi
-
-      local disk_hash
-      if $use_batch_hash; then
-        IFS= read -r disk_hash <&4 || disk_hash=""
-      else
-        disk_hash=$(git -C "$repo_root" hash-object --path="$notes_dir/$id" "$readable_file" 2>/dev/null) || continue
-      fi
-      if [ "$head_hash" != "$disk_hash" ]; then
-        printf 'modified\t%s\n' "$relpath"
-      fi
-    else
-      # Readable name not on disk — check if obfuscated form exists. If neither
-      # exists and HEAD has the obfuscated blob, the note was deleted. If the
-      # obfuscated form exists on disk, the file isn't deobfuscated — skip.
-      if [ ! -f "$abs_notes_dir/$id" ] && $head_exists; then
-        printf 'deleted\t%s\n' "$relpath"
-      fi
-    fi
-  done < "$manifest"
-  exec 3<&-
-  exec 4<&-
+  cat "$detected"
 
   # Classify files not represented by the current manifest in one set pass.
   # Per-file grep and basename processes dominate this path at repository scale.

--- a/lib/changes.sh
+++ b/lib/changes.sh
@@ -26,61 +26,32 @@ detect_dual_present_conflicts() {
   done < "$manifest"
 }
 
-# Detect changed notes relative to HEAD.
-# Outputs one line per change: "<status>\t<readable_name>"
-# Status values: modified, new, deleted
-# Usage: detect_changes <abs_notes_dir>
-detect_changes() {
-  local abs_notes_dir="${1:?usage: detect_changes <abs_notes_dir>}"
+_prepare_change_detection_workspace() {
+  local abs_notes_dir="$1" repo_root="$2" notes_dir="$3" workspace="$4"
   local manifest="$abs_notes_dir/.manifest"
-  [ ! -f "$manifest" ] && return
+  local id relpath state_file=""
 
-  resolve_notes_dir "$abs_notes_dir" || return
-  local repo_root="$RESOLVED_REPO_ROOT"
-  local notes_dir="$RESOLVED_NOTES_DIR"
-
-  local tmp_dir head_in head_out raw_in raw_out state_aligned detected
-  local fallback_in fallback_meta fallback_out manifest_ids manifest_names stale_readables all_files
-  local tracked_attr_in readable_attr_in tracked_attr_out readable_attr_out
-  tmp_dir=$(mktemp -d) || return
-  head_in="$tmp_dir/head-in"
-  head_out="$tmp_dir/head-out"
-  raw_in="$tmp_dir/raw-in"
-  raw_out="$tmp_dir/raw-out"
-  state_aligned="$tmp_dir/state-aligned"
-  detected="$tmp_dir/detected"
-  fallback_in="$tmp_dir/fallback-in"
-  fallback_meta="$tmp_dir/fallback-meta"
-  fallback_out="$tmp_dir/fallback-out"
-  manifest_ids="$tmp_dir/manifest-ids"
-  manifest_names="$tmp_dir/manifest-names"
-  stale_readables="$tmp_dir/stale-readables"
-  all_files="$tmp_dir/all-files"
-  tracked_attr_in="$tmp_dir/tracked-attr-in"
-  readable_attr_in="$tmp_dir/readable-attr-in"
-  tracked_attr_out="$tmp_dir/tracked-attr-out"
-  readable_attr_out="$tmp_dir/readable-attr-out"
-  : > "$head_in"
-  : > "$raw_in"
-  : > "$detected"
-  : > "$fallback_in"
-  : > "$fallback_meta"
-  : > "$fallback_out"
-  : > "$manifest_ids"
-  : > "$manifest_names"
-  : > "$stale_readables"
-  : > "$all_files"
-  : > "$tracked_attr_in"
-  : > "$readable_attr_in"
+  : > "$workspace/head-in"
+  : > "$workspace/raw-in"
+  : > "$workspace/detected"
+  : > "$workspace/fallback-in"
+  : > "$workspace/fallback-meta"
+  : > "$workspace/fallback-out"
+  : > "$workspace/manifest-ids"
+  : > "$workspace/manifest-names"
+  : > "$workspace/stale-readables"
+  : > "$workspace/all-files"
+  : > "$workspace/tracked-attr-in"
+  : > "$workspace/readable-attr-in"
 
   while IFS=$'\t' read -r id relpath; do
     [ -z "$id" ] && continue
-    printf 'HEAD:%s/%s\n' "$notes_dir" "$id" >> "$head_in"
-    printf '%s\n' "$id" >> "$manifest_ids"
-    printf '%s\n' "$relpath" >> "$manifest_names"
+    printf 'HEAD:%s/%s\n' "$notes_dir" "$id" >> "$workspace/head-in"
+    printf '%s\n' "$id" >> "$workspace/manifest-ids"
+    printf '%s\n' "$relpath" >> "$workspace/manifest-names"
 
     if [ -f "$abs_notes_dir/$relpath" ]; then
-      printf '%s/%s\n' "$notes_dir" "$relpath" >> "$raw_in"
+      printf '%s/%s\n' "$notes_dir" "$relpath" >> "$workspace/raw-in"
     fi
   done < "$manifest"
 
@@ -89,26 +60,20 @@ detect_changes() {
     if ! detect_stale_readable_notes "$abs_notes_dir" 2>/dev/null \
       | while IFS=$'\t' read -r _stale_state stale_relpath; do
           [ -n "$stale_relpath" ] && printf '%s\n' "$stale_relpath"
-        done > "$stale_readables"; then
+        done > "$workspace/stale-readables"; then
       :
     fi
   fi
 
-  git -C "$repo_root" cat-file --batch-check='%(objectname)' < "$head_in" > "$head_out" 2>/dev/null || {
-    rm -rf "$tmp_dir"
-    return
-  }
-  if [ -s "$raw_in" ]; then
+  git -C "$repo_root" cat-file --batch-check='%(objectname)' \
+    < "$workspace/head-in" > "$workspace/head-out" 2>/dev/null || return 1
+  if [ -s "$workspace/raw-in" ]; then
     git -C "$repo_root" hash-object --no-filters --stdin-paths \
-      < "$raw_in" > "$raw_out" 2>/dev/null || {
-        rm -rf "$tmp_dir"
-        return
-      }
+      < "$workspace/raw-in" > "$workspace/raw-out" 2>/dev/null || return 1
   else
-    : > "$raw_out"
+    : > "$workspace/raw-out"
   fi
 
-  local state_file=""
   if declare -F _deobfuscation_state_file >/dev/null 2>&1; then
     state_file=$(_deobfuscation_state_file "$abs_notes_dir" 2>/dev/null) || state_file=""
   fi
@@ -133,19 +98,25 @@ detect_changes() {
           print "|"
         }
       }
-    ' "$state_file" "$manifest" > "$state_aligned"
+    ' "$state_file" "$manifest" > "$workspace/state-aligned"
   else
-    awk '$1 != "" { print "|" }' "$manifest" > "$state_aligned"
+    awk '$1 != "" { print "|" }' "$manifest" > "$workspace/state-aligned"
   fi
+}
 
-  exec 3< "$head_out"
-  exec 4< "$raw_out"
-  exec 5< "$state_aligned"
+_classify_manifest_changes() {
+  local abs_notes_dir="$1" notes_dir="$2" workspace="$3"
+  local manifest="$abs_notes_dir/.manifest"
+  local id relpath readable_file head_hash head_exists state_pair state_tracked state_raw raw_hash
+
+  exec 3< "$workspace/head-out"
+  exec 4< "$workspace/raw-out"
+  exec 5< "$workspace/state-aligned"
   while IFS=$'\t' read -r id relpath; do
     [ -z "$id" ] && continue
 
-    local readable_file="$abs_notes_dir/$relpath"
-    local head_hash head_exists=true state_pair state_tracked state_raw raw_hash
+    readable_file="$abs_notes_dir/$relpath"
+    head_exists=true
     IFS= read -r head_hash <&3 || head_hash=""
     IFS= read -r state_pair <&5 || state_pair="|"
     state_tracked="${state_pair%%|*}"
@@ -158,84 +129,78 @@ detect_changes() {
       IFS= read -r raw_hash <&4 || raw_hash=""
 
       if ! $head_exists; then
-        printf 'new\t%s\n' "$relpath" >> "$detected"
+        printf 'new\t%s\n' "$relpath" >> "$workspace/detected"
       elif [ -n "$state_raw" ] && [ "$state_tracked" = "$head_hash" ]; then
-        [ "$state_raw" != "$raw_hash" ] && printf 'modified\t%s\n' "$relpath" >> "$detected"
+        [ "$state_raw" != "$raw_hash" ] && printf 'modified\t%s\n' "$relpath" >> "$workspace/detected"
       else
-        printf '%s/%s\n' "$notes_dir" "$relpath" >> "$fallback_in"
-        printf '%s\t%s\t%s\n' "$id" "$relpath" "$head_hash" >> "$fallback_meta"
-        printf '%s/%s\n' "$notes_dir" "$id" >> "$tracked_attr_in"
-        printf '%s/%s\n' "$notes_dir" "$relpath" >> "$readable_attr_in"
+        printf '%s/%s\n' "$notes_dir" "$relpath" >> "$workspace/fallback-in"
+        printf '%s\t%s\t%s\n' "$id" "$relpath" "$head_hash" >> "$workspace/fallback-meta"
+        printf '%s/%s\n' "$notes_dir" "$id" >> "$workspace/tracked-attr-in"
+        printf '%s/%s\n' "$notes_dir" "$relpath" >> "$workspace/readable-attr-in"
       fi
-    else
-      # Readable name not on disk — check if obfuscated form exists. If neither
-      # exists and HEAD has the obfuscated blob, the note was deleted. If the
-      # obfuscated form exists on disk, the file isn't deobfuscated — skip.
-      if [ ! -f "$abs_notes_dir/$id" ] && $head_exists; then
-        printf 'deleted\t%s\n' "$relpath" >> "$detected"
-      fi
+    elif [ ! -f "$abs_notes_dir/$id" ] && $head_exists; then
+      # If the obfuscated form still exists, the note simply is not deobfuscated.
+      printf 'deleted\t%s\n' "$relpath" >> "$workspace/detected"
     fi
   done < "$manifest"
   exec 3<&-
   exec 4<&-
   exec 5<&-
+}
 
-  if [ -s "$fallback_in" ]; then
-    local use_batch_hash=true
-    # Preserve tracked-path filter semantics for legacy, missing, or stale
-    # state rows. Current four-field rows bypass filters through raw hashes.
-    if git -C "$repo_root" check-attr --stdin \
-      filter text eol ident working-tree-encoding \
-      < "$tracked_attr_in" > "$tracked_attr_out.raw" 2>/dev/null; then
-      sed 's/^[^:]*: //' "$tracked_attr_out.raw" > "$tracked_attr_out"
-    else
-      use_batch_hash=false
-    fi
-    if git -C "$repo_root" check-attr --stdin \
-      filter text eol ident working-tree-encoding \
-      < "$readable_attr_in" > "$readable_attr_out.raw" 2>/dev/null; then
-      sed 's/^[^:]*: //' "$readable_attr_out.raw" > "$readable_attr_out"
-    else
-      use_batch_hash=false
-    fi
+_classify_fallback_changes() {
+  local repo_root="$1" notes_dir="$2" abs_notes_dir="$3" workspace="$4"
+  [ -s "$workspace/fallback-in" ] || return 0
 
-    if $use_batch_hash && cmp -s "$tracked_attr_out" "$readable_attr_out"; then
-      git -C "$repo_root" hash-object --stdin-paths \
-        < "$fallback_in" > "$fallback_out" 2>/dev/null || {
-          rm -rf "$tmp_dir"
-          return
-        }
-
-      exec 6< "$fallback_out"
-      while IFS=$'\t' read -r id relpath head_hash; do
-        local disk_hash
-        IFS= read -r disk_hash <&6 || disk_hash=""
-        [ "$head_hash" != "$disk_hash" ] && printf 'modified\t%s\n' "$relpath" >> "$detected"
-      done < "$fallback_meta"
-      exec 6<&-
-    else
-      while IFS=$'\t' read -r id relpath head_hash; do
-        local disk_hash
-        disk_hash=$(git -C "$repo_root" hash-object \
-          --path="$notes_dir/$id" "$abs_notes_dir/$relpath" 2>/dev/null) || continue
-        [ "$head_hash" != "$disk_hash" ] && printf 'modified\t%s\n' "$relpath" >> "$detected"
-      done < "$fallback_meta"
-    fi
+  local use_batch_hash=true
+  local id relpath head_hash disk_hash
+  # Preserve tracked-path filter semantics for legacy, missing, or stale
+  # state rows. Current four-field rows bypass filters through raw hashes.
+  if git -C "$repo_root" check-attr --stdin \
+    filter text eol ident working-tree-encoding \
+    < "$workspace/tracked-attr-in" > "$workspace/tracked-attr-out.raw" 2>/dev/null; then
+    sed 's/^[^:]*: //' "$workspace/tracked-attr-out.raw" > "$workspace/tracked-attr-out"
+  else
+    use_batch_hash=false
+  fi
+  if git -C "$repo_root" check-attr --stdin \
+    filter text eol ident working-tree-encoding \
+    < "$workspace/readable-attr-in" > "$workspace/readable-attr-out.raw" 2>/dev/null; then
+    sed 's/^[^:]*: //' "$workspace/readable-attr-out.raw" > "$workspace/readable-attr-out"
+  else
+    use_batch_hash=false
   fi
 
-  cat "$detected"
+  if $use_batch_hash && cmp -s "$workspace/tracked-attr-out" "$workspace/readable-attr-out"; then
+    git -C "$repo_root" hash-object --stdin-paths \
+      < "$workspace/fallback-in" > "$workspace/fallback-out" 2>/dev/null || return 1
 
-  # Classify files not represented by the current manifest in one set pass.
-  # Per-file grep and basename processes dominate this path at repository scale.
-  if ! find "$abs_notes_dir" -type f | sort > "$all_files"; then
-    rm -rf "$tmp_dir"
-    return
+    exec 6< "$workspace/fallback-out"
+    while IFS=$'\t' read -r id relpath head_hash; do
+      IFS= read -r disk_hash <&6 || disk_hash=""
+      [ "$head_hash" != "$disk_hash" ] && printf 'modified\t%s\n' "$relpath" >> "$workspace/detected"
+    done < "$workspace/fallback-meta"
+    exec 6<&-
+  else
+    while IFS=$'\t' read -r id relpath head_hash; do
+      disk_hash=$(git -C "$repo_root" hash-object \
+        --path="$notes_dir/$id" "$abs_notes_dir/$relpath" 2>/dev/null) || continue
+      [ "$head_hash" != "$disk_hash" ] && printf 'modified\t%s\n' "$relpath" >> "$workspace/detected"
+    done < "$workspace/fallback-meta"
   fi
+
+  return 0
+}
+
+_classify_unmanaged_files() {
+  local abs_notes_dir="$1" workspace="$2"
+
+  find "$abs_notes_dir" -type f | sort > "$workspace/all-files" || return 1
   awk \
-    -v ids_file="$manifest_ids" \
-    -v names_file="$manifest_names" \
-    -v stale_file="$stale_readables" \
-    -v files_file="$all_files" \
+    -v ids_file="$workspace/manifest-ids" \
+    -v names_file="$workspace/manifest-names" \
+    -v stale_file="$workspace/stale-readables" \
+    -v files_file="$workspace/all-files" \
     -v root="$abs_notes_dir/" '
       FILENAME == ids_file   { ids[$0] = 1; next }
       FILENAME == names_file { names[$0] = 1; next }
@@ -254,9 +219,45 @@ detect_changes() {
           print "new\t" relpath
         }
       }
-    ' "$manifest_ids" "$manifest_names" "$stale_readables" "$all_files"
+    ' "$workspace/manifest-ids" "$workspace/manifest-names" \
+      "$workspace/stale-readables" "$workspace/all-files"
+}
 
-  rm -rf "$tmp_dir"
+# Detect changed notes relative to HEAD.
+# Outputs one line per change: "<status>\t<readable_name>"
+# Status values: modified, new, deleted
+# Usage: detect_changes <abs_notes_dir>
+detect_changes() {
+  local abs_notes_dir="${1:?usage: detect_changes <abs_notes_dir>}"
+  local manifest="$abs_notes_dir/.manifest"
+  [ ! -f "$manifest" ] && return
+
+  resolve_notes_dir "$abs_notes_dir" || return
+  local repo_root="$RESOLVED_REPO_ROOT"
+  local notes_dir="$RESOLVED_NOTES_DIR"
+  local workspace
+  workspace=$(mktemp -d) || return
+
+  if ! _prepare_change_detection_workspace "$abs_notes_dir" "$repo_root" "$notes_dir" "$workspace"; then
+    rm -rf "$workspace"
+    return
+  fi
+  if ! _classify_manifest_changes "$abs_notes_dir" "$notes_dir" "$workspace"; then
+    rm -rf "$workspace"
+    return
+  fi
+  if ! _classify_fallback_changes "$repo_root" "$notes_dir" "$abs_notes_dir" "$workspace"; then
+    rm -rf "$workspace"
+    return
+  fi
+
+  cat "$workspace/detected"
+  if ! _classify_unmanaged_files "$abs_notes_dir" "$workspace"; then
+    rm -rf "$workspace"
+    return
+  fi
+
+  rm -rf "$workspace"
 }
 
 # Print ordinary diff output while preserving genuine diff execution failures.

--- a/lib/changes.sh
+++ b/lib/changes.sh
@@ -33,16 +33,8 @@ _prepare_change_detection_workspace() {
 
   : > "$workspace/head-in"
   : > "$workspace/raw-in"
-  : > "$workspace/detected"
-  : > "$workspace/fallback-in"
-  : > "$workspace/fallback-meta"
-  : > "$workspace/fallback-out"
   : > "$workspace/manifest-ids"
   : > "$workspace/manifest-names"
-  : > "$workspace/stale-readables"
-  : > "$workspace/all-files"
-  : > "$workspace/tracked-attr-in"
-  : > "$workspace/readable-attr-in"
 
   while IFS=$'\t' read -r id relpath; do
     [ -z "$id" ] && continue
@@ -63,6 +55,8 @@ _prepare_change_detection_workspace() {
         done > "$workspace/stale-readables"; then
       :
     fi
+  else
+    : > "$workspace/stale-readables"
   fi
 
   git -C "$repo_root" cat-file --batch-check='%(objectname)' \
@@ -108,6 +102,11 @@ _classify_manifest_changes() {
   local abs_notes_dir="$1" notes_dir="$2" workspace="$3"
   local manifest="$abs_notes_dir/.manifest"
   local id relpath readable_file head_hash head_exists state_pair state_tracked state_raw raw_hash
+
+  : > "$workspace/fallback-in"
+  : > "$workspace/fallback-meta"
+  : > "$workspace/tracked-attr-in"
+  : > "$workspace/readable-attr-in"
 
   exec 3< "$workspace/head-out"
   exec 4< "$workspace/raw-out"
@@ -237,6 +236,7 @@ detect_changes() {
   local notes_dir="$RESOLVED_NOTES_DIR"
   local workspace
   workspace=$(mktemp -d) || return
+  : > "$workspace/detected"
 
   if ! _prepare_change_detection_workspace "$abs_notes_dir" "$repo_root" "$notes_dir" "$workspace"; then
     rm -rf "$workspace"

--- a/lib/obfuscate.sh
+++ b/lib/obfuscate.sh
@@ -247,7 +247,7 @@ _deobfuscation_readable_matches_base_ref() {
   return 1
 }
 
-_record_deobfuscation_base_hashes() {
+_calculate_deobfuscation_state_rows() {
   local notes_dir="$1"
   shift
   local ids=("$@")
@@ -258,55 +258,47 @@ _record_deobfuscation_base_hashes() {
   resolve_notes_dir "$notes_dir" || return 0
   local repo_root="$RESOLVED_REPO_ROOT"
   local notes_rel="$RESOLVED_NOTES_DIR"
-  local state="$repo_root/.git/info/notes-obfuscation-state"
-  local tmp_dir requested candidates records raw_in raw_out index_out rows
+  local workspace
   local tracked_paths=()
-  tmp_dir=$(mktemp -d) || return 1
-  requested="$tmp_dir/requested"
-  candidates="$tmp_dir/candidates"
-  records="$tmp_dir/records"
-  raw_in="$tmp_dir/raw-in"
-  raw_out="$tmp_dir/raw-out"
-  index_out="$tmp_dir/index-out"
-  rows="$tmp_dir/rows"
-  printf '%s\n' "${ids[@]}" > "$requested"
-  : > "$records"
-  : > "$raw_in"
+  workspace=$(mktemp -d) || return 1
+  printf '%s\n' "${ids[@]}" > "$workspace/requested"
+  : > "$workspace/records"
+  : > "$workspace/raw-in"
 
   awk -F '\t' '
     FNR == NR { requested[$1] = 1; next }
     $1 in requested { print $1 "\t" $2 }
-  ' "$requested" "$manifest" > "$candidates"
+  ' "$workspace/requested" "$manifest" > "$workspace/candidates"
 
   local id relpath
   while IFS=$'\t' read -r id relpath; do
     [ -z "$id" ] && continue
     [ -f "$notes_dir/$relpath" ] || continue
-    printf '%s\t%s\t%s/%s\n' "$id" "$relpath" "$notes_rel" "$id" >> "$records"
-    printf '%s/%s\n' "$notes_rel" "$relpath" >> "$raw_in"
+    printf '%s\t%s\t%s/%s\n' "$id" "$relpath" "$notes_rel" "$id" >> "$workspace/records"
+    printf '%s/%s\n' "$notes_rel" "$relpath" >> "$workspace/raw-in"
     tracked_paths+=("$notes_rel/$id")
-  done < "$candidates"
+  done < "$workspace/candidates"
 
-  if [ ! -s "$records" ]; then
-    rm -rf "$tmp_dir"
+  if [ ! -s "$workspace/records" ]; then
+    rm -rf "$workspace"
     return 0
   fi
 
   if ! git -C "$repo_root" hash-object --no-filters --stdin-paths \
-    < "$raw_in" > "$raw_out"; then
-    rm -rf "$tmp_dir"
+    < "$workspace/raw-in" > "$workspace/raw-out"; then
+    rm -rf "$workspace"
     return 1
   fi
   if ! git -C "$repo_root" -c core.quotePath=false ls-files --stage -- \
-    "${tracked_paths[@]}" > "$index_out"; then
-    rm -rf "$tmp_dir"
+    "${tracked_paths[@]}" > "$workspace/index-out"; then
+    rm -rf "$workspace"
     return 1
   fi
 
   awk -F '\t' \
-    -v index_file="$index_out" \
-    -v records_file="$records" \
-    -v raw_file="$raw_out" '
+    -v index_file="$workspace/index-out" \
+    -v records_file="$workspace/records" \
+    -v raw_file="$workspace/raw-out" '
       FILENAME == index_file {
         split($1, metadata, " ")
         tracked[$2] = metadata[2]
@@ -318,10 +310,29 @@ _record_deobfuscation_base_hashes() {
           print $1 "\t" $2 "\t" tracked[$3] "\t" raw
         }
       }
-    ' "$index_out" "$records" > "$rows" || {
-      rm -rf "$tmp_dir"
+    ' "$workspace/index-out" "$workspace/records" || {
+      rm -rf "$workspace"
       return 1
     }
+
+  rm -rf "$workspace"
+}
+
+_record_deobfuscation_base_hashes() {
+  local notes_dir="$1"
+  shift
+  local state rows
+  state=$(_deobfuscation_state_file "$notes_dir") || return 0
+  rows=$(mktemp) || return 1
+
+  if ! _calculate_deobfuscation_state_rows "$notes_dir" "$@" > "$rows"; then
+    rm -f "$rows"
+    return 1
+  fi
+  if [ ! -s "$rows" ]; then
+    rm -f "$rows"
+    return 0
+  fi
 
   mkdir -p "$(dirname "$state")"
   touch "$state"
@@ -333,7 +344,7 @@ _record_deobfuscation_base_hashes() {
     [ -n "$row" ] && printf '%s\n' "$row" >> "$state"
   done < "$rows"
 
-  rm -rf "$tmp_dir"
+  rm -f "$rows"
 }
 
 # Rename a single obfuscated ID back to its readable name.

--- a/lib/obfuscate.sh
+++ b/lib/obfuscate.sh
@@ -196,8 +196,9 @@ rename_to_obfuscated() {
 # file (safe to update/remove after pull/merge/checkout) from a locally-edited
 # readable file (must preserve).
 #
-# Current row format: <id>\t<relpath>\t<hash>
-# Legacy row format:  <id>\t<hash>
+# Current row format: <id>\t<relpath>\t<tracked-hash>\t<raw-hash>
+# Previous row format: <id>\t<relpath>\t<tracked-hash>
+# Legacy row format:   <id>\t<tracked-hash>
 _deobfuscation_state_file() {
   local notes_dir="$1"
   resolve_notes_dir "$notes_dir" || return 1
@@ -256,22 +257,83 @@ _record_deobfuscation_base_hashes() {
 
   resolve_notes_dir "$notes_dir" || return 0
   local repo_root="$RESOLVED_REPO_ROOT"
+  local notes_rel="$RESOLVED_NOTES_DIR"
   local state="$repo_root/.git/info/notes-obfuscation-state"
+  local tmp_dir requested candidates records raw_in raw_out index_out rows
+  local tracked_paths=()
+  tmp_dir=$(mktemp -d) || return 1
+  requested="$tmp_dir/requested"
+  candidates="$tmp_dir/candidates"
+  records="$tmp_dir/records"
+  raw_in="$tmp_dir/raw-in"
+  raw_out="$tmp_dir/raw-out"
+  index_out="$tmp_dir/index-out"
+  rows="$tmp_dir/rows"
+  printf '%s\n' "${ids[@]}" > "$requested"
+  : > "$records"
+  : > "$raw_in"
+
+  awk -F '\t' '
+    FNR == NR { requested[$1] = 1; next }
+    $1 in requested { print $1 "\t" $2 }
+  ' "$requested" "$manifest" > "$candidates"
+
+  local id relpath
+  while IFS=$'\t' read -r id relpath; do
+    [ -z "$id" ] && continue
+    [ -f "$notes_dir/$relpath" ] || continue
+    printf '%s\t%s\t%s/%s\n' "$id" "$relpath" "$notes_rel" "$id" >> "$records"
+    printf '%s/%s\n' "$notes_rel" "$relpath" >> "$raw_in"
+    tracked_paths+=("$notes_rel/$id")
+  done < "$candidates"
+
+  if [ ! -s "$records" ]; then
+    rm -rf "$tmp_dir"
+    return 0
+  fi
+
+  if ! git -C "$repo_root" hash-object --no-filters --stdin-paths \
+    < "$raw_in" > "$raw_out"; then
+    rm -rf "$tmp_dir"
+    return 1
+  fi
+  if ! git -C "$repo_root" -c core.quotePath=false ls-files --stage -- \
+    "${tracked_paths[@]}" > "$index_out"; then
+    rm -rf "$tmp_dir"
+    return 1
+  fi
+
+  awk -F '\t' \
+    -v index_file="$index_out" \
+    -v records_file="$records" \
+    -v raw_file="$raw_out" '
+      FILENAME == index_file {
+        split($1, metadata, " ")
+        tracked[$2] = metadata[2]
+        next
+      }
+      FILENAME == records_file {
+        if ((getline raw < raw_file) <= 0) exit 1
+        if ($3 in tracked && raw != "") {
+          print $1 "\t" $2 "\t" tracked[$3] "\t" raw
+        }
+      }
+    ' "$index_out" "$records" > "$rows" || {
+      rm -rf "$tmp_dir"
+      return 1
+    }
+
   mkdir -p "$(dirname "$state")"
   touch "$state"
 
-  # Append-only on purpose: O_APPEND under PIPE_BUF is atomic, so concurrent
-  # writers get out-of-order rows but never torn ones, and the lookup helper
-  # takes the last matching entry. Don't "fix" this back to tmp+mv -- that's
-  # the read-modify-write race we're avoiding.
-  for id in "${ids[@]}"; do
-    local relpath sha
-    relpath=$(manifest_name_for_id "$manifest" "$id")
-    [ -z "$relpath" ] && continue
-    [ -f "$notes_dir/$relpath" ] || continue
-    sha=$(git -C "$repo_root" hash-object -- "$notes_dir/$relpath") || return 1
-    printf '%s\t%s\t%s\n' "$id" "$relpath" "$sha" >> "$state"
-  done
+  # Append one complete row at a time. Each row stays below PIPE_BUF, preserving
+  # the concurrent append contract while newer rows shadow older formats.
+  local row
+  while IFS= read -r row; do
+    [ -n "$row" ] && printf '%s\n' "$row" >> "$state"
+  done < "$rows"
+
+  rm -rf "$tmp_dir"
 }
 
 # Rename a single obfuscated ID back to its readable name.

--- a/lib/obfuscate.sh
+++ b/lib/obfuscate.sh
@@ -222,6 +222,17 @@ _deobfuscation_base_hash_for_id() {
   ' "$state"
 }
 
+_deobfuscation_base_raw_hash_for_id() {
+  local notes_dir="$1" id="$2"
+  local state
+  state=$(_deobfuscation_state_file "$notes_dir") || return 0
+  [ -f "$state" ] || return 0
+  awk -F '\t' -v wanted="$id" '
+    $1 == wanted { found = (NF >= 4 ? $4 : "") }
+    END { if (found != "") print found }
+  ' "$state"
+}
+
 _deobfuscation_readable_matches_base_ref() {
   local notes_dir="$1" id="$2" relpath="$3" base_ref="$4"
   [ -n "$base_ref" ] || return 1
@@ -362,12 +373,20 @@ _rename_one_to_readable() {
   [ ! -d "$target_dir" ] && mkdir -p "$target_dir"
 
   if [ -e "$notes_dir/$relpath" ] && ! cmp -s "$notes_dir/$id" "$notes_dir/$relpath"; then
-    local current_hash base_hash state_file dirty_readable=false
+    local current_hash base_hash base_raw_hash state_file dirty_readable=false
     state_file=$(_deobfuscation_state_file "$notes_dir" 2>/dev/null) || state_file=""
-    if ! current_hash=$(git -C "$notes_dir" hash-object -- "$notes_dir/$relpath" 2>/dev/null); then
-      current_hash=""
+    base_raw_hash=$(_deobfuscation_base_raw_hash_for_id "$notes_dir" "$id")
+    if [ -n "$base_raw_hash" ]; then
+      base_hash="$base_raw_hash"
+      if ! current_hash=$(git -C "$notes_dir" hash-object --no-filters -- "$notes_dir/$relpath" 2>/dev/null); then
+        current_hash=""
+      fi
+    else
+      base_hash=$(_deobfuscation_base_hash_for_id "$notes_dir" "$id")
+      if ! current_hash=$(git -C "$notes_dir" hash-object -- "$notes_dir/$relpath" 2>/dev/null); then
+        current_hash=""
+      fi
     fi
-    base_hash=$(_deobfuscation_base_hash_for_id "$notes_dir" "$id")
 
     # No state file (fresh clone or pre-safety upgrade) -> trust the readable
     # and let the rename proceed. Force-prompting on every file would train

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -74,6 +74,32 @@ run_with_process_counters() {
   "$function_name" "$@"
 }
 
+setup_clean_filter_counter() {
+  CLEAN_FILTER_CALLS="$BATS_TEST_TMPDIR/clean-filter.calls"
+  CLEAN_FILTER="$BATS_TEST_TMPDIR/counting-clean-filter"
+  export CLEAN_FILTER_CALLS
+  cat > "$CLEAN_FILTER" <<'BASH'
+#!/usr/bin/env bash
+printf '1\n' >> "${CLEAN_FILTER_CALLS:?}"
+cat
+BASH
+  chmod +x "$CLEAN_FILTER"
+  git -C "$NOTES_CALLER_PWD" config filter.notes-test.clean "$CLEAN_FILTER"
+  git -C "$NOTES_CALLER_PWD" config filter.notes-test.smudge cat
+  git -C "$NOTES_CALLER_PWD" config filter.notes-test.required true
+  printf 'notes/** filter=notes-test\n' > "$NOTES_CALLER_PWD/.gitattributes"
+  git -C "$NOTES_CALLER_PWD" add .gitattributes
+  git -C "$NOTES_CALLER_PWD" commit -q -m "add counting clean filter"
+}
+
+clean_filter_call_count() {
+  if [ -f "$CLEAN_FILTER_CALLS" ]; then
+    wc -l < "$CLEAN_FILTER_CALLS" | tr -d ' '
+  else
+    printf '0\n'
+  fi
+}
+
 record_deobfuscation_state_for_manifest() {
   local ids=()
   while IFS=$'\t' read -r id relpath; do
@@ -226,6 +252,90 @@ SH
   [ -z "$output" ]
   [ ! -e "$NOTES_PROCESS_COUNTER_DIR/grep.calls" ]
   [ ! -e "$NOTES_PROCESS_COUNTER_DIR/basename.calls" ]
+}
+
+@test "detect_changes: trusted raw baselines avoid per-note clean filters" {
+  local delete_id state
+  add_clean_numbered_notes 40
+  setup_clean_filter_counter
+  record_deobfuscation_state_for_manifest
+
+  state="$NOTES_CALLER_PWD/.git/info/notes-obfuscation-state"
+  awk -F '\t' 'NF != 4 { exit 1 }' "$state"
+  rm -f "$CLEAN_FILTER_CALLS"
+
+  printf '# Note 10 edited\n' > "$NOTES_CALLER_PWD/notes/note-10.md"
+  delete_id=$(manifest_id_for_name "$MANIFEST" "note-20.md")
+  rm "$NOTES_CALLER_PWD/notes/note-20.md"
+  rm -f "$NOTES_CALLER_PWD/notes/$delete_id"
+
+  run detect_changes "$NOTES_CALLER_PWD/notes"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"modified"*"note-10.md"* ]]
+  [[ "$output" == *"deleted"*"note-20.md"* ]]
+  [ "$(clean_filter_call_count)" -eq 0 ]
+}
+
+@test "detect_changes: stale raw baseline safely falls back then refreshes" {
+  local alpha_id
+  setup_clean_filter_counter
+  record_deobfuscation_state_for_manifest
+  alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
+
+  clear_status_suppression "$NOTES_CALLER_PWD/notes"
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
+  printf '# Alpha upstream\n' > "$NOTES_CALLER_PWD/notes/$alpha_id"
+  git -C "$NOTES_CALLER_PWD" add -f "notes/$alpha_id"
+  git -C "$NOTES_CALLER_PWD" commit -q -m "update alpha upstream"
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
+  rm -f "$CLEAN_FILTER_CALLS"
+
+  run detect_changes "$NOTES_CALLER_PWD/notes"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  [ "$(clean_filter_call_count)" -eq 1 ]
+
+  record_deobfuscation_state_for_manifest
+  rm -f "$CLEAN_FILTER_CALLS"
+  run detect_changes "$NOTES_CALLER_PWD/notes"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  [ "$(clean_filter_call_count)" -eq 0 ]
+}
+
+@test "detect_changes: staged baseline still compares against old HEAD" {
+  local alpha_id
+  setup_clean_filter_counter
+  record_deobfuscation_state_for_manifest
+  alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
+
+  clear_status_suppression "$NOTES_CALLER_PWD/notes"
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
+  printf '# Alpha staged\n' > "$NOTES_CALLER_PWD/notes/$alpha_id"
+  git -C "$NOTES_CALLER_PWD" add -f "notes/$alpha_id"
+  rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
+  record_deobfuscation_state_for_manifest
+  rm -f "$CLEAN_FILTER_CALLS"
+
+  run detect_changes "$NOTES_CALLER_PWD/notes"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"modified"*"alpha.md"* ]]
+  [ "$(clean_filter_call_count)" -eq 1 ]
+}
+
+@test "detect_changes: legacy state safely falls back to clean filters" {
+  local state
+  setup_clean_filter_counter
+  record_deobfuscation_state_for_manifest
+  state="$NOTES_CALLER_PWD/.git/info/notes-obfuscation-state"
+  cut -f1-3 "$state" > "$state.legacy"
+  mv "$state.legacy" "$state"
+  rm -f "$CLEAN_FILTER_CALLS"
+
+  run detect_changes "$NOTES_CALLER_PWD/notes"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  [ "$(clean_filter_call_count)" -eq 2 ]
 }
 
 @test "detect_changes: preserves tracked-path filter semantics when attrs differ" {

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -88,6 +88,42 @@ generate_test_key() {
   grep -q "secret content" "$TARGET_DIR/notes/secret.md"
 }
 
+@test "lock removes plaintext hashes before invoking rudi" {
+  notes setup --yes
+
+  local fpr
+  fpr=$(generate_test_key "$GNUPGHOME")
+  notes add-user -- --gpg-key "$fpr"
+
+  mkdir -p "$TARGET_DIR/notes"
+  echo "secret content" > "$TARGET_DIR/notes/secret.md"
+  git -C "$TARGET_DIR" add .
+  git -C "$TARGET_DIR" commit -q -m "Add encrypted note"
+
+  local state="$TARGET_DIR/.git/info/notes-obfuscation-state"
+  local fake_bin="$BATS_TEST_TMPDIR/fake-lock-bin"
+  local lock_log="$BATS_TEST_TMPDIR/rudi-lock.log"
+  [ -f "$state" ]
+  mkdir -p "$fake_bin"
+
+  cat > "$fake_bin/rudi" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "${1:-}" = "lock" ] || exit 64
+[ ! -e "${RUDI_STATE_FILE:?RUDI_STATE_FILE not set}" ] || exit 74
+: > "${RUDI_LOCK_LOG:?RUDI_LOCK_LOG not set}"
+exit 73
+SH
+  chmod +x "$fake_bin/rudi"
+  export RUDI_STATE_FILE="$state"
+  export RUDI_LOCK_LOG="$lock_log"
+
+  PATH="$fake_bin:$PATH" run notes lock --yes
+  [ "$status" -eq 73 ]
+  [ -f "$lock_log" ]
+  [ ! -e "$state" ]
+}
+
 @test "unlock no-ops when already unlocked, even with a dirty tree (#42)" {
   notes setup --yes
 

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -68,12 +68,17 @@ generate_test_key() {
   git -C "$TARGET_DIR" add .
   git -C "$TARGET_DIR" commit -q -m "Add encrypted note"
 
+  local state="$TARGET_DIR/.git/info/notes-obfuscation-state"
+  [ -f "$state" ]
+  awk -F '\t' 'NF >= 4 && $4 != "" { found=1 } END { exit !found }' "$state"
+
   # Lock
   run notes lock --yes
   [ "$status" -eq 0 ]
 
-  # File should not be readable as plaintext
+  # Neither plaintext nor its raw content hashes remain after locking.
   ! grep -q "secret content" "$TARGET_DIR/notes/secret.md" 2>/dev/null
+  [ ! -e "$state" ]
 
   # Unlock
   run notes unlock

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -1028,6 +1028,29 @@ EOT
   [ -f "$NOTES_CALLER_PWD/notes/$alpha_id" ]
 }
 
+@test "deobfuscate accepts clean readable when tracked and readable filters differ" {
+  git -C "$NOTES_CALLER_PWD" config filter.prefix.clean "sed 's/^/clean:/'"
+  git -C "$NOTES_CALLER_PWD" config filter.prefix.smudge cat
+  printf 'notes/???????? filter=prefix\n' > "$NOTES_CALLER_PWD/.gitattributes"
+
+  notes obfuscate
+  local beta_id
+  beta_id=$(grep "beta.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "obfuscate with tracked-path filter"
+  notes deobfuscate
+
+  # Simulate checkout restoring the filtered obfuscated source while the clean
+  # generated readable remains on disk.
+  git -C "$NOTES_CALLER_PWD" update-index --no-assume-unchanged "notes/$beta_id"
+  git -C "$NOTES_CALLER_PWD" checkout -- "notes/$beta_id"
+
+  run notes deobfuscate
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"refusing to overwrite dirty readable note"* ]]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/beta.md")" == clean:* ]]
+}
+
 @test "deobfuscate refreshes clean stale readable when state row is missing but base ref matches" {
   notes obfuscate
   local alpha_id base_ref state


### PR DESCRIPTION
## Summary

- record raw plaintext hashes alongside tracked hashes in the append-only deobfuscation state
- compare trusted readable baselines with one no-filter Git hash batch
- retain filtered hashing for missing, legacy, stale, or staged baselines
- batch state recording instead of looking up and hashing each note separately
- add deterministic clean-filter process regressions for trusted, stale, staged, and legacy states

## Why

`notes changes --summary` still launched one `git-crypt clean` process per readable note after #167 removed the grep/basename membership fanout. Fold's 535-note corpus therefore paid for 535 clean-filter processes on every clean check.

A raw baseline is trusted only when its recorded tracked hash still matches the note's current HEAD blob. Otherwise the existing filtered comparison remains the safe fallback.

## Validation

- focused changes suite: 56/56
- focused obfuscation suite: 78/78
- full suite: 394 BATS and 9 Python tests
- all 8 configured Codebase lints
- `git diff --check`
- Fold pre-commit and pre-push
- one comparable warm Fold observation after temporary state upgrade: 7.700s on #167 to 1.553s here

Stacked on #167. No release or merge is requested by this PR.
