### PR TITLE
perf: derive deobfuscate paths in shell

### DIFF
--- a/.mise/tasks/deobfuscate
+++ b/.mise/tasks/deobfuscate
@@ -28,6 +28,10 @@ if [ -n "${usage_files:-}" ]; then
     arg="${arg#"${notes_dir}/"}"
     # Skip empty variadic defaults after xargs unquotes "''".
     [ -z "$arg" ] && continue
+    # Match basename's handling of trailing slashes without spawning it.
+    while [ -n "$arg" ] && [ "${arg%/}" != "$arg" ]; do
+      arg="${arg%/}"
+    done
     arg="${arg##*/}"
     ARGS+=("$arg")
   done < <(printf '%s' "${usage_files}" | xargs printf '%s\n')

--- a/.mise/tasks/deobfuscate
+++ b/.mise/tasks/deobfuscate
@@ -28,7 +28,7 @@ if [ -n "${usage_files:-}" ]; then
     arg="${arg#"${notes_dir}/"}"
     # Skip empty variadic defaults after xargs unquotes "''".
     [ -z "$arg" ] && continue
-    arg=$(basename "$arg")
+    arg="${arg##*/}"
     ARGS+=("$arg")
   done < <(printf '%s' "${usage_files}" | xargs printf '%s\n')
 fi

--- a/.mise/tasks/deobfuscate
+++ b/.mise/tasks/deobfuscate
@@ -29,10 +29,12 @@ if [ -n "${usage_files:-}" ]; then
     # Skip empty variadic defaults after xargs unquotes "''".
     [ -z "$arg" ] && continue
     # Match basename's handling of trailing slashes without spawning it.
-    while [ -n "$arg" ] && [ "${arg%/}" != "$arg" ]; do
-      arg="${arg%/}"
+    while [ "${arg%/}" != "$arg" ]; do
+      trimmed="${arg%/}"
+      [ -n "$trimmed" ] || break
+      arg="$trimmed"
     done
-    arg="${arg##*/}"
+    [ "$arg" = "/" ] || arg="${arg##*/}"
     ARGS+=("$arg")
   done < <(printf '%s' "${usage_files}" | xargs printf '%s\n')
 fi

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 422](https://img.shields.io/badge/tests-422-brightgreen?style=flat)](test/)
+[![tests: 423](https://img.shields.io/badge/tests-423-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 423](https://img.shields.io/badge/tests-423-brightgreen?style=flat)](test/)
+[![tests: 424](https://img.shields.io/badge/tests-424-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 420](https://img.shields.io/badge/tests-420-brightgreen?style=flat)](test/)
+[![tests: 422](https://img.shields.io/badge/tests-422-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/lib/obfuscate.sh
+++ b/lib/obfuscate.sh
@@ -433,7 +433,8 @@ _rename_one_to_readable() {
   fi
 
   local target_dir
-  target_dir=$(dirname "$notes_dir/$relpath")
+  target_dir="$notes_dir/$relpath"
+  target_dir="${target_dir%/*}"
   [ ! -d "$target_dir" ] && mkdir -p "$target_dir"
 
   if [ -e "$notes_dir/$relpath" ] && ! cmp -s "$notes_dir/$id" "$notes_dir/$relpath"; then

--- a/test/deobfuscate.bats
+++ b/test/deobfuscate.bats
@@ -239,6 +239,21 @@ BASH
 }
 
 
+@test "scoped deobfuscate keeps a trailing-slash path scoped" {
+  notes obfuscate
+
+  local alpha_id beta_id
+  alpha_id=$(grep 'alpha.md' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  beta_id=$(grep 'beta.md' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+
+  notes deobfuscate "notes/$alpha_id/"
+
+  [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/$beta_id" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/beta.md" ]
+}
+
+
 @test "deobfuscate with args warns on unknown ID" {
   notes obfuscate
 

--- a/test/deobfuscate.bats
+++ b/test/deobfuscate.bats
@@ -254,6 +254,23 @@ BASH
 }
 
 
+@test "scoped deobfuscate keeps a slash-only path scoped" {
+  notes obfuscate
+
+  local alpha_id beta_id
+  alpha_id=$(grep 'alpha.md' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  beta_id=$(grep 'beta.md' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+
+  run notes deobfuscate "////"
+
+  [ "$status" -eq 0 ]
+  [ -f "$NOTES_CALLER_PWD/notes/$alpha_id" ]
+  [ -f "$NOTES_CALLER_PWD/notes/$beta_id" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/beta.md" ]
+}
+
+
 @test "deobfuscate with args warns on unknown ID" {
   notes obfuscate
 

--- a/test/deobfuscate.bats
+++ b/test/deobfuscate.bats
@@ -208,6 +208,37 @@ SH
 }
 
 
+@test "scoped deobfuscate derives an ID without calling basename" {
+  notes obfuscate
+
+  local alpha_id mock_bin real_basename blocked_log
+  alpha_id=$(grep 'alpha.md' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  mock_bin="$BATS_TEST_TMPDIR/basename-guard-bin"
+  blocked_log="$BATS_TEST_TMPDIR/basename-blocked"
+  real_basename=$(command -v basename)
+  mkdir -p "$mock_bin"
+  cat > "$mock_bin/basename" <<'BASH'
+#!/usr/bin/env bash
+if [ "$#" -eq 1 ] && [ "$1" = "$BLOCKED_BASENAME_ARG" ]; then
+  printf '%s\n' "$1" > "$BLOCKED_COMMAND_LOG"
+  exit 97
+fi
+exec "$REAL_BASENAME" "$@"
+BASH
+  chmod +x "$mock_bin/basename"
+
+  PATH="$mock_bin:$PATH" \
+    BLOCKED_BASENAME_ARG="$alpha_id" \
+    BLOCKED_COMMAND_LOG="$blocked_log" \
+    REAL_BASENAME="$real_basename" \
+    run notes deobfuscate "notes/$alpha_id"
+
+  [ "$status" -eq 0 ]
+  [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ ! -e "$blocked_log" ]
+}
+
+
 @test "deobfuscate with args warns on unknown ID" {
   notes obfuscate
 

--- a/test/rename.bats
+++ b/test/rename.bats
@@ -226,6 +226,30 @@ setup() {
   [ -f "$NOTES_CALLER_PWD/notes/sub/deep.md" ]
 }
 
+@test "rename_to_readable derives nested target directories without dirname" {
+  mkdir -p "$NOTES_CALLER_PWD/notes/sub"
+  echo "# Deep" > "$NOTES_CALLER_PWD/notes/sub/deep.md"
+  rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
+
+  local mock_bin blocked_log
+  mock_bin="$BATS_TEST_TMPDIR/dirname-guard-bin"
+  blocked_log="$BATS_TEST_TMPDIR/dirname-blocked"
+  mkdir -p "$mock_bin"
+  cat > "$mock_bin/dirname" <<'BASH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$BLOCKED_COMMAND_LOG"
+exit 97
+BASH
+  chmod +x "$mock_bin/dirname"
+
+  PATH="$mock_bin:$PATH" BLOCKED_COMMAND_LOG="$blocked_log" \
+    run rename_to_readable "$NOTES_CALLER_PWD/notes"
+
+  [ "$status" -eq 0 ]
+  [ -f "$NOTES_CALLER_PWD/notes/sub/deep.md" ]
+  [ ! -e "$blocked_log" ]
+}
+
 @test "rename_to_readable preserves manifest" {
   rename_to_obfuscated "$NOTES_CALLER_PWD/notes" > /dev/null
   local manifest_before


### PR DESCRIPTION
## Summary

- derive scoped deobfuscation IDs with Bash parameter expansion instead of `basename`
- derive readable target directories in shell instead of one `dirname` process per restored note
- keep dirty-readable checks, partial-success state, suppression, staging, and move behavior unchanged
- add focused guards proving the target paths do not invoke those external commands

## Validation

- `mise run test test/deobfuscate.bats` (29 passed)
- `mise run test test/rename.bats` (25 passed)
- `mise run test` (414 BATS and 9 Python tests passed)
- `codebase lint .` (8 rules passed)
- `mise run doctor`
- `bash -n .mise/tasks/deobfuscate lib/obfuscate.sh`
- `git diff --check`
- Fold `git:pre-commit` and `git:pre-push` (no failures)
