### PR TITLE
fix: clear plaintext hashes before lock

### DIFF
--- a/.mise/tasks/lock
+++ b/.mise/tasks/lock
@@ -29,6 +29,12 @@ if [ -f "$TARGET_DIR/notes/.manifest" ]; then
   git -C "$TARGET_DIR" add notes/
 fi
 
+# Raw plaintext hashes accelerate change detection only while readable notes
+# exist. Remove those offline-verifiable fingerprints before encryption so an
+# interrupted lock cannot leave them behind in an otherwise locked checkout.
+state_file=$(git rev-parse --git-path info/notes-obfuscation-state)
+rm -f "$state_file"
+
 if [ -n "${usage_key:-}" ]; then
   rudi lock --key "$usage_key"
 else
@@ -37,8 +43,3 @@ else
   # files, not just notes. Tracked in KnickKnackLabs/rudi#5.
   echo "Note: lock re-encrypts all encrypted files in this repo (rudi#5)."
 fi
-
-# Raw plaintext hashes accelerate change detection only while readable notes
-# exist. Do not retain those offline-verifiable fingerprints after locking.
-state_file=$(git rev-parse --git-path info/notes-obfuscation-state)
-rm -f "$state_file"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 402](https://img.shields.io/badge/tests-402-brightgreen?style=flat)](test/)
+[![tests: 403](https://img.shields.io/badge/tests-403-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -88,6 +88,42 @@ generate_test_key() {
   grep -q "secret content" "$TARGET_DIR/notes/secret.md"
 }
 
+@test "lock removes plaintext hashes before invoking rudi" {
+  notes setup --yes
+
+  local fpr
+  fpr=$(generate_test_key "$GNUPGHOME")
+  notes add-user -- --gpg-key "$fpr"
+
+  mkdir -p "$TARGET_DIR/notes"
+  echo "secret content" > "$TARGET_DIR/notes/secret.md"
+  git -C "$TARGET_DIR" add .
+  git -C "$TARGET_DIR" commit -q -m "Add encrypted note"
+
+  local state="$TARGET_DIR/.git/info/notes-obfuscation-state"
+  local fake_bin="$BATS_TEST_TMPDIR/fake-lock-bin"
+  local lock_log="$BATS_TEST_TMPDIR/rudi-lock.log"
+  [ -f "$state" ]
+  mkdir -p "$fake_bin"
+
+  cat > "$fake_bin/rudi" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "${1:-}" = "lock" ] || exit 64
+[ ! -e "${RUDI_STATE_FILE:?RUDI_STATE_FILE not set}" ] || exit 74
+: > "${RUDI_LOCK_LOG:?RUDI_LOCK_LOG not set}"
+exit 73
+SH
+  chmod +x "$fake_bin/rudi"
+  export RUDI_STATE_FILE="$state"
+  export RUDI_LOCK_LOG="$lock_log"
+
+  PATH="$fake_bin:$PATH" run notes lock --yes
+  [ "$status" -eq 73 ]
+  [ -f "$lock_log" ]
+  [ ! -e "$state" ]
+}
+
 @test "unlock no-ops when already unlocked, even with a dirty tree (#42)" {
   notes setup --yes
 


### PR DESCRIPTION
## Finding

Notes #170 removes raw plaintext hashes only after `rudi lock` returns. If the process is interrupted after encryption but before that removal, a locked checkout can retain the offline-verifiable plaintext fingerprints the fix is meant to clear.

## Fix

Remove the local state file after notes are obfuscated and staged, but before invoking `rudi lock`. Losing the cache on a failed lock is safe: change detection falls back conservatively and a later deobfuscation rebuilds it.

The new integration regression uses a failing fake `rudi lock` and proves the state is already absent when the encryption boundary is entered. The regression fails on #170's current head and passes here.

## Validation

- New regression fails on #170 and passes on this branch
- `test/integration.bats`: 23 passed, 3 existing skips
- Full suite: 395 BATS passed, 3 existing skips; 9 Python tests passed
- All 8 Codebase lints passed
- Generated README is stable
- `git diff --check` and Fold preflight passed
