### PR TITLE
fix: keep trailing-slash deobfuscation scoped

### DIFF
--- a/.mise/tasks/deobfuscate
+++ b/.mise/tasks/deobfuscate
@@ -28,6 +28,10 @@ if [ -n "${usage_files:-}" ]; then
     arg="${arg#"${notes_dir}/"}"
     # Skip empty variadic defaults after xargs unquotes "''".
     [ -z "$arg" ] && continue
+    # Match basename's handling of trailing slashes without spawning it.
+    while [ -n "$arg" ] && [ "${arg%/}" != "$arg" ]; do
+      arg="${arg%/}"
+    done
     arg="${arg##*/}"
     ARGS+=("$arg")
   done < <(printf '%s' "${usage_files}" | xargs printf '%s\n')

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 422](https://img.shields.io/badge/tests-422-brightgreen?style=flat)](test/)
+[![tests: 423](https://img.shields.io/badge/tests-423-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/test/deobfuscate.bats
+++ b/test/deobfuscate.bats
@@ -239,6 +239,21 @@ BASH
 }
 
 
+@test "scoped deobfuscate keeps a trailing-slash path scoped" {
+  notes obfuscate
+
+  local alpha_id beta_id
+  alpha_id=$(grep 'alpha.md' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+  beta_id=$(grep 'beta.md' "$NOTES_CALLER_PWD/notes/.manifest" | cut -f1)
+
+  notes deobfuscate "notes/$alpha_id/"
+
+  [ -f "$NOTES_CALLER_PWD/notes/alpha.md" ]
+  [ -f "$NOTES_CALLER_PWD/notes/$beta_id" ]
+  [ ! -f "$NOTES_CALLER_PWD/notes/beta.md" ]
+}
+
+
 @test "deobfuscate with args warns on unknown ID" {
   notes obfuscate
 


### PR DESCRIPTION
## Finding

PR #185 replaces `basename` with `${arg##*/}` for scoped deobfuscation. Unlike `basename`, that expansion returns an empty string for a path ending in `/`. Passing `notes/<id>/` therefore leaves no non-empty scoped ID, selects full mode, and restores every note instead of only the requested note.

This fix removes trailing slashes before taking the final path component, using Bash 3.2-compatible parameter expansion. The regression proves only the selected note is restored and would fail on PR #185's exact head.

## Validation

- Regression on `8c91b5f902943a893b06bd1f48968a77d2478b06`: failed as expected because all three notes were restored
- `mise run test test/deobfuscate.bats`: 30 passed
- `mise run test`: 415 BATS passed, 9 Python passed
- `codebase lint "$PWD"`: 8 rules passed
- `mise run doctor`: required checks passed; optional clone-local pre-commit hook is not installed
- `readme build --check`
- `bash -n .mise/tasks/deobfuscate lib/obfuscate.sh`
- `git diff --check`

Fix-it for #185. Base is `junior/deobfuscate-path-builtins`; this PR does not target `main`.
