### PR TITLE
fix: match quoted tracked note paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 406](https://img.shields.io/badge/tests-406-brightgreen?style=flat)](test/)
+[![tests: 407](https://img.shields.io/badge/tests-407-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -236,20 +236,29 @@ detect_double_tracked_notes() {
   local repo_root="${1:?usage: detect_double_tracked_notes <repo_root> <notes_dir_rel>}"
   local notes_dir_rel="${2:?usage: detect_double_tracked_notes <repo_root> <notes_dir_rel>}"
   local manifest="$repo_root/$notes_dir_rel/.manifest"
-  local tracked_paths rc
+  local workspace snapshot tracked_paths tracked_path rc
   [ ! -f "$manifest" ] && return 0
 
-  tracked_paths=$(mktemp) || return 1
-  if ! git -C "$repo_root" -c core.quotePath=false ls-files -- "$notes_dir_rel" > "$tracked_paths"; then
-    rm -f "$tracked_paths"
+  workspace=$(mktemp -d) || return 1
+  snapshot="$workspace/snapshot"
+  tracked_paths="$workspace/tracked-paths"
+  if ! git -C "$repo_root" ls-files -z -- "$notes_dir_rel" > "$snapshot"; then
+    rm -rf "$workspace"
     return 1
   fi
+
+  # Git quotes backslashes, quotes, and control characters in line-delimited
+  # output even with core.quotePath=false. Read its NUL-delimited snapshot and
+  # normalize the manifest-representable paths without starting more processes.
+  while IFS= read -r -d '' tracked_path; do
+    printf '%s\n' "$tracked_path"
+  done < "$snapshot" > "$tracked_paths"
 
   awk -F '\t' -v tracked_file="$tracked_paths" -v prefix="$notes_dir_rel/" '
     FILENAME == tracked_file { tracked[$0] = 1; next }
     $1 != "" && ((prefix $2) in tracked) { print $1 "\t" $2 }
   ' "$tracked_paths" "$manifest"
   rc=$?
-  rm -f "$tracked_paths"
+  rm -rf "$workspace"
   return "$rc"
 }

--- a/test/common.bats
+++ b/test/common.bats
@@ -207,3 +207,21 @@ SH
   [ "$output" = $'00000017\tnote-17.md' ]
   [ "$(wc -l < "$calls" | tr -d ' ')" -eq 1 ]
 }
+
+@test "detect_double_tracked_notes matches Git-quoted readable paths literally" {
+  local backslash_name='back\slash.md'
+  local quote_name='double"quote.md'
+  git -C "$NOTES_CALLER_PWD" init -q
+
+  printf 'abc12345\t%s\ndef67890\t%s\n' "$backslash_name" "$quote_name" > "$MANIFEST"
+  printf '# Obfuscated\n' > "$NOTES_CALLER_PWD/notes/abc12345"
+  printf '# Obfuscated\n' > "$NOTES_CALLER_PWD/notes/def67890"
+  printf '# Readable\n' > "$NOTES_CALLER_PWD/notes/$backslash_name"
+  printf '# Readable\n' > "$NOTES_CALLER_PWD/notes/$quote_name"
+  git -C "$NOTES_CALLER_PWD" add -f notes
+
+  run detect_double_tracked_notes "$NOTES_CALLER_PWD" notes
+
+  [ "$status" -eq 0 ]
+  [ "$output" = $'abc12345\tback\\slash.md\ndef67890\tdouble"quote.md' ]
+}


### PR DESCRIPTION
## Finding

`detect_double_tracked_notes` reads line-delimited `git ls-files` output as literal paths, but Git still C-quotes backslashes and double quotes when `core.quotePath=false`. A tracked readable name such as `back\slash.md` is therefore omitted from the double-tracking guard.

## Fix

Read the single Git snapshot with `-z`, normalize its manifest-representable paths in Bash without extra processes, and add regressions for backslash and quote names.

## Validation

- `mise run test test/common.bats` (20/20)
- focused stage and commit integration tests (2/2)
- all eight configured Codebase lints
- Bash syntax and `git diff --check`
- manual mixed unusual-name stress: spaces, non-ASCII, backslash, quote, and glob characters all detected
