### PR TITLE
perf: batch commit readable-path verification

### DIFF
--- a/.mise/tasks/commit
+++ b/.mise/tasks/commit
@@ -99,13 +99,16 @@ require_no_preexisting_staged_changes() {
 }
 
 verify_no_readable_paths_tracked() {
-  local bad=() id relpath
+  local bad=() id relpath double_tracked
+  if ! double_tracked=$(detect_double_tracked_notes "$TARGET_DIR" "$notes_dir"); then
+    echo "Error: failed to inspect tracked readable note paths after commit." >&2
+    return 1
+  fi
+
   while IFS=$'\t' read -r id relpath; do
     [ -z "$id" ] && continue
-    if git -C "$TARGET_DIR" ls-files --error-unmatch -- "$notes_dir/$relpath" >/dev/null 2>&1; then
-      bad+=("$relpath")
-    fi
-  done < "$manifest"
+    bad+=("$relpath")
+  done <<< "$double_tracked"
 
   if [ ${#bad[@]} -gt 0 ]; then
     echo "Error: commit created tracked readable note path(s); repair before pushing:" >&2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 406](https://img.shields.io/badge/tests-406-brightgreen?style=flat)](test/)
+[![tests: 407](https://img.shields.io/badge/tests-407-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -74,6 +74,21 @@ run_with_process_counters() {
   "$function_name" "$@"
 }
 
+setup_git_argument_counter() {
+  local real_git
+  PROCESS_COUNTER_BIN="$BATS_TEST_TMPDIR/git-counter-bin"
+  NOTES_PROCESS_COUNTER_DIR="$BATS_TEST_TMPDIR/git-counter-results"
+  real_git=$(command -v git)
+  mkdir -p "$PROCESS_COUNTER_BIN" "$NOTES_PROCESS_COUNTER_DIR"
+  export NOTES_PROCESS_COUNTER_DIR
+  cat > "$PROCESS_COUNTER_BIN/git" <<SH
+#!/usr/bin/env bash
+printf '%s\\n' "\$*" >> "\${NOTES_PROCESS_COUNTER_DIR:?}/git.args"
+exec '$real_git' "\$@"
+SH
+  chmod +x "$PROCESS_COUNTER_BIN/git"
+}
+
 setup_clean_filter_counter() {
   CLEAN_FILTER_CALLS="$BATS_TEST_TMPDIR/clean-filter.calls"
   CLEAN_FILTER="$BATS_TEST_TMPDIR/counting-clean-filter"
@@ -904,6 +919,18 @@ SH
 }
 
 # ── commit wrapper ───────────────────────────────────────────
+
+@test "notes commit post-check batches readable-path inspection" {
+  add_clean_numbered_notes 40
+  notes install-hooks --yes >/dev/null
+  printf '# changed\n' >> "$NOTES_CALLER_PWD/notes/alpha.md"
+  setup_git_argument_counter
+
+  run run_with_process_counters notes commit -m "update alpha" alpha.md
+
+  [ "$status" -eq 0 ]
+  [ "$(grep -c 'ls-files --error-unmatch' "$NOTES_PROCESS_COUNTER_DIR/git.args" || true)" -eq 0 ]
+}
 
 @test "notes commit: explicit file commits modified note and leaves clean readable tree" {
   notes install-hooks --yes

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -929,7 +929,7 @@ SH
   run run_with_process_counters notes commit -m "update alpha" alpha.md
 
   [ "$status" -eq 0 ]
-  [ "$(grep -c 'ls-files --error-unmatch' "$NOTES_PROCESS_COUNTER_DIR/git.args" || true)" -eq 0 ]
+  [ "$(grep -c ' ls-files ' "$NOTES_PROCESS_COUNTER_DIR/git.args" || true)" -le 3 ]
 }
 
 @test "notes commit: explicit file commits modified note and leaves clean readable tree" {


### PR DESCRIPTION
## Finding

The new helper regression passes, but the production `notes commit` post-check still loops over every manifest row and launches `git ls-files --error-unmatch` once per note. In a 42-note fixture with one changed note, exact head `9d2ce4f` launched 43 `ls-files` processes: one batched stage snapshot plus 42 post-check lookups.

## Fix

Reuse `detect_double_tracked_notes` in the post-commit verifier and add an end-to-end 42-note `notes commit` regression that rejects per-row `ls-files --error-unmatch` calls.

## Validation

- `mise run test test/changes.bats` (58/58)
- all eight configured Codebase lints
- Bash syntax and `git diff --check`
- production counter: 43 `ls-files` processes before, 2 batched snapshots after
- the new regression fails against reviewed head `9d2ce4f` and passes here
