### PR TITLE
fix: reject unreadable manifest path shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 412](https://img.shields.io/badge/tests-412-brightgreen?style=flat)](test/)
+[![tests: 413](https://img.shields.io/badge/tests-413-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/lib/diff.sh
+++ b/lib/diff.sh
@@ -22,6 +22,32 @@ _guard_manifest_path() {
   esac
 }
 
+_validate_manifest_readable_paths() {
+  local ref="$1" manifest="$2"
+
+  awk -F '\t' -v ref="$ref" '
+    {
+      separator = index($0, FS)
+      path = substr($0, separator + 1)
+      paths[path] = 1
+    }
+    END {
+      invalid = 0
+      for (path in paths) {
+        ancestor = path
+        while (sub(/\/[^/]+$/, "", ancestor)) {
+          if (ancestor in paths) {
+            printf "Error: %s readable path is both a file and directory: %s\n", ref, ancestor > "/dev/stderr"
+            invalid = 1
+            break
+          }
+        }
+      }
+      exit invalid
+    }
+  ' "$manifest"
+}
+
 # Build and validate one ref's readable-name index without materializing note blobs.
 _prepare_readable_notes_ref_index() {
   local repo_root="$1" notes_dir="$2" ref="$3" manifest_out="$4"
@@ -106,6 +132,11 @@ _prepare_readable_notes_ref_index() {
         print count > unmapped
       }
     ' "$tree_ids" "$validated_manifest"
+
+  if ! _validate_manifest_readable_paths "$ref" "$manifest_out"; then
+    rm -f "$tree_paths" "$tree_ids" "$raw_manifest" "$validated_manifest" "$missing_manifest" "$unmapped_file"
+    return 1
+  fi
 
   while IFS=$'\t' read -r id relpath; do
     [ -z "$id" ] && continue

--- a/lib/diff.sh
+++ b/lib/diff.sh
@@ -35,7 +35,7 @@ _validate_manifest_readable_paths() {
       invalid = 0
       for (path in paths) {
         ancestor = path
-        while (sub(/\/[^/]+$/, "", ancestor)) {
+        while (sub(/\/[^\/]+$/, "", ancestor)) {
           if (ancestor in paths) {
             printf "Error: %s readable path is both a file and directory: %s\n", ref, ancestor > "/dev/stderr"
             invalid = 1

--- a/test/diff.bats
+++ b/test/diff.bats
@@ -172,6 +172,32 @@ commit_readable_update() {
   ! grep -q "a/notes/beta.md" "$out_dir/readable.patch"
 }
 
+@test "notes diff rejects readable file and directory path collisions" {
+  local alpha_id beta_id manifest next_manifest
+  manifest="$NOTES_CALLER_PWD/notes/.manifest"
+  alpha_id=$(awk -F '\t' '$2 == "alpha.md" { print $1 }' "$manifest")
+  beta_id=$(awk -F '\t' '$2 == "beta.md" { print $1 }' "$manifest")
+  next_manifest="$BATS_TEST_TMPDIR/prefix-colliding.manifest"
+
+  {
+    printf '%s\tshared\n' "$alpha_id"
+    printf '%s\tshared/child.md\n' "$beta_id"
+  } > "$next_manifest"
+  mv "$next_manifest" "$manifest"
+  git -C "$NOTES_CALLER_PWD" add notes/.manifest
+  git -C "$NOTES_CALLER_PWD" commit -q -m "create readable path prefix collision"
+
+  echo "# Beta changed" > "$NOTES_CALLER_PWD/notes/$beta_id"
+  git -C "$NOTES_CALLER_PWD" add "notes/$beta_id"
+  git -C "$NOTES_CALLER_PWD" commit -q -m "edit colliding note"
+
+  run notes diff HEAD~1 HEAD
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"readable path is both a file and directory: shared"* ]]
+  [[ "$output" != *"# Beta changed"* ]]
+}
+
 @test "ref diff Git process count does not grow with unchanged notes" {
   local i real_git counter_bin calls git_call_count
   rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null


### PR DESCRIPTION
## Finding

The changed-note reducer treats only exact readable-path equality as a manifest collision. A manifest can also map one blob to `shared` and another to `shared/child.md`. A full readable-tree materialization cannot represent that ref and fails regardless of row order, but the reduced path can select only the changed child ID, omit the colliding parent ID, and emit a plausible patch.

This fix validates the complete existing-blob mapping for each ref and rejects any readable path that is also another mapped path's directory. Exact duplicate paths remain supported for the alias semantics repaired by #177.

## Validation

- `mise run test` — 405 BATS tests and 9 Python tests passed
- `mise run test diff` — 15/15 passed
- all eight Codebase lints passed
- `mise run doctor` passed; optional local pre-commit hook remains uninstalled
- `bash -n lib/diff.sh .mise/tasks/diff`
- `readme build --check`
- `git diff --check`

Fixes one adversarial review finding on #176.
