### PR TITLE
perf: batch pre-commit hook inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 428](https://img.shields.io/badge/tests-428-brightgreen?style=flat)](test/)
+[![tests: 431](https://img.shields.io/badge/tests-431-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 424](https://img.shields.io/badge/tests-424-brightgreen?style=flat)](test/)
+[![tests: 428](https://img.shields.io/badge/tests-428-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/hooks/encryption.template
+++ b/hooks/encryption.template
@@ -7,6 +7,9 @@
 # commit. See KnickKnackLabs/notes#49.
 set -eo pipefail
 
+NOTES_TOOL_ROOT="__NOTES_TOOL_ROOT__"
+source "$NOTES_TOOL_ROOT/lib/encryption.sh"
+
 if ! command -v git-crypt &>/dev/null; then
   echo "WARNING: git-crypt not found — skipping encryption check" >&2
   exit 0
@@ -28,30 +31,4 @@ while IFS= read -r -d '' path \
 done < <(git check-attr --cached -z filter -- "${staged[@]}")
 [ "${#encrypted_staged[@]}" -eq 0 ] && exit 0
 
-# Flag any that are currently plaintext (e.g. git-crypt locked at stage time).
-bad_files=()
-for file in "${encrypted_staged[@]}"; do
-  status_output=""
-  status=0
-  if status_output=$(git-crypt status -- "$file" 2>&1); then
-    :
-  else
-    status=$?
-  fi
-
-  if grep -qi "not encrypted" <<< "$status_output"; then
-    bad_files+=("$file")
-  elif [ "$status" -ne 0 ]; then
-    echo "ERROR: git-crypt could not inspect staged encrypted path: $file" >&2
-    [ -z "$status_output" ] || printf '%s\n' "$status_output" >&2
-    exit 1
-  fi
-done
-
-if [ "${#bad_files[@]}" -gt 0 ]; then
-  echo "ERROR: Staged files should be encrypted but are plaintext:" >&2
-  printf '  %s\n' "${bad_files[@]}" >&2
-  echo "" >&2
-  echo "Run 'notes unlock' if git-crypt is locked, then re-stage." >&2
-  exit 1
-fi
+verify_encrypted_paths "${encrypted_staged[@]}"

--- a/hooks/encryption.template
+++ b/hooks/encryption.template
@@ -15,20 +15,38 @@ if ! command -v git-crypt &>/dev/null; then
   exit 0
 fi
 
+staged_input=$(mktemp) || {
+  echo "ERROR: Failed to create encryption hook staged-path input" >&2
+  exit 1
+}
+attribute_input=$(mktemp) || {
+  rm -f "$staged_input"
+  echo "ERROR: Failed to create encryption hook attribute input" >&2
+  exit 1
+}
+trap 'rm -f "$staged_input" "$attribute_input"' EXIT
+
 # Staged adds/copies/modifies/renames, NUL-delimited for path safety.
+if ! git diff --cached --name-only --diff-filter=ACMR -z > "$staged_input"; then
+  echo "ERROR: Could not inspect staged paths for encryption" >&2
+  exit 1
+fi
 staged=()
-while IFS= read -r -d '' path; do staged+=("$path"); done \
-  < <(git diff --cached --name-only --diff-filter=ACMR -z)
+while IFS= read -r -d '' path; do staged+=("$path"); done < "$staged_input"
 [ "${#staged[@]}" -eq 0 ] && exit 0
 
 # Which staged paths are under an encrypted (filter=git-crypt) pattern?
 # check-attr -z emits NUL-delimited <path> <attr> <value> triples.
+if ! git check-attr --cached -z filter -- "${staged[@]}" > "$attribute_input"; then
+  echo "ERROR: Could not inspect staged encryption attributes" >&2
+  exit 1
+fi
 encrypted_staged=()
 while IFS= read -r -d '' path \
    && IFS= read -r -d '' _attr \
    && IFS= read -r -d '' value; do
   [ "$value" = "git-crypt" ] && encrypted_staged+=("$path")
-done < <(git check-attr --cached -z filter -- "${staged[@]}")
+done < "$attribute_input"
 [ "${#encrypted_staged[@]}" -eq 0 ] && exit 0
 
 verify_encrypted_paths "${encrypted_staged[@]}"

--- a/hooks/obfuscation.template
+++ b/hooks/obfuscation.template
@@ -20,15 +20,21 @@ run_notes() {
 
 build_staged_obfuscation_plan() {
   local candidates="$1" plan="$2"
+  local staged="$candidates.staged"
   local file relpath
   : > "$candidates"
 
+  if ! git diff --cached --name-only --diff-filter=ACMR > "$staged"; then
+    rm -f "$staged"
+    return 1
+  fi
   while IFS= read -r file; do
     [[ "$file" != "$NOTES_ROOT/"* ]] && continue
     relpath="${file#"$NOTES_ROOT/"}"
     [[ "$relpath" == ".manifest" ]] && continue
     printf '%s\n' "$relpath" >> "$candidates"
-  done < <(git diff --cached --name-only --diff-filter=ACMR)
+  done < "$staged"
+  rm -f "$staged"
 
   classify_obfuscation_candidates \
     "$NOTES_ROOT" "$NOTES_ROOT/.manifest" "$candidates" "$plan"

--- a/hooks/obfuscation.template
+++ b/hooks/obfuscation.template
@@ -9,6 +9,8 @@ NOTES_TOOL_ROOT="__NOTES_TOOL_ROOT__"
 MISE_BIN="__MISE_BIN__"
 MODE="${NOTES_OBFUSCATE_HOOK:-auto}"
 
+source "$NOTES_TOOL_ROOT/lib/obfuscate.sh"
+
 run_notes() {
   local repo_root
   repo_root="$(git rev-parse --show-toplevel)"
@@ -16,17 +18,43 @@ run_notes() {
   (cd "$NOTES_TOOL_ROOT" && "$MISE_BIN" run -q "$@")
 }
 
-if [ -f "$NOTES_ROOT/.manifest" ]; then
-  unobfuscated=()
+build_staged_obfuscation_plan() {
+  local candidates="$1" plan="$2"
+  local file relpath
+  : > "$candidates"
+
   while IFS= read -r file; do
     [[ "$file" != "$NOTES_ROOT/"* ]] && continue
-    base=$(basename "$file")
-    [[ "$base" == ".manifest" ]] && continue
-    # Check if basename is a known ID in the manifest
-    if ! grep -q "^${base}	" "$NOTES_ROOT/.manifest"; then
-      unobfuscated+=("$file")
-    fi
+    relpath="${file#"$NOTES_ROOT/"}"
+    [[ "$relpath" == ".manifest" ]] && continue
+    printf '%s\n' "$relpath" >> "$candidates"
   done < <(git diff --cached --name-only --diff-filter=ACMR)
+
+  classify_obfuscation_candidates \
+    "$NOTES_ROOT" "$NOTES_ROOT/.manifest" "$candidates" "$plan"
+}
+
+if [ -f "$NOTES_ROOT/.manifest" ]; then
+  candidates=$(mktemp) || {
+    echo "ERROR: Failed to create obfuscation hook candidates" >&2
+    exit 1
+  }
+  plan=$(mktemp) || {
+    rm -f "$candidates"
+    echo "ERROR: Failed to create obfuscation hook plan" >&2
+    exit 1
+  }
+  trap 'rm -f "$candidates" "$plan"' EXIT
+
+  if ! build_staged_obfuscation_plan "$candidates" "$plan"; then
+    echo "ERROR: Could not classify staged note filenames" >&2
+    exit 1
+  fi
+
+  unobfuscated=()
+  while IFS=$'\t' read -r _kind _id relpath; do
+    [ -n "$relpath" ] && unobfuscated+=("$NOTES_ROOT/$relpath")
+  done < "$plan"
 
   if [ "${#unobfuscated[@]}" -gt 0 ]; then
     if [ "$MODE" = "auto" ]; then
@@ -35,6 +63,21 @@ if [ -f "$NOTES_ROOT/.manifest" ]; then
       # `notes` command happens to appear first on PATH.
       # Pass only the staged unobfuscated files.
       run_notes obfuscate "${unobfuscated[@]}" >&2
+
+      # Auto mode must prove the index no longer contains readable note paths.
+      # A staged file can be absent from the working tree and therefore cannot
+      # be repaired by obfuscation; fail rather than committing that path.
+      if ! build_staged_obfuscation_plan "$candidates" "$plan"; then
+        echo "ERROR: Could not verify staged note filenames" >&2
+        exit 1
+      fi
+      if [ -s "$plan" ]; then
+        echo "ERROR: Auto-obfuscation left staged non-obfuscated filenames:" >&2
+        while IFS=$'\t' read -r _kind _id relpath; do
+          [ -n "$relpath" ] && printf '  %s/%s\n' "$NOTES_ROOT" "$relpath" >&2
+        done < "$plan"
+        exit 1
+      fi
     else
       echo "ERROR: Staged notes have non-obfuscated filenames:" >&2
       printf '  %s\n' "${unobfuscated[@]}" >&2

--- a/lib/encryption.sh
+++ b/lib/encryption.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# encryption.sh — staged encrypted-path validation
+
+# Verify that indexed blobs for encrypted paths are encrypted.
+# The common path checks all paths in one git-crypt call. If that call reports
+# plaintext or fails, inspect paths individually so diagnostics remain precise
+# and unexpected backend failures remain fail closed.
+# Usage: verify_encrypted_paths <path...>
+verify_encrypted_paths() {
+  local encrypted_paths=("$@")
+  local batch_output batch_status=0 marker_status=0
+
+  [ "${#encrypted_paths[@]}" -gt 0 ] || return 0
+
+  if batch_output=$(git-crypt status -- "${encrypted_paths[@]}" 2>&1); then
+    :
+  else
+    batch_status=$?
+  fi
+
+  # git-crypt reports plaintext paths in human output but still exits zero.
+  # Use the same marker as the existing per-path contract only to select the
+  # precise fallback; do not parse path names from batched output.
+  grep -qi "not encrypted" <<< "$batch_output" || marker_status=$?
+  case "$marker_status" in
+    0) ;;
+    1)
+      [ "$batch_status" -eq 0 ] && return 0
+      ;;
+    *)
+      echo "ERROR: could not interpret git-crypt inspection output" >&2
+      [ -z "$batch_output" ] || printf '%s\n' "$batch_output" >&2
+      return 1
+      ;;
+  esac
+
+  local bad_files=()
+  local file status_output status
+  for file in "${encrypted_paths[@]}"; do
+    status_output=""
+    status=0
+    marker_status=0
+    if status_output=$(git-crypt status -- "$file" 2>&1); then
+      :
+    else
+      status=$?
+    fi
+
+    grep -qi "not encrypted" <<< "$status_output" || marker_status=$?
+    case "$marker_status" in
+      0)
+        bad_files+=("$file")
+        ;;
+      1)
+        if [ "$status" -ne 0 ]; then
+          echo "ERROR: git-crypt could not inspect staged encrypted path: $file" >&2
+          [ -z "$status_output" ] || printf '%s\n' "$status_output" >&2
+          return 1
+        fi
+        ;;
+      *)
+        echo "ERROR: could not interpret git-crypt inspection output for: $file" >&2
+        [ -z "$status_output" ] || printf '%s\n' "$status_output" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  if [ "${#bad_files[@]}" -gt 0 ]; then
+    echo "ERROR: Staged files should be encrypted but are plaintext:" >&2
+    printf '  %s\n' "${bad_files[@]}" >&2
+    echo "" >&2
+    echo "Run 'notes unlock' if git-crypt is locked, then re-stage." >&2
+    return 1
+  fi
+
+  # The batched command failed, but no individual path explained the failure.
+  # Preserve fail-closed behavior rather than trusting an ambiguous result.
+  echo "ERROR: git-crypt could not inspect staged encrypted paths" >&2
+  [ -z "$batch_output" ] || printf '%s\n' "$batch_output" >&2
+  return 1
+}

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -42,10 +42,12 @@ ensure_hook_dispatcher() {
 }
 
 # Install the encryption pre-commit check.
+# Render the source package path so the hook uses the exact Notes version that
+# installed it rather than whichever `notes` command appears first on PATH.
 install_encryption_hook() {
   ensure_hook_dispatcher pre-commit
   local target="$TARGET_DIR/.git/hooks/pre-commit.d/encryption"
-  cp "$HOOKS_DIR/encryption" "$target"
+  _render_notes_hook_template "$HOOKS_DIR/encryption.template" "." > "$target"
   chmod +x "$target"
 }
 

--- a/lib/obfuscate.sh
+++ b/lib/obfuscate.sh
@@ -37,18 +37,72 @@ EOF
   return 0
 }
 
-# Build a corpus-level obfuscation plan.
+# Classify a prepared readable-path snapshot against one manifest snapshot.
 # Output rows are "<kind>\t<id-or-dash>\t<relpath>", where kind is
 # "known" for an existing manifest mapping or "new" for a new readable name.
 # Already-obfuscated IDs are omitted. The full plan is checked for orphan
 # hash-shaped names before any caller mutates the working tree.
+# Usage: classify_obfuscation_candidates <notes_dir> <manifest> <candidates> <plan>
+classify_obfuscation_candidates() {
+  local notes_dir="$1" manifest_input="$2" candidates="$3" plan_file="$4"
+
+  if ! awk -F '\t' -v OFS='\t' -v candidates="$candidates" '
+    FILENAME != candidates {
+      if ($1 != "") {
+        if (($1 in id_names) && id_names[$1] != $2) duplicate_ids[$1] = 1
+        id_names[$1] = $2
+        ids[$1] = 1
+        if (!($2 in names)) names[$2] = $1
+      }
+      next
+    }
+    {
+      relpath = $0
+      if (relpath == "" || seen[relpath]++) next
+      count = split(relpath, parts, "/")
+      base = parts[count]
+      if (base in ids) next
+      if (base ~ /^[a-f0-9]{8}$/) {
+        print "invalid", "-", relpath
+      } else if (relpath in names) {
+        if (names[relpath] in duplicate_ids) {
+          print "collision", names[relpath], relpath
+        } else {
+          print "known", names[relpath], relpath
+        }
+      } else {
+        print "new", "-", relpath
+      }
+    }
+  ' "$manifest_input" "$candidates" > "$plan_file"; then
+    return 1
+  fi
+
+  local kind id relpath
+  while IFS=$'\t' read -r kind id relpath; do
+    if [ "$kind" = "invalid" ]; then
+      refuse_if_hex_basename "$relpath"
+      return 1
+    fi
+    if [ "$kind" = "collision" ]; then
+      echo "Error: manifest ID '$id' maps to multiple readable paths" >&2
+      return 1
+    fi
+    if [ "$kind" = "known" ] && { [ -e "$notes_dir/$id" ] || [ -L "$notes_dir/$id" ]; }; then
+      echo "Error: refusing to overwrite existing obfuscated path: $id" >&2
+      return 1
+    fi
+  done < "$plan_file"
+}
+
+# Build a corpus-level obfuscation plan from readable files on disk.
 # Usage: build_obfuscation_plan <notes_dir> <plan_file> [file...]
 build_obfuscation_plan() {
   local notes_dir="$1" plan_file="$2"
   shift 2
   local scoped_files=("$@")
   local manifest="$notes_dir/.manifest"
-  local workspace candidates manifest_input
+  local workspace candidates manifest_input rc=0
 
   workspace=$(mktemp -d) || {
     echo "Error: failed to create obfuscation workspace" >&2
@@ -80,59 +134,10 @@ build_obfuscation_plan() {
     : > "$manifest_input"
   fi
 
-  if ! awk -F '\t' -v OFS='\t' -v candidates="$candidates" '
-    FILENAME != candidates {
-      if ($1 != "") {
-        if (($1 in id_names) && id_names[$1] != $2) duplicate_ids[$1] = 1
-        id_names[$1] = $2
-        ids[$1] = 1
-        if (!($2 in names)) names[$2] = $1
-      }
-      next
-    }
-    {
-      relpath = $0
-      if (relpath == "" || seen[relpath]++) next
-      count = split(relpath, parts, "/")
-      base = parts[count]
-      if (base in ids) next
-      if (base ~ /^[a-f0-9]{8}$/) {
-        print "invalid", "-", relpath
-      } else if (relpath in names) {
-        if (names[relpath] in duplicate_ids) {
-          print "collision", names[relpath], relpath
-        } else {
-          print "known", names[relpath], relpath
-        }
-      } else {
-        print "new", "-", relpath
-      }
-    }
-  ' "$manifest_input" "$candidates" > "$plan_file"; then
-    rm -rf "$workspace"
-    return 1
-  fi
-
-  local kind id
-  while IFS=$'\t' read -r kind id relpath; do
-    if [ "$kind" = "invalid" ]; then
-      rm -rf "$workspace"
-      refuse_if_hex_basename "$relpath"
-      return 1
-    fi
-    if [ "$kind" = "collision" ]; then
-      rm -rf "$workspace"
-      echo "Error: manifest ID '$id' maps to multiple readable paths" >&2
-      return 1
-    fi
-    if [ "$kind" = "known" ] && { [ -e "$notes_dir/$id" ] || [ -L "$notes_dir/$id" ]; }; then
-      rm -rf "$workspace"
-      echo "Error: refusing to overwrite existing obfuscated path: $id" >&2
-      return 1
-    fi
-  done < "$plan_file"
-
+  classify_obfuscation_candidates \
+    "$notes_dir" "$manifest_input" "$candidates" "$plan_file" || rc=$?
   rm -rf "$workspace"
+  return "$rc"
 }
 
 # Apply a precomputed obfuscation plan.

--- a/test/encrypt.bats
+++ b/test/encrypt.bats
@@ -97,6 +97,10 @@ load test_helper
   # Individual hooks
   [ -x "$TARGET_DIR/.git/hooks/pre-commit.d/encryption" ]
   grep -q "git-crypt" "$TARGET_DIR/.git/hooks/pre-commit.d/encryption"
+  grep -qF "NOTES_TOOL_ROOT=\"$REPO_DIR\"" \
+    "$TARGET_DIR/.git/hooks/pre-commit.d/encryption"
+  grep -qF 'source "$NOTES_TOOL_ROOT/lib/encryption.sh"' \
+    "$TARGET_DIR/.git/hooks/pre-commit.d/encryption"
   [ -x "$TARGET_DIR/.git/hooks/pre-commit.d/obfuscation" ]
   grep -q "manifest" "$TARGET_DIR/.git/hooks/pre-commit.d/obfuscation"
 }

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -539,6 +539,67 @@ run_encryption_hook() {
   [ "$status" -eq 0 ]
 }
 
+@test "encryption hook checks multiple valid staged paths in one git-crypt call (#49)" {
+  notes setup --yes
+  local fpr
+  fpr=$(generate_test_key "$GNUPGHOME")
+  notes add-user -- --gpg-key "$fpr"
+
+  mkdir -p "$TARGET_DIR/notes"
+  printf '%s\n' "first secret" > "$TARGET_DIR/notes/first.md"
+  printf '%s\n' "second secret" > "$TARGET_DIR/notes/second.md"
+  git -C "$TARGET_DIR" add notes/first.md notes/second.md
+
+  local mock_bin="$BATS_TEST_TMPDIR/counting-git-crypt-bin"
+  local calls="$BATS_TEST_TMPDIR/git-crypt-calls"
+  export GIT_CRYPT_CALLS="$calls"
+  mkdir -p "$mock_bin"
+  cat > "$mock_bin/git-crypt" <<'SH'
+#!/usr/bin/env bash
+printf 'call\n' >> "$GIT_CRYPT_CALLS"
+PATH="${PATH#*:}" exec git-crypt "$@"
+SH
+  chmod +x "$mock_bin/git-crypt"
+  export PATH="$mock_bin:$PATH"
+
+  run_encryption_hook
+  [ "$status" -eq 0 ]
+  [ "$(wc -l < "$calls" | tr -d ' ')" -eq 1 ]
+}
+
+@test "encryption hook falls back per path after a batched plaintext result (#49)" {
+  notes setup --yes
+  local fpr
+  fpr=$(generate_test_key "$GNUPGHOME")
+  notes add-user -- --gpg-key "$fpr"
+
+  mkdir -p "$TARGET_DIR/notes"
+  local file blob
+  for file in first.md second.md; do
+    blob=$(printf 'PLAINTEXT-LEAK\n' | git -C "$TARGET_DIR" hash-object -w --stdin)
+    git -C "$TARGET_DIR" update-index --add --cacheinfo \
+      100644 "$blob" "notes/$file"
+  done
+
+  local mock_bin="$BATS_TEST_TMPDIR/fallback-git-crypt-bin"
+  local calls="$BATS_TEST_TMPDIR/git-crypt-fallback-calls"
+  export GIT_CRYPT_CALLS="$calls"
+  mkdir -p "$mock_bin"
+  cat > "$mock_bin/git-crypt" <<'SH'
+#!/usr/bin/env bash
+printf 'call\n' >> "$GIT_CRYPT_CALLS"
+PATH="${PATH#*:}" exec git-crypt "$@"
+SH
+  chmod +x "$mock_bin/git-crypt"
+  export PATH="$mock_bin:$PATH"
+
+  run_encryption_hook
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"notes/first.md"* ]]
+  [[ "$output" == *"notes/second.md"* ]]
+  [ "$(wc -l < "$calls" | tr -d ' ')" -eq 3 ]
+}
+
 @test "encryption hook fails closed when git-crypt cannot inspect a staged path (#49)" {
   notes setup --yes
   local fpr

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -567,6 +567,64 @@ SH
   [ "$(wc -l < "$calls" | tr -d ' ')" -eq 1 ]
 }
 
+@test "encryption hook fails closed when staged-path inspection fails (#49)" {
+  notes setup --yes
+
+  printf '%s\n' "public" > "$TARGET_DIR/public.md"
+  git -C "$TARGET_DIR" add public.md
+
+  local mock_bin="$BATS_TEST_TMPDIR/failing-encryption-diff-bin"
+  local real_git
+  real_git=$(command -v git)
+  mkdir -p "$mock_bin"
+  cat > "$mock_bin/git" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = "diff" ]; then
+  printf '%s\n' "staged inspection failed" >&2
+  exit 73
+fi
+exec "$REAL_GIT" "$@"
+SH
+  chmod +x "$mock_bin/git"
+  export PATH="$mock_bin:$PATH"
+  export REAL_GIT="$real_git"
+
+  run_encryption_hook
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"staged inspection failed"* ]]
+  [[ "$output" == *"Could not inspect staged paths for encryption"* ]]
+}
+
+@test "encryption hook fails closed when staged-attribute inspection fails (#49)" {
+  notes setup --yes
+
+  mkdir -p "$TARGET_DIR/notes"
+  printf '%s\n' "secret" > "$TARGET_DIR/notes/secret.md"
+  git -C "$TARGET_DIR" add notes/secret.md
+
+  local mock_bin="$BATS_TEST_TMPDIR/failing-encryption-attr-bin"
+  local real_git
+  real_git=$(command -v git)
+  mkdir -p "$mock_bin"
+  cat > "$mock_bin/git" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = "check-attr" ]; then
+  printf '%s\n' "attribute inspection failed" >&2
+  exit 74
+fi
+exec "$REAL_GIT" "$@"
+SH
+  chmod +x "$mock_bin/git"
+  export PATH="$mock_bin:$PATH"
+  export REAL_GIT="$real_git"
+
+  run_encryption_hook
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"attribute inspection failed"* ]]
+  [[ "$output" == *"Could not inspect staged encryption attributes"* ]]
+}
+
+
 @test "encryption hook falls back per path after a batched plaintext result (#49)" {
   notes setup --yes
   local fpr

--- a/test/obfuscation-hooks.bats
+++ b/test/obfuscation-hooks.bats
@@ -67,7 +67,11 @@ setup() {
   [ -x "$NOTES_CALLER_PWD/.git/hooks/pre-commit" ]
   grep -q "Generic hook dispatcher" "$NOTES_CALLER_PWD/.git/hooks/pre-commit"
   [ -x "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d/encryption" ]
-  grep -q "git-crypt status" "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d/encryption"
+  grep -q "git-crypt" "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d/encryption"
+  grep -qF "NOTES_TOOL_ROOT=\"$REPO_DIR\"" \
+    "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d/encryption"
+  grep -qF 'source "$NOTES_TOOL_ROOT/lib/encryption.sh"' \
+    "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d/encryption"
   [ -x "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d/obfuscation" ]
   grep -q "manifest" "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d/obfuscation"
 }
@@ -144,6 +148,71 @@ EOF
   [ "$status" -ne 0 ]
   [[ "$output" == *"non-obfuscated filenames"* ]]
   [[ "$output" == *"sneaky.md"* ]]
+}
+
+
+@test "multi-file obfuscation guard uses one planner without per-file classifiers" {
+  notes setup --yes
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit --no-verify -q -m "setup"
+
+  printf '%s\n' "# Delta" > "$NOTES_CALLER_PWD/notes/delta.md"
+  printf '%s\n' "# Epsilon" > "$NOTES_CALLER_PWD/notes/epsilon.md"
+  git -C "$NOTES_CALLER_PWD" add notes/delta.md notes/epsilon.md
+
+  local mock_bin="$BATS_TEST_TMPDIR/obfuscation-classifier-bin"
+  local awk_calls="$BATS_TEST_TMPDIR/obfuscation-awk-calls"
+  local real_awk
+  real_awk=$(command -v awk)
+  mkdir -p "$mock_bin"
+
+  for command in basename grep; do
+    cat > "$mock_bin/$command" <<'SH'
+#!/usr/bin/env bash
+printf 'unexpected per-file classifier: %s\n' "${0##*/}" >&2
+exit 97
+SH
+    chmod +x "$mock_bin/$command"
+  done
+
+  cat > "$mock_bin/awk" <<'SH'
+#!/usr/bin/env bash
+printf 'call\n' >> "$AWK_CALLS"
+exec "$REAL_AWK" "$@"
+SH
+  chmod +x "$mock_bin/awk"
+
+  run env \
+    PATH="$mock_bin:$PATH" \
+    AWK_CALLS="$awk_calls" \
+    REAL_AWK="$real_awk" \
+    NOTES_OBFUSCATE_HOOK=guard \
+    bash -c 'cd "$1" && .git/hooks/pre-commit.d/obfuscation' \
+      _ "$NOTES_CALLER_PWD"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"delta.md"* ]]
+  [[ "$output" == *"epsilon.md"* ]]
+  [[ "$output" != *"unexpected per-file classifier"* ]]
+  [ "$(wc -l < "$awk_calls" | tr -d ' ')" -eq 1 ]
+}
+
+
+@test "auto hook fails closed when a staged readable file is missing from disk" {
+  notes setup --yes
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit --no-verify -q -m "setup"
+
+  printf '%s\n' "# Index Only" > "$NOTES_CALLER_PWD/notes/index-only.md"
+  git -C "$NOTES_CALLER_PWD" add notes/index-only.md
+  rm "$NOTES_CALLER_PWD/notes/index-only.md"
+
+  run bash -c 'cd "$1" && .git/hooks/pre-commit.d/obfuscation' \
+    _ "$NOTES_CALLER_PWD"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"left staged non-obfuscated filenames"* ]]
+  [[ "$output" == *"notes/index-only.md"* ]]
 }
 
 

--- a/test/obfuscation-hooks.bats
+++ b/test/obfuscation-hooks.bats
@@ -198,6 +198,38 @@ SH
 }
 
 
+@test "obfuscation hook fails closed when staged-path inspection fails" {
+  notes setup --yes
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit --no-verify -q -m "setup"
+
+  printf '%s\n' "# Delta" > "$NOTES_CALLER_PWD/notes/delta.md"
+  git -C "$NOTES_CALLER_PWD" add notes/delta.md
+
+  local mock_bin="$BATS_TEST_TMPDIR/failing-obfuscation-git-bin"
+  local real_git
+  real_git=$(command -v git)
+  mkdir -p "$mock_bin"
+  cat > "$mock_bin/git" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = "diff" ]; then
+  printf '%s\n' "staged inspection failed" >&2
+  exit 73
+fi
+exec "$REAL_GIT" "$@"
+SH
+  chmod +x "$mock_bin/git"
+
+  run env PATH="$mock_bin:$PATH" REAL_GIT="$real_git" \
+    bash -c 'cd "$1" && .git/hooks/pre-commit.d/obfuscation' \
+      _ "$NOTES_CALLER_PWD"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"staged inspection failed"* ]]
+  [[ "$output" == *"Could not classify staged note filenames"* ]]
+}
+
+
 @test "auto hook fails closed when a staged readable file is missing from disk" {
   notes setup --yes
   git -C "$NOTES_CALLER_PWD" add -A


### PR DESCRIPTION
## Summary

- make the obfuscation pre-commit hook delegate staged-path classification to Notes' production planner once
- render the encryption hook from the installing Notes source and move validation into a shared library
- inspect all valid staged encrypted paths with one `git-crypt status` call, falling back to exact per-path checks only when plaintext is reported
- preserve fail-closed backend handling, staged-attribute behavior, hook ordering, and installed-version ownership

This PR is stacked on #185 so the hook work could continue while that review completed. Its diff begins after exact updated #185 head `aade93244282686aa8f663485f557fa8a619253d`.

## Validation

- focused hook/obfuscate/rename/encryption/integration suites: 135 tests passed
- full suite: 420 BATS and 9 Python tests passed
- all eight configured Codebase lints passed
- doctor, generated README check, Bash syntax, diff check, and Fold preflight passed
- exact source commits are GPG-signed by Junior
