### PR TITLE
fix: reject obfuscation path collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 418](https://img.shields.io/badge/tests-418-brightgreen?style=flat)](test/)
+[![tests: 419](https://img.shields.io/badge/tests-419-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 416](https://img.shields.io/badge/tests-416-brightgreen?style=flat)](test/)
+[![tests: 418](https://img.shields.io/badge/tests-418-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/lib/obfuscate.sh
+++ b/lib/obfuscate.sh
@@ -125,7 +125,7 @@ build_obfuscation_plan() {
       echo "Error: manifest ID '$id' maps to multiple readable paths" >&2
       return 1
     fi
-    if [ "$kind" = "known" ] && [ -e "$notes_dir/$id" ]; then
+    if [ "$kind" = "known" ] && { [ -e "$notes_dir/$id" ] || [ -L "$notes_dir/$id" ]; }; then
       rm -rf "$workspace"
       echo "Error: refusing to overwrite existing obfuscated path: $id" >&2
       return 1

--- a/lib/obfuscate.sh
+++ b/lib/obfuscate.sh
@@ -83,6 +83,8 @@ build_obfuscation_plan() {
   if ! awk -F '\t' -v OFS='\t' -v candidates="$candidates" '
     FILENAME != candidates {
       if ($1 != "") {
+        if (($1 in id_names) && id_names[$1] != $2) duplicate_ids[$1] = 1
+        id_names[$1] = $2
         ids[$1] = 1
         if (!($2 in names)) names[$2] = $1
       }
@@ -97,7 +99,11 @@ build_obfuscation_plan() {
       if (base ~ /^[a-f0-9]{8}$/) {
         print "invalid", "-", relpath
       } else if (relpath in names) {
-        print "known", names[relpath], relpath
+        if (names[relpath] in duplicate_ids) {
+          print "collision", names[relpath], relpath
+        } else {
+          print "known", names[relpath], relpath
+        }
       } else {
         print "new", "-", relpath
       }
@@ -112,6 +118,16 @@ build_obfuscation_plan() {
     if [ "$kind" = "invalid" ]; then
       rm -rf "$workspace"
       refuse_if_hex_basename "$relpath"
+      return 1
+    fi
+    if [ "$kind" = "collision" ]; then
+      rm -rf "$workspace"
+      echo "Error: manifest ID '$id' maps to multiple readable paths" >&2
+      return 1
+    fi
+    if [ "$kind" = "known" ] && [ -e "$notes_dir/$id" ]; then
+      rm -rf "$workspace"
+      echo "Error: refusing to overwrite existing obfuscated path: $id" >&2
       return 1
     fi
   done < "$plan_file"

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -193,6 +193,23 @@ setup() {
   [ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" = "dirty readable content" ]
 }
 
+@test "obfuscate refuses to replace a dangling known-ID symlink" {
+  notes obfuscate
+  local alpha_id
+  alpha_id=$(grep $'\talpha\.md$' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  rm "$NOTES_CALLER_PWD/notes/$alpha_id"
+  printf 'readable content\n' > "$NOTES_CALLER_PWD/notes/alpha.md"
+  ln -s missing-target "$NOTES_CALLER_PWD/notes/$alpha_id"
+
+  run notes obfuscate alpha.md
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"refusing to overwrite existing obfuscated path: $alpha_id"* ]]
+  [ -L "$NOTES_CALLER_PWD/notes/$alpha_id" ]
+  [ "$(readlink "$NOTES_CALLER_PWD/notes/$alpha_id")" = "missing-target" ]
+  [ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" = "readable content" ]
+}
+
 @test "obfuscate refuses a manifest ID shared by planned readable paths" {
   notes obfuscate
   local alpha_id

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -174,6 +174,40 @@ setup() {
   [ -f "$NOTES_CALLER_PWD/notes/$alpha_id" ]
 }
 
+@test "obfuscate refuses to overwrite an existing known-ID destination" {
+  notes obfuscate
+  local alpha_id
+  alpha_id=$(grep $'\talpha\.md$' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscated"
+
+  # Simulate an interrupted or stale state containing both representations.
+  printf 'dirty readable content\n' > "$NOTES_CALLER_PWD/notes/alpha.md"
+  local obfuscated_before
+  obfuscated_before=$(cat "$NOTES_CALLER_PWD/notes/$alpha_id")
+
+  run notes obfuscate alpha.md
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"refusing to overwrite existing obfuscated path: $alpha_id"* ]]
+  [ "$(cat "$NOTES_CALLER_PWD/notes/$alpha_id")" = "$obfuscated_before" ]
+  [ "$(cat "$NOTES_CALLER_PWD/notes/alpha.md")" = "dirty readable content" ]
+}
+
+@test "obfuscate refuses a manifest ID shared by planned readable paths" {
+  notes obfuscate
+  local alpha_id
+  alpha_id=$(grep $'\talpha\.md$' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  notes deobfuscate
+  printf '%s\tbeta.md\n' "$alpha_id" >> "$NOTES_CALLER_PWD/notes/.manifest"
+
+  run notes obfuscate alpha.md beta.md
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"manifest ID '$alpha_id' maps to multiple readable paths"* ]]
+  [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/beta.md" ]
+}
+
 @test "full obfuscate batches Fold-scale known-entry classification and staging" {
   local count=535 i=1 id name mock_bin command real_command call_log
   rm -rf "$NOTES_CALLER_PWD/notes"


### PR DESCRIPTION
## Finding

The corpus plan allowed a known readable path to target an already-existing obfuscated path. `mv` then overwrote that destination before staging. A duplicated manifest ID could likewise send two planned readable paths to one destination.

## Fix

- reject existing known-ID destinations during planning, before mutation
- reject manifest IDs shared by multiple planned readable paths
- cover both stale/interrupted-state collision shapes

## Validation

- `mise run test test/obfuscate.bats` (84 passed)
- all 8 configured `codebase lint` rules
- Bash syntax and `git diff --check`
- Fold pre-commit OK; pre-push had only expected new-branch and inherited unsigned-history warnings
