### PR TITLE
test: enforce commit process budget

### DIFF
--- a/test/changes.bats
+++ b/test/changes.bats
@@ -929,7 +929,7 @@ SH
   run run_with_process_counters notes commit -m "update alpha" alpha.md
 
   [ "$status" -eq 0 ]
-  [ "$(grep -c 'ls-files --error-unmatch' "$NOTES_PROCESS_COUNTER_DIR/git.args" || true)" -eq 0 ]
+  [ "$(grep -c ' ls-files ' "$NOTES_PROCESS_COUNTER_DIR/git.args" || true)" -le 3 ]
 }
 
 @test "notes commit: explicit file commits modified note and leaves clean readable tree" {


### PR DESCRIPTION
## Finding

The production commit regression in Notes #174 rejects only the old `ls-files --error-unmatch` spelling. It can stay green if a later implementation launches another `ls-files` form once per note.

## Fix

Count every logged `ls-files` subcommand and enforce a phase-level budget of at most three calls for the real 42-note `notes commit` path.

The stronger regression:

- fails on reviewed Notes #172 head `9d2ce4f` with the per-note verifier;
- passes on Notes #174 exact head `df0e250` plus this test change; and
- keeps the exact production command path rather than testing only the helper.

## Validation

- named focused BATS case passes on this branch;
- the same case fails on #172 for the expected process-budget assertion;
- `git diff --check` passes;
- Fold pre-commit and pre-push report zero failures;
- commit is signed by Junior.
