### PR TITLE
fix: preserve manifest collision order

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 412](https://img.shields.io/badge/tests-412-brightgreen?style=flat)](test/)
+[![tests: 413](https://img.shields.io/badge/tests-413-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/lib/diff.sh
+++ b/lib/diff.sh
@@ -143,23 +143,49 @@ _changed_note_ids_between_refs() {
   done < "$changed_paths"
 
   awk -F '\t' '
+    function manifest_path(row) {
+      return substr(row, index(row, FS) + 1)
+    }
     FILENAME == ARGV[1] { selected_id[$1] = 1; next }
     FILENAME == ARGV[2] {
+      path = manifest_path($0)
       base_row[$0] = 1
       row_id[$0] = $1
+      base_path[path] = 1
+      base_order[path, ++base_count[path]] = $1
       edge_id[++edge_count] = $1
-      edge_path[edge_count] = $2
+      edge_path[edge_count] = path
       next
     }
     {
+      path = manifest_path($0)
       head_row[$0] = 1
       row_id[$0] = $1
+      head_path[path] = 1
+      head_order[path, ++head_count[path]] = $1
       edge_id[++edge_count] = $1
-      edge_path[edge_count] = $2
+      edge_path[edge_count] = path
     }
     END {
       for (row in base_row) if (!(row in head_row)) selected_id[row_id[row]] = 1
       for (row in head_row) if (!(row in base_row)) selected_id[row_id[row]] = 1
+
+      # Exact row sets do not capture order. When IDs collide on one readable
+      # path, their manifest order decides which blob materialization leaves
+      # behind. Select every ID on paths whose order changed.
+      for (path in base_path) compared_path[path] = 1
+      for (path in head_path) compared_path[path] = 1
+      for (path in compared_path) {
+        order_changed = (base_count[path] != head_count[path])
+        count = base_count[path] > head_count[path] ? base_count[path] : head_count[path]
+        for (i = 1; !order_changed && i <= count; i++) {
+          if (base_order[path, i] != head_order[path, i]) order_changed = 1
+        }
+        if (order_changed) {
+          for (i = 1; i <= base_count[path]; i++) selected_id[base_order[path, i]] = 1
+          for (i = 1; i <= head_count[path]; i++) selected_id[head_order[path, i]] = 1
+        }
+      }
 
       # A malformed or merge-produced manifest can alias one ID to multiple
       # paths, or multiple IDs to one path. Pull in the entire affected

--- a/test/diff.bats
+++ b/test/diff.bats
@@ -172,6 +172,38 @@ commit_readable_update() {
   ! grep -q "a/notes/beta.md" "$out_dir/readable.patch"
 }
 
+@test "notes diff preserves changed overwrite order for colliding readable paths" {
+  local alpha_id beta_id manifest next_manifest out_dir
+  manifest="$NOTES_CALLER_PWD/notes/.manifest"
+  alpha_id=$(awk -F '\t' '$2 == "alpha.md" { print $1 }' "$manifest")
+  beta_id=$(awk -F '\t' '$2 == "beta.md" { print $1 }' "$manifest")
+  next_manifest="$BATS_TEST_TMPDIR/reordered.manifest"
+  out_dir="$BATS_TEST_TMPDIR/reordered-review"
+
+  {
+    printf '%s\tshared.md\n' "$alpha_id"
+    printf '%s\tshared.md\n' "$beta_id"
+  } > "$manifest"
+  git -C "$NOTES_CALLER_PWD" add notes/.manifest
+  git -C "$NOTES_CALLER_PWD" commit -q -m "collide readable paths"
+
+  {
+    printf '%s\tshared.md\n' "$beta_id"
+    printf '%s\tshared.md\n' "$alpha_id"
+  } > "$next_manifest"
+  mv "$next_manifest" "$manifest"
+  git -C "$NOTES_CALLER_PWD" add notes/.manifest
+  git -C "$NOTES_CALLER_PWD" commit -q -m "change collision overwrite order"
+
+  run notes diff --out "$out_dir" HEAD~1 HEAD
+
+  [ "$status" -eq 0 ]
+  grep -q "# Beta" "$out_dir/base/notes/shared.md"
+  grep -q "# Alpha" "$out_dir/head/notes/shared.md"
+  grep -q -- "-# Beta" "$out_dir/readable.patch"
+  grep -q -- "+# Alpha" "$out_dir/readable.patch"
+}
+
 @test "ref diff Git process count does not grow with unchanged notes" {
   local i real_git counter_bin calls git_call_count
   rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null


### PR DESCRIPTION
## Finding

PR #177 repairs exact-row aliases and expands exact ID/path components, but exact row sets discard manifest order. When two IDs map to one readable path, full materialization uses the last row as the resulting file. Reordering those same rows can therefore change readable content without changing any row membership or blob. Exact head `3de63a2` selects no IDs and reports no readable change.

This fix records each ref's ordered ID sequence per readable path. A changed sequence seeds every ID on that path before the existing component expansion, preserving full-tree overwrite semantics while retaining changed-only blob materialization.

## Validation

- `mise run test` — 405 BATS tests and 9 Python tests passed
- `mise run test diff` — 15/15 passed
- all eight Codebase lints passed
- `mise run doctor` passed; optional local pre-commit hook remains uninstalled
- `bash -n lib/diff.sh .mise/tasks/diff`
- `readme build --check`
- `git diff --check`

Fixes one adversarial review finding on #176.
