### PR TITLE
fix: preserve aliased manifest diff semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 410](https://img.shields.io/badge/tests-410-brightgreen?style=flat)](test/)
+[![tests: 412](https://img.shields.io/badge/tests-412-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/lib/diff.sh
+++ b/lib/diff.sh
@@ -143,15 +143,48 @@ _changed_note_ids_between_refs() {
   done < "$changed_paths"
 
   awk -F '\t' '
-    FILENAME == ARGV[1] { base[$1] = $2; next }
-    {
-      seen[$1] = 1
-      if (!($1 in base) || base[$1] != $2) print $1
+    FILENAME == ARGV[1] { selected_id[$1] = 1; next }
+    FILENAME == ARGV[2] {
+      base_row[$0] = 1
+      row_id[$0] = $1
+      edge_id[++edge_count] = $1
+      edge_path[edge_count] = $2
+      next
     }
-    END { for (id in base) if (!(id in seen)) print id }
-  ' "$base_manifest" "$head_manifest" >> "$candidates"
+    {
+      head_row[$0] = 1
+      row_id[$0] = $1
+      edge_id[++edge_count] = $1
+      edge_path[edge_count] = $2
+    }
+    END {
+      for (row in base_row) if (!(row in head_row)) selected_id[row_id[row]] = 1
+      for (row in head_row) if (!(row in base_row)) selected_id[row_id[row]] = 1
 
-  LC_ALL=C sort -u "$candidates" > "$out"
+      # A malformed or merge-produced manifest can alias one ID to multiple
+      # paths, or multiple IDs to one path. Pull in the entire affected
+      # ID/path component so selection preserves full-tree diff semantics.
+      do {
+        expanded = 0
+        for (i = 1; i <= edge_count; i++) {
+          if ((edge_id[i] in selected_id) || (edge_path[i] in selected_path)) {
+            if (!(edge_id[i] in selected_id)) {
+              selected_id[edge_id[i]] = 1
+              expanded = 1
+            }
+            if (!(edge_path[i] in selected_path)) {
+              selected_path[edge_path[i]] = 1
+              expanded = 1
+            }
+          }
+        }
+      } while (expanded)
+
+      for (id in selected_id) print id
+    }
+  ' "$candidates" "$base_manifest" "$head_manifest" > "$out"
+
+  LC_ALL=C sort -u -o "$out" "$out"
   rm -f "$changed_paths" "$candidates"
 }
 

--- a/test/diff.bats
+++ b/test/diff.bats
@@ -117,6 +117,61 @@ commit_readable_update() {
   grep -q "notes/renamed/alpha.md" "$out_dir/readable.patch"
 }
 
+@test "notes diff preserves manifest aliases when one readable path is removed" {
+  local alpha_id manifest next_manifest out_dir
+  manifest="$NOTES_CALLER_PWD/notes/.manifest"
+  alpha_id=$(awk -F '\t' '$2 == "alpha.md" { print $1 }' "$manifest")
+  next_manifest="$BATS_TEST_TMPDIR/aliased.manifest"
+  out_dir="$BATS_TEST_TMPDIR/alias-review"
+
+  printf '%s\talias-alpha.md\n' "$alpha_id" >> "$manifest"
+  git -C "$NOTES_CALLER_PWD" add notes/.manifest
+  git -C "$NOTES_CALLER_PWD" commit -q -m "alias alpha in manifest"
+
+  awk -F '\t' '$2 != "alpha.md" { print }' "$manifest" > "$next_manifest"
+  mv "$next_manifest" "$manifest"
+  git -C "$NOTES_CALLER_PWD" add notes/.manifest
+  git -C "$NOTES_CALLER_PWD" commit -q -m "remove original alpha path"
+
+  run notes diff --out "$out_dir" HEAD~1 HEAD
+
+  [ "$status" -eq 0 ]
+  [ -f "$out_dir/base/notes/alpha.md" ]
+  [ -f "$out_dir/base/notes/alias-alpha.md" ]
+  [ ! -e "$out_dir/head/notes/alpha.md" ]
+  [ -f "$out_dir/head/notes/alias-alpha.md" ]
+  grep -q "deleted file mode" "$out_dir/readable.patch"
+  grep -q "a/notes/alpha.md" "$out_dir/readable.patch"
+  ! grep -q "a/notes/alias-alpha.md" "$out_dir/readable.patch"
+}
+
+@test "notes diff includes unchanged IDs that collide on a changed readable path" {
+  local alpha_id beta_id manifest next_manifest out_dir
+  manifest="$NOTES_CALLER_PWD/notes/.manifest"
+  alpha_id=$(awk -F '\t' '$2 == "alpha.md" { print $1 }' "$manifest")
+  beta_id=$(awk -F '\t' '$2 == "beta.md" { print $1 }' "$manifest")
+  next_manifest="$BATS_TEST_TMPDIR/colliding.manifest"
+  out_dir="$BATS_TEST_TMPDIR/collision-review"
+
+  {
+    printf '%s\tbeta.md\n' "$alpha_id"
+    printf '%s\tbeta.md\n' "$beta_id"
+  } > "$next_manifest"
+  mv "$next_manifest" "$manifest"
+  git -C "$NOTES_CALLER_PWD" add notes/.manifest
+  git -C "$NOTES_CALLER_PWD" commit -q -m "collide readable paths"
+
+  run notes diff --out "$out_dir" HEAD~1 HEAD
+
+  [ "$status" -eq 0 ]
+  [ -f "$out_dir/base/notes/alpha.md" ]
+  grep -q "# Beta" "$out_dir/base/notes/beta.md"
+  [ ! -e "$out_dir/head/notes/alpha.md" ]
+  grep -q "# Beta" "$out_dir/head/notes/beta.md"
+  grep -q "a/notes/alpha.md" "$out_dir/readable.patch"
+  ! grep -q "a/notes/beta.md" "$out_dir/readable.patch"
+}
+
 @test "ref diff Git process count does not grow with unchanged notes" {
   local i real_git counter_bin calls git_call_count
   rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null


### PR DESCRIPTION
## Finding

The changed-ID derivation collapses each manifest to one path per ID. A manifest can contain repeated IDs after a merge-produced alias, so removing one alias while retaining another produces no candidate ID and an empty readable patch. Multiple IDs can also target the same readable path; selecting only the changed ID can then materialize content that the full readable tree would overwrite with an unchanged ID.

This fix seeds selection from exact changed manifest rows, then expands through the affected ID/path component across both refs. The changed-note artifacts therefore preserve full-tree diff semantics without returning to per-note Git processes.

## Validation

- `mise run test test/diff.bats` — 14/14 passed
- all eight Codebase lints passed
- `bash -n lib/diff.sh .mise/tasks/diff`
- `readme build --check`
- `git diff --check`
- Fold pre-commit passed

Fixes the review finding on KnickKnackLabs/notes#176.
