### PR TITLE
fix: clear plaintext hashes when locking

### DIFF
--- a/.mise/tasks/lock
+++ b/.mise/tasks/lock
@@ -37,3 +37,8 @@ else
   # files, not just notes. Tracked in KnickKnackLabs/rudi#5.
   echo "Note: lock re-encrypts all encrypted files in this repo (rudi#5)."
 fi
+
+# Raw plaintext hashes accelerate change detection only while readable notes
+# exist. Do not retain those offline-verifiable fingerprints after locking.
+state_file=$(git rev-parse --git-path info/notes-obfuscation-state)
+rm -f "$state_file"

--- a/.mise/tasks/lock
+++ b/.mise/tasks/lock
@@ -29,6 +29,12 @@ if [ -f "$TARGET_DIR/notes/.manifest" ]; then
   git -C "$TARGET_DIR" add notes/
 fi
 
+# Raw plaintext hashes accelerate change detection only while readable notes
+# exist. Remove those offline-verifiable fingerprints before encryption so an
+# interrupted lock cannot leave them behind in an otherwise locked checkout.
+state_file=$(git rev-parse --git-path info/notes-obfuscation-state)
+rm -f "$state_file"
+
 if [ -n "${usage_key:-}" ]; then
   rudi lock --key "$usage_key"
 else
@@ -37,8 +43,3 @@ else
   # files, not just notes. Tracked in KnickKnackLabs/rudi#5.
   echo "Note: lock re-encrypts all encrypted files in this repo (rudi#5)."
 fi
-
-# Raw plaintext hashes accelerate change detection only while readable notes
-# exist. Do not retain those offline-verifiable fingerprints after locking.
-state_file=$(git rev-parse --git-path info/notes-obfuscation-state)
-rm -f "$state_file"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 402](https://img.shields.io/badge/tests-402-brightgreen?style=flat)](test/)
+[![tests: 403](https://img.shields.io/badge/tests-403-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -88,6 +88,42 @@ generate_test_key() {
   grep -q "secret content" "$TARGET_DIR/notes/secret.md"
 }
 
+@test "lock removes plaintext hashes before invoking rudi" {
+  notes setup --yes
+
+  local fpr
+  fpr=$(generate_test_key "$GNUPGHOME")
+  notes add-user -- --gpg-key "$fpr"
+
+  mkdir -p "$TARGET_DIR/notes"
+  echo "secret content" > "$TARGET_DIR/notes/secret.md"
+  git -C "$TARGET_DIR" add .
+  git -C "$TARGET_DIR" commit -q -m "Add encrypted note"
+
+  local state="$TARGET_DIR/.git/info/notes-obfuscation-state"
+  local fake_bin="$BATS_TEST_TMPDIR/fake-lock-bin"
+  local lock_log="$BATS_TEST_TMPDIR/rudi-lock.log"
+  [ -f "$state" ]
+  mkdir -p "$fake_bin"
+
+  cat > "$fake_bin/rudi" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "${1:-}" = "lock" ] || exit 64
+[ ! -e "${RUDI_STATE_FILE:?RUDI_STATE_FILE not set}" ] || exit 74
+: > "${RUDI_LOCK_LOG:?RUDI_LOCK_LOG not set}"
+exit 73
+SH
+  chmod +x "$fake_bin/rudi"
+  export RUDI_STATE_FILE="$state"
+  export RUDI_LOCK_LOG="$lock_log"
+
+  PATH="$fake_bin:$PATH" run notes lock --yes
+  [ "$status" -eq 73 ]
+  [ -f "$lock_log" ]
+  [ ! -e "$state" ]
+}
+
 @test "unlock no-ops when already unlocked, even with a dirty tree (#42)" {
   notes setup --yes
 

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -68,12 +68,17 @@ generate_test_key() {
   git -C "$TARGET_DIR" add .
   git -C "$TARGET_DIR" commit -q -m "Add encrypted note"
 
+  local state="$TARGET_DIR/.git/info/notes-obfuscation-state"
+  [ -f "$state" ]
+  awk -F '\t' 'NF >= 4 && $4 != "" { found=1 } END { exit !found }' "$state"
+
   # Lock
   run notes lock --yes
   [ "$status" -eq 0 ]
 
-  # File should not be readable as plaintext
+  # Neither plaintext nor its raw content hashes remain after locking.
   ! grep -q "secret content" "$TARGET_DIR/notes/secret.md" 2>/dev/null
+  [ ! -e "$state" ]
 
   # Unlock
   run notes unlock


### PR DESCRIPTION
## Finding

PR #168 adds unsalted raw plaintext Git object hashes to `.git/info/notes-obfuscation-state`. `notes lock` re-encrypts and removes readable note content but leaves that state file behind, so a locked checkout retains offline-verifiable fingerprints of every cached plaintext note.

## Fix

- remove the local deobfuscation state only after `rudi lock` succeeds
- extend the real lock/unlock integration test to prove four-field state exists before lock and no state fingerprint survives lock

The regression failed on the reviewed `9c45d2c` head at `[ ! -e "$state" ]` before the implementation change.

## Validation

- `mise run test integration --filter 'lock and unlock round-trip preserves file content'`
- `mise run test` (394 BATS, 9 Python)
- `codebase lint "$PWD"` (8/8)
- `git diff --check`
