### PR TITLE
fix: compare raw deobfuscation safety baselines

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 402](https://img.shields.io/badge/tests-402-brightgreen?style=flat)](test/)
+[![tests: 403](https://img.shields.io/badge/tests-403-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/lib/obfuscate.sh
+++ b/lib/obfuscate.sh
@@ -222,6 +222,17 @@ _deobfuscation_base_hash_for_id() {
   ' "$state"
 }
 
+_deobfuscation_base_raw_hash_for_id() {
+  local notes_dir="$1" id="$2"
+  local state
+  state=$(_deobfuscation_state_file "$notes_dir") || return 0
+  [ -f "$state" ] || return 0
+  awk -F '\t' -v wanted="$id" '
+    $1 == wanted { found = (NF >= 4 ? $4 : "") }
+    END { if (found != "") print found }
+  ' "$state"
+}
+
 _deobfuscation_readable_matches_base_ref() {
   local notes_dir="$1" id="$2" relpath="$3" base_ref="$4"
   [ -n "$base_ref" ] || return 1
@@ -362,12 +373,20 @@ _rename_one_to_readable() {
   [ ! -d "$target_dir" ] && mkdir -p "$target_dir"
 
   if [ -e "$notes_dir/$relpath" ] && ! cmp -s "$notes_dir/$id" "$notes_dir/$relpath"; then
-    local current_hash base_hash state_file dirty_readable=false
+    local current_hash base_hash base_raw_hash state_file dirty_readable=false
     state_file=$(_deobfuscation_state_file "$notes_dir" 2>/dev/null) || state_file=""
-    if ! current_hash=$(git -C "$notes_dir" hash-object -- "$notes_dir/$relpath" 2>/dev/null); then
-      current_hash=""
+    base_raw_hash=$(_deobfuscation_base_raw_hash_for_id "$notes_dir" "$id")
+    if [ -n "$base_raw_hash" ]; then
+      base_hash="$base_raw_hash"
+      if ! current_hash=$(git -C "$notes_dir" hash-object --no-filters -- "$notes_dir/$relpath" 2>/dev/null); then
+        current_hash=""
+      fi
+    else
+      base_hash=$(_deobfuscation_base_hash_for_id "$notes_dir" "$id")
+      if ! current_hash=$(git -C "$notes_dir" hash-object -- "$notes_dir/$relpath" 2>/dev/null); then
+        current_hash=""
+      fi
     fi
-    base_hash=$(_deobfuscation_base_hash_for_id "$notes_dir" "$id")
 
     # No state file (fresh clone or pre-safety upgrade) -> trust the readable
     # and let the rename proceed. Force-prompting on every file would train

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -1028,6 +1028,29 @@ EOT
   [ -f "$NOTES_CALLER_PWD/notes/$alpha_id" ]
 }
 
+@test "deobfuscate accepts clean readable when tracked and readable filters differ" {
+  git -C "$NOTES_CALLER_PWD" config filter.prefix.clean "sed 's/^/clean:/'"
+  git -C "$NOTES_CALLER_PWD" config filter.prefix.smudge cat
+  printf 'notes/???????? filter=prefix\n' > "$NOTES_CALLER_PWD/.gitattributes"
+
+  notes obfuscate
+  local beta_id
+  beta_id=$(grep "beta.md" "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q -m "obfuscate with tracked-path filter"
+  notes deobfuscate
+
+  # Simulate checkout restoring the filtered obfuscated source while the clean
+  # generated readable remains on disk.
+  git -C "$NOTES_CALLER_PWD" update-index --no-assume-unchanged "notes/$beta_id"
+  git -C "$NOTES_CALLER_PWD" checkout -- "notes/$beta_id"
+
+  run notes deobfuscate
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"refusing to overwrite dirty readable note"* ]]
+  [[ "$(cat "$NOTES_CALLER_PWD/notes/beta.md")" == clean:* ]]
+}
+
 @test "deobfuscate refreshes clean stale readable when state row is missing but base ref matches" {
   notes obfuscate
   local alpha_id base_ref state


### PR DESCRIPTION
## Finding

PR #168 changes the third deobfuscation-state field from the readable-path hash to the tracked/index hash, but the dirty-readable overwrite guard still compares that field with a readable-path hash. When attributes differ between an obfuscated ID and its readable name, a clean generated readable is therefore misclassified as dirty and deobfuscation refuses to restore the incoming source.

## Fix

- use the fourth-field raw baseline for four-field state rows and compare it with `hash-object --no-filters`
- preserve the filtered-hash comparison for previous and legacy state rows
- add a regression with a tracked-path-only clean filter

The regression failed on the reviewed `9c45d2c` head at the expected deobfuscation status assertion before the implementation change.

## Validation

- `mise run test obfuscate --filter 'tracked and readable filters differ'`
- `mise run test` (395 BATS, 9 Python)
- `codebase lint "$PWD"` (8/8)
- `git diff --check`
