### PR TITLE
fix: propagate double-tracked inspection errors

### DIFF
--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -151,8 +151,11 @@ if [ -n "$conflicting_notes" ]; then
 fi
 
 double_tracked=""
-if ! double_tracked=$(detect_double_tracked_notes "$TARGET_DIR" "$notes_dir" 2>/dev/null); then
-  double_tracked=""
+double_tracked_status=0
+double_tracked=$(detect_double_tracked_notes "$TARGET_DIR" "$notes_dir") || double_tracked_status=$?
+if [ "$double_tracked_status" -ne 0 ]; then
+  echo "Error: failed to inspect double-tracked note paths." >&2
+  exit "$double_tracked_status"
 fi
 if [ -n "$double_tracked" ]; then
   blocked_tracked=()

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -69,8 +69,11 @@ fi
 # --- Double-tracked notes (readable + obfuscated both tracked) ---
 
 double_tracked=""
-if ! double_tracked=$(detect_double_tracked_notes "$TARGET_DIR" "$NOTES_DIR" 2>/dev/null); then
-  double_tracked=""
+double_tracked_status=0
+double_tracked=$(detect_double_tracked_notes "$TARGET_DIR" "$NOTES_DIR") || double_tracked_status=$?
+if [ "$double_tracked_status" -ne 0 ]; then
+  echo "Error: failed to inspect double-tracked note paths." >&2
+  exit "$double_tracked_status"
 fi
 double_tracked_count=0
 if [ -n "$double_tracked" ]; then

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 445](https://img.shields.io/badge/tests-445-brightgreen?style=flat)](test/)
+[![tests: 446](https://img.shields.io/badge/tests-446-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -15,6 +15,22 @@ SH
   chmod +x "$FAILING_FIND_BIN/find"
 }
 
+setup_failing_tracked_path_inspection_overlay() {
+  FAILING_GIT_BIN="$BATS_TEST_TMPDIR/failing-git-bin"
+  local real_git
+  real_git=$(command -v git)
+  mkdir -p "$FAILING_GIT_BIN"
+  cat > "$FAILING_GIT_BIN/git" <<'SH'
+#!/usr/bin/env bash
+case " $* " in
+  *" ls-files -z -- notes ") exit 73 ;;
+esac
+exec "$REAL_GIT" "$@"
+SH
+  chmod +x "$FAILING_GIT_BIN/git"
+  export REAL_GIT="$real_git"
+}
+
 # ── detect_changes ────────────────────────────────────────────
 
 @test "detect_changes: no changes when files match HEAD" {
@@ -279,6 +295,21 @@ SH
   PATH="$FAILING_FIND_BIN:$PATH" run notes status --json
   [ "$status" -ne 0 ]
   [[ "$output" == *"failed to inspect note changes"* ]]
+}
+
+@test "safety consumers propagate double-tracked path inspection failure" {
+  setup_failing_tracked_path_inspection_overlay
+  printf '# Alpha modified\n' > "$NOTES_CALLER_PWD/notes/alpha.md"
+
+  PATH="$FAILING_GIT_BIN:$PATH" run notes stage alpha.md
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed to inspect double-tracked note paths"* ]]
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
+  [ -z "$output" ]
+
+  PATH="$FAILING_GIT_BIN:$PATH" run notes status --json
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed to inspect double-tracked note paths"* ]]
 }
 
 @test "notes changes fails instead of widening an unparsed file scope" {


### PR DESCRIPTION
## Summary

- make `notes stage` fail when double-tracked path inspection fails
- make `notes status` propagate the same safety-check failure instead of reporting zero conflicts
- add CLI-level regressions proving stage leaves the index untouched and status exits non-zero

## Context

Focused fix-it for KnickKnackLabs/notes#189, based directly on reviewed head `173a2ee7fe17ad090ed9f83a963d19c7c7dea82b`.

## Validation

- `mise run test changes` (20 passed)
- `mise run test` (438 BATS passed, 9 Python passed; 6 existing skips)
- `codebase lint "$PWD"` (8 rules passed)
- `mise run doctor` (passed; existing optional local-hook warning only)
- `readme build --check`
- `bash -n .mise/tasks/stage .mise/tasks/status test/changes.bats`
- `git diff --check`

Local `git pre-commit` and `git pre-push` commands are unavailable in this checkout, so direct repository checks were used.
