### PR TITLE
perf: batch stage and commit checks

### DIFF
--- a/.mise/tasks/commit
+++ b/.mise/tasks/commit
@@ -99,13 +99,16 @@ require_no_preexisting_staged_changes() {
 }
 
 verify_no_readable_paths_tracked() {
-  local bad=() id relpath
+  local bad=() id relpath double_tracked
+  if ! double_tracked=$(detect_double_tracked_notes "$TARGET_DIR" "$notes_dir"); then
+    echo "Error: failed to inspect tracked readable note paths after commit." >&2
+    return 1
+  fi
+
   while IFS=$'\t' read -r id relpath; do
     [ -z "$id" ] && continue
-    if git -C "$TARGET_DIR" ls-files --error-unmatch -- "$notes_dir/$relpath" >/dev/null 2>&1; then
-      bad+=("$relpath")
-    fi
-  done < "$manifest"
+    bad+=("$relpath")
+  done <<< "$double_tracked"
 
   if [ ${#bad[@]} -gt 0 ]; then
     echo "Error: commit created tracked readable note path(s); repair before pushing:" >&2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 406](https://img.shields.io/badge/tests-406-brightgreen?style=flat)](test/)
+[![tests: 407](https://img.shields.io/badge/tests-407-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 404](https://img.shields.io/badge/tests-404-brightgreen?style=flat)](test/)
+[![tests: 406](https://img.shields.io/badge/tests-406-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 407](https://img.shields.io/badge/tests-407-brightgreen?style=flat)](test/)
+[![tests: 408](https://img.shields.io/badge/tests-408-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -236,20 +236,29 @@ detect_double_tracked_notes() {
   local repo_root="${1:?usage: detect_double_tracked_notes <repo_root> <notes_dir_rel>}"
   local notes_dir_rel="${2:?usage: detect_double_tracked_notes <repo_root> <notes_dir_rel>}"
   local manifest="$repo_root/$notes_dir_rel/.manifest"
-  local tracked_paths rc
+  local workspace snapshot tracked_paths tracked_path rc
   [ ! -f "$manifest" ] && return 0
 
-  tracked_paths=$(mktemp) || return 1
-  if ! git -C "$repo_root" -c core.quotePath=false ls-files -- "$notes_dir_rel" > "$tracked_paths"; then
-    rm -f "$tracked_paths"
+  workspace=$(mktemp -d) || return 1
+  snapshot="$workspace/snapshot"
+  tracked_paths="$workspace/tracked-paths"
+  if ! git -C "$repo_root" ls-files -z -- "$notes_dir_rel" > "$snapshot"; then
+    rm -rf "$workspace"
     return 1
   fi
+
+  # Git quotes backslashes, quotes, and control characters in line-delimited
+  # output even with core.quotePath=false. Read its NUL-delimited snapshot and
+  # normalize the manifest-representable paths without starting more processes.
+  while IFS= read -r -d '' tracked_path; do
+    printf '%s\n' "$tracked_path"
+  done < "$snapshot" > "$tracked_paths"
 
   awk -F '\t' -v tracked_file="$tracked_paths" -v prefix="$notes_dir_rel/" '
     FILENAME == tracked_file { tracked[$0] = 1; next }
     $1 != "" && ((prefix $2) in tracked) { print $1 "\t" $2 }
   ' "$tracked_paths" "$manifest"
   rc=$?
-  rm -f "$tracked_paths"
+  rm -rf "$workspace"
   return "$rc"
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -236,13 +236,20 @@ detect_double_tracked_notes() {
   local repo_root="${1:?usage: detect_double_tracked_notes <repo_root> <notes_dir_rel>}"
   local notes_dir_rel="${2:?usage: detect_double_tracked_notes <repo_root> <notes_dir_rel>}"
   local manifest="$repo_root/$notes_dir_rel/.manifest"
+  local tracked_paths rc
   [ ! -f "$manifest" ] && return 0
 
-  while IFS=$'\t' read -r id relpath; do
-    [ -z "$id" ] && continue
-    # If the readable path is tracked in git's index, it's double-tracked.
-    if git -C "$repo_root" ls-files --error-unmatch -- "$notes_dir_rel/$relpath" >/dev/null 2>&1; then
-      printf '%s\t%s\n' "$id" "$relpath"
-    fi
-  done < "$manifest"
+  tracked_paths=$(mktemp) || return 1
+  if ! git -C "$repo_root" -c core.quotePath=false ls-files -- "$notes_dir_rel" > "$tracked_paths"; then
+    rm -f "$tracked_paths"
+    return 1
+  fi
+
+  awk -F '\t' -v tracked_file="$tracked_paths" -v prefix="$notes_dir_rel/" '
+    FILENAME == tracked_file { tracked[$0] = 1; next }
+    $1 != "" && ((prefix $2) in tracked) { print $1 "\t" $2 }
+  ' "$tracked_paths" "$manifest"
+  rc=$?
+  rm -f "$tracked_paths"
+  return "$rc"
 }

--- a/lib/obfuscate.sh
+++ b/lib/obfuscate.sh
@@ -362,11 +362,12 @@ _record_deobfuscation_base_hashes() {
 # Returns: 0=renamed, 2=skipped (not found/no match),
 #          3=dirty readable preserved, 1=error (mv failed).
 _rename_one_to_readable() {
-  local notes_dir="$1" manifest="$2" id="$3"
-  local relpath
-  relpath=$(manifest_name_for_id "$manifest" "$id")
-  [ -z "$relpath" ] && return 2
+  local notes_dir="$1" manifest="$2" id="$3" relpath="${4:-}"
   [ ! -f "$notes_dir/$id" ] && return 2
+  if [ -z "$relpath" ]; then
+    relpath=$(manifest_name_for_id "$manifest" "$id")
+    [ -z "$relpath" ] && return 2
+  fi
 
   local target_dir
   target_dir=$(dirname "$notes_dir/$relpath")
@@ -451,7 +452,7 @@ rename_to_readable() {
     while IFS=$'\t' read -r id relpath; do
       [ -z "$id" ] && continue
       local _rc
-      _rename_one_to_readable "$notes_dir" "$manifest" "$id" && _rc=0 || _rc=$?
+      _rename_one_to_readable "$notes_dir" "$manifest" "$id" "$relpath" && _rc=0 || _rc=$?
       case $_rc in
         0) count=$((count + 1)) ;;
         3) dirty_count=$((dirty_count + 1)) ;;

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -74,6 +74,21 @@ run_with_process_counters() {
   "$function_name" "$@"
 }
 
+setup_git_argument_counter() {
+  local real_git
+  PROCESS_COUNTER_BIN="$BATS_TEST_TMPDIR/git-counter-bin"
+  NOTES_PROCESS_COUNTER_DIR="$BATS_TEST_TMPDIR/git-counter-results"
+  real_git=$(command -v git)
+  mkdir -p "$PROCESS_COUNTER_BIN" "$NOTES_PROCESS_COUNTER_DIR"
+  export NOTES_PROCESS_COUNTER_DIR
+  cat > "$PROCESS_COUNTER_BIN/git" <<SH
+#!/usr/bin/env bash
+printf '%s\\n' "\$*" >> "\${NOTES_PROCESS_COUNTER_DIR:?}/git.args"
+exec '$real_git' "\$@"
+SH
+  chmod +x "$PROCESS_COUNTER_BIN/git"
+}
+
 setup_clean_filter_counter() {
   CLEAN_FILTER_CALLS="$BATS_TEST_TMPDIR/clean-filter.calls"
   CLEAN_FILTER="$BATS_TEST_TMPDIR/counting-clean-filter"
@@ -904,6 +919,18 @@ SH
 }
 
 # ── commit wrapper ───────────────────────────────────────────
+
+@test "notes commit post-check batches readable-path inspection" {
+  add_clean_numbered_notes 40
+  notes install-hooks --yes >/dev/null
+  printf '# changed\n' >> "$NOTES_CALLER_PWD/notes/alpha.md"
+  setup_git_argument_counter
+
+  run run_with_process_counters notes commit -m "update alpha" alpha.md
+
+  [ "$status" -eq 0 ]
+  [ "$(grep -c 'ls-files --error-unmatch' "$NOTES_PROCESS_COUNTER_DIR/git.args" || true)" -eq 0 ]
+}
 
 @test "notes commit: explicit file commits modified note and leaves clean readable tree" {
   notes install-hooks --yes

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -929,7 +929,7 @@ SH
   run run_with_process_counters notes commit -m "update alpha" alpha.md
 
   [ "$status" -eq 0 ]
-  [ "$(grep -c 'ls-files --error-unmatch' "$NOTES_PROCESS_COUNTER_DIR/git.args" || true)" -eq 0 ]
+  [ "$(grep -c ' ls-files ' "$NOTES_PROCESS_COUNTER_DIR/git.args" || true)" -le 3 ]
 }
 
 @test "notes commit: explicit file commits modified note and leaves clean readable tree" {

--- a/test/common.bats
+++ b/test/common.bats
@@ -173,3 +173,37 @@ EOF
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
+
+@test "detect_double_tracked_notes inspects tracked paths in one Git process" {
+  local i=1 id name real_git counter_bin calls
+  git -C "$NOTES_CALLER_PWD" init -q
+
+  while [ "$i" -le 42 ]; do
+    id=$(printf '%08d' "$i")
+    name=$(printf 'note-%02d.md' "$i")
+    printf '%s\t%s\n' "$id" "$name" >> "$MANIFEST"
+    printf '# Note %02d\n' "$i" > "$NOTES_CALLER_PWD/notes/$id"
+    i=$((i + 1))
+  done
+  git -C "$NOTES_CALLER_PWD" add notes
+  git -C "$NOTES_CALLER_PWD" commit -q -m "obfuscated notes"
+  printf '# Tracked readable\n' > "$NOTES_CALLER_PWD/notes/note-17.md"
+  git -C "$NOTES_CALLER_PWD" add -f notes/note-17.md
+
+  counter_bin="$BATS_TEST_TMPDIR/counter-bin"
+  calls="$BATS_TEST_TMPDIR/git.calls"
+  real_git=$(command -v git)
+  mkdir -p "$counter_bin"
+  cat > "$counter_bin/git" <<SH
+#!/usr/bin/env bash
+printf '1\\n' >> '$calls'
+exec '$real_git' "\$@"
+SH
+  chmod +x "$counter_bin/git"
+
+  PATH="$counter_bin:$PATH" run detect_double_tracked_notes "$NOTES_CALLER_PWD" notes
+
+  [ "$status" -eq 0 ]
+  [ "$output" = $'00000017\tnote-17.md' ]
+  [ "$(wc -l < "$calls" | tr -d ' ')" -eq 1 ]
+}

--- a/test/common.bats
+++ b/test/common.bats
@@ -207,3 +207,21 @@ SH
   [ "$output" = $'00000017\tnote-17.md' ]
   [ "$(wc -l < "$calls" | tr -d ' ')" -eq 1 ]
 }
+
+@test "detect_double_tracked_notes matches Git-quoted readable paths literally" {
+  local backslash_name='back\slash.md'
+  local quote_name='double"quote.md'
+  git -C "$NOTES_CALLER_PWD" init -q
+
+  printf 'abc12345\t%s\ndef67890\t%s\n' "$backslash_name" "$quote_name" > "$MANIFEST"
+  printf '# Obfuscated\n' > "$NOTES_CALLER_PWD/notes/abc12345"
+  printf '# Obfuscated\n' > "$NOTES_CALLER_PWD/notes/def67890"
+  printf '# Readable\n' > "$NOTES_CALLER_PWD/notes/$backslash_name"
+  printf '# Readable\n' > "$NOTES_CALLER_PWD/notes/$quote_name"
+  git -C "$NOTES_CALLER_PWD" add -f notes
+
+  run detect_double_tracked_notes "$NOTES_CALLER_PWD" notes
+
+  [ "$status" -eq 0 ]
+  [ "$output" = $'abc12345\tback\\slash.md\ndef67890\tdouble"quote.md' ]
+}

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -322,6 +322,43 @@ setup() {
   [ -f "$NOTES_CALLER_PWD/notes/gamma.txt" ]
 }
 
+@test "full deobfuscation skips manifest lookup processes for absent IDs" {
+  local i=1 id name restored_id="" counter_bin command real_command
+  rm -rf "$NOTES_CALLER_PWD/notes"
+  mkdir -p "$NOTES_CALLER_PWD/notes"
+
+  while [ "$i" -le 42 ]; do
+    id=$(printf '%08d' "$i")
+    name=$(printf 'note-%02d.md' "$i")
+    printf '%s\t%s\n' "$id" "$name" >> "$NOTES_CALLER_PWD/notes/.manifest"
+    if [ "$i" -eq 17 ]; then
+      restored_id="$id"
+      printf '# Restored\n' > "$NOTES_CALLER_PWD/notes/$id"
+    fi
+    i=$((i + 1))
+  done
+
+  counter_bin="$BATS_TEST_TMPDIR/lookup-counter-bin"
+  mkdir -p "$counter_bin"
+  for command in grep cut; do
+    real_command=$(command -v "$command")
+    cat > "$counter_bin/$command" <<SH
+#!/usr/bin/env bash
+printf '1\\n' >> '$BATS_TEST_TMPDIR/$command.calls'
+exec '$real_command' "\$@"
+SH
+    chmod +x "$counter_bin/$command"
+  done
+
+  PATH="$counter_bin:$PATH" run rename_to_readable "$NOTES_CALLER_PWD/notes"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$restored_id"*$'\t'"note-17.md"* ]]
+  [ -f "$NOTES_CALLER_PWD/notes/note-17.md" ]
+  [ ! -e "$BATS_TEST_TMPDIR/grep.calls" ]
+  [ ! -e "$BATS_TEST_TMPDIR/cut.calls" ]
+}
+
 @test "deobfuscate preserves manifest for stable IDs" {
   notes obfuscate
   notes deobfuscate


### PR DESCRIPTION
## Summary

- batch double-tracked readable-path detection through one `git ls-files` snapshot instead of one Git process per manifest row
- skip manifest lookup subprocesses for absent obfuscated IDs during full deobfuscation, and pass known manifest names directly
- add deterministic 42-note regressions for the Git-process and lookup-process boundaries

## Why

A one-note commit on a 535-note repository could run the per-row double-tracking query during staging, pre-commit, and post-commit verification, producing roughly 1,605 Git processes. Full post-commit deobfuscation could also launch roughly 535 unnecessary `grep | cut` lookup pipelines before discovering that almost every obfuscated ID was absent.

The new behavior scales subprocesses with operation phases and changed files rather than total manifest size.

## Validation

- `mise run test test/common.bats` (19/19)
- `mise run test test/obfuscate.bats` (80/80)
- `mise run test test/integration.bats` (26/26, including 3 existing skips)
- `mise run test` (398 BATS, 9 Python)
- all eight configured Codebase lints
- Bash syntax and `git diff --check`
- Fold pre-commit and pre-push (zero failures; expected new-branch/GitHub-merge signature warnings)

No wall-time loop was run. The regressions count the exact subprocess boundaries deterministically.
