### PR TITLE
fix: preserve readable staging safety chain

### DIFF
--- a/.mise/tasks/obfuscate
+++ b/.mise/tasks/obfuscate
@@ -117,7 +117,7 @@ while IFS=$'\t' read -r relpath id; do
   new_count=$((new_count + 1))
 done < "$renamed"
 
-git -C "$TARGET_DIR" add -- "${obfuscated_paths[@]}"
+git -C "$TARGET_DIR" add --sparse -- "${obfuscated_paths[@]}"
 git -C "$TARGET_DIR" rm --cached --quiet --ignore-unmatch -- \
   "${readable_paths[@]}"
 

--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -10,6 +10,7 @@ source "$MISE_CONFIG_ROOT/lib/common.sh"
 source "$MISE_CONFIG_ROOT/lib/obfuscate.sh"
 source "$MISE_CONFIG_ROOT/lib/suppress.sh"
 source "$MISE_CONFIG_ROOT/lib/changes.sh"
+source "$MISE_CONFIG_ROOT/lib/hooks.sh"
 require_git
 
 notes_dir="${usage_dir:-notes}"
@@ -213,6 +214,12 @@ if [ "${usage_dry_run:-}" = "true" ]; then
     echo "  $relpath"
   done
   exit 0
+fi
+
+if ! required_pre_commit_hooks_ready "$notes_dir"; then
+  echo "Error: required Notes pre-commit hooks are missing or stale; refusing to stage readable notes." >&2
+  echo "Run 'notes install-hooks --yes', then retry." >&2
+  exit 1
 fi
 
 # Stage each file using git add -f to bypass .git/info/exclude

--- a/.mise/tasks/unlock
+++ b/.mise/tasks/unlock
@@ -5,6 +5,7 @@
 set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
+source "$MISE_CONFIG_ROOT/lib/hooks.sh"
 require_git
 require_initialized
 require_rudi
@@ -34,4 +35,9 @@ if [ -f "$TARGET_DIR/notes/.manifest" ]; then
   else
     cd "$MISE_CONFIG_ROOT" && NOTES_CALLER_PWD="$TARGET_DIR" mise run -q deobfuscate
   fi
+fi
+
+if ! required_pre_commit_hooks_ready notes; then
+  echo "Warning: required Notes pre-commit hooks are missing or stale." >&2
+  echo "Run 'notes install-hooks --yes' before staging readable notes." >&2
 fi

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 450](https://img.shields.io/badge/tests-450-brightgreen?style=flat)](test/)
+[![tests: 457](https://img.shields.io/badge/tests-457-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 457](https://img.shields.io/badge/tests-457-brightgreen?style=flat)](test/)
+[![tests: 459](https://img.shields.io/badge/tests-459-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -10,13 +10,15 @@ _hook_template_value() {
 }
 
 _render_notes_hook_template() {
-  local template="${1:?usage: _render_notes_hook_template <template> <notes-dir>}"
-  local notes_dir="${2:?usage: _render_notes_hook_template <template> <notes-dir>}"
-  local mise_bin
-  mise_bin=$(command -v mise) || {
-    echo "Error: mise not found; cannot install notes hooks" >&2
-    return 1
-  }
+  local template="${1:?usage: _render_notes_hook_template <template> <notes-dir> [mise-bin]}"
+  local notes_dir="${2:?usage: _render_notes_hook_template <template> <notes-dir> [mise-bin]}"
+  local mise_bin="${3:-}"
+  if [ -z "$mise_bin" ]; then
+    mise_bin=$(command -v mise) || {
+      echo "Error: mise not found; cannot install notes hooks" >&2
+      return 1
+    }
+  fi
 
   sed \
     -e "s|__NOTES_DIR__|$(_hook_template_value "$notes_dir")|g" \
@@ -72,6 +74,57 @@ install_double_tracking_hook() {
   local target="$TARGET_DIR/.git/hooks/pre-commit.d/verify-double-tracking"
   _render_notes_hook_template "$HOOKS_DIR/verify-double-tracking.template" "$notes_dir" > "$target"
   chmod +x "$target"
+}
+
+_installed_hook_matches() {
+  local template="${1:?usage: _installed_hook_matches <template> <notes-dir> <installed-hook> [mise-bin]}"
+  local notes_dir="${2:?usage: _installed_hook_matches <template> <notes-dir> <installed-hook> [mise-bin]}"
+  local installed="${3:?usage: _installed_hook_matches <template> <notes-dir> <installed-hook> [mise-bin]}"
+  local mise_bin="${4:-}"
+  local expected
+
+  [ -x "$installed" ] || return 1
+  expected=$(mktemp) || return 1
+  if ! _render_notes_hook_template \
+    "$template" "$notes_dir" "$mise_bin" > "$expected"; then
+    rm -f "$expected"
+    return 1
+  fi
+  if cmp -s "$expected" "$installed"; then
+    rm -f "$expected"
+    return 0
+  fi
+  rm -f "$expected"
+  return 1
+}
+
+required_pre_commit_hooks_ready() {
+  local notes_dir="${1:-notes}"
+  local hooks_dir="$TARGET_DIR/.git/hooks"
+  local dispatcher="$hooks_dir/pre-commit"
+  local fragments="$hooks_dir/pre-commit.d"
+  local obfuscation_hook="$fragments/obfuscation"
+  local installed_mise_bin
+
+  [ -x "$dispatcher" ] || return 1
+  if ! cmp -s "$HOOKS_DIR/dispatcher" "$dispatcher" \
+    && ! grep -qF 'pre-commit.d' "$dispatcher" 2>/dev/null; then
+    return 1
+  fi
+  [ -x "$obfuscation_hook" ] || return 1
+  installed_mise_bin=$(sed -n 's/^MISE_BIN="\(.*\)"$/\1/p' \
+    "$obfuscation_hook")
+  [ -n "$installed_mise_bin" ] || return 1
+  [ -x "$installed_mise_bin" ] || return 1
+  _installed_hook_matches \
+    "$HOOKS_DIR/encryption.template" "." "$fragments/encryption" \
+    "$installed_mise_bin" || return 1
+  _installed_hook_matches \
+    "$HOOKS_DIR/obfuscation.template" "$notes_dir" "$obfuscation_hook" \
+    "$installed_mise_bin" || return 1
+  _installed_hook_matches \
+    "$HOOKS_DIR/verify-double-tracking.template" "$notes_dir" \
+    "$fragments/verify-double-tracking" "$installed_mise_bin" || return 1
 }
 
 # Install the manifest merge driver.

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -27,17 +27,27 @@ _render_notes_hook_template() {
     "$template"
 }
 
-# Ensure a hook dispatcher is installed for the given hook type.
+_active_git_hooks_dir() {
+  local repo_root hooks_dir
+  repo_root=$(git -C "$TARGET_DIR" rev-parse --show-toplevel) || return 1
+  hooks_dir=$(git -C "$TARGET_DIR" rev-parse --git-path hooks) || return 1
+  case "$hooks_dir" in
+    /*) printf '%s\n' "$hooks_dir" ;;
+    *) printf '%s/%s\n' "$repo_root" "$hooks_dir" ;;
+  esac
+}
+
+# Ensure the exact Notes dispatcher is installed in Git's active hooks path.
 # Usage: ensure_hook_dispatcher <pre-commit|post-commit|post-merge|post-checkout>
 ensure_hook_dispatcher() {
   local hook_type="${1:?usage: ensure_hook_dispatcher <pre-commit|post-commit|post-merge|post-checkout>}"
-  local hooks_dir="$TARGET_DIR/.git/hooks"
+  local hooks_dir
+  hooks_dir=$(_active_git_hooks_dir) || return 1
   local dispatcher="$hooks_dir/$hook_type"
 
   mkdir -p "$hooks_dir/${hook_type}.d"
 
-  # Only install if the dispatcher isn't already in place
-  if ! grep -q "${hook_type}.d" "$dispatcher" 2>/dev/null; then
+  if ! cmp -s "$HOOKS_DIR/dispatcher" "$dispatcher"; then
     cp "$HOOKS_DIR/dispatcher" "$dispatcher"
     chmod +x "$dispatcher"
   fi
@@ -48,7 +58,9 @@ ensure_hook_dispatcher() {
 # installed it rather than whichever `notes` command appears first on PATH.
 install_encryption_hook() {
   ensure_hook_dispatcher pre-commit
-  local target="$TARGET_DIR/.git/hooks/pre-commit.d/encryption"
+  local hooks_dir
+  hooks_dir=$(_active_git_hooks_dir) || return 1
+  local target="$hooks_dir/pre-commit.d/encryption"
   _render_notes_hook_template "$HOOKS_DIR/encryption.template" "." > "$target"
   chmod +x "$target"
 }
@@ -58,7 +70,9 @@ install_encryption_hook() {
 install_obfuscation_hook() {
   local notes_dir="${1:-notes}"
   ensure_hook_dispatcher pre-commit
-  local target="$TARGET_DIR/.git/hooks/pre-commit.d/obfuscation"
+  local hooks_dir
+  hooks_dir=$(_active_git_hooks_dir) || return 1
+  local target="$hooks_dir/pre-commit.d/obfuscation"
   _render_notes_hook_template "$HOOKS_DIR/obfuscation.template" "$notes_dir" > "$target"
   chmod +x "$target"
 }
@@ -69,9 +83,11 @@ install_obfuscation_hook() {
 install_double_tracking_hook() {
   local notes_dir="${1:-notes}"
   ensure_hook_dispatcher pre-commit
+  local hooks_dir
+  hooks_dir=$(_active_git_hooks_dir) || return 1
   # Name sorts after `obfuscation` so the auto-obfuscation hook can fix a
   # naively-staged readable before this guard runs.
-  local target="$TARGET_DIR/.git/hooks/pre-commit.d/verify-double-tracking"
+  local target="$hooks_dir/pre-commit.d/verify-double-tracking"
   _render_notes_hook_template "$HOOKS_DIR/verify-double-tracking.template" "$notes_dir" > "$target"
   chmod +x "$target"
 }
@@ -100,17 +116,15 @@ _installed_hook_matches() {
 
 required_pre_commit_hooks_ready() {
   local notes_dir="${1:-notes}"
-  local hooks_dir="$TARGET_DIR/.git/hooks"
+  local hooks_dir
+  hooks_dir=$(_active_git_hooks_dir) || return 1
   local dispatcher="$hooks_dir/pre-commit"
   local fragments="$hooks_dir/pre-commit.d"
   local obfuscation_hook="$fragments/obfuscation"
   local installed_mise_bin
 
   [ -x "$dispatcher" ] || return 1
-  if ! cmp -s "$HOOKS_DIR/dispatcher" "$dispatcher" \
-    && ! grep -qF 'pre-commit.d' "$dispatcher" 2>/dev/null; then
-    return 1
-  fi
+  cmp -s "$HOOKS_DIR/dispatcher" "$dispatcher" || return 1
   [ -x "$obfuscation_hook" ] || return 1
   installed_mise_bin=$(sed -n 's/^MISE_BIN="\(.*\)"$/\1/p' \
     "$obfuscation_hook")
@@ -151,25 +165,27 @@ install_manifest_merge_driver() {
 # After a branch checkout changes the manifest, post-checkout reconciles stale names.
 install_deobfuscation_hook() {
   local notes_dir="${1:-notes}"
+  local hooks_dir
+  hooks_dir=$(_active_git_hooks_dir) || return 1
   local commit_template="$HOOKS_DIR/post-commit-deobfuscate.template"
   local merge_template="$HOOKS_DIR/post-merge-deobfuscate.template"
   local checkout_template="$HOOKS_DIR/post-checkout-deobfuscate.template"
 
   # Install for post-commit (deobfuscate after committing)
   ensure_hook_dispatcher post-commit
-  local target="$TARGET_DIR/.git/hooks/post-commit.d/deobfuscation"
+  local target="$hooks_dir/post-commit.d/deobfuscation"
   _render_notes_hook_template "$commit_template" "$notes_dir" > "$target"
   chmod +x "$target"
 
   # Install for post-merge (deobfuscate after pulling)
   ensure_hook_dispatcher post-merge
-  local merge_target="$TARGET_DIR/.git/hooks/post-merge.d/deobfuscation"
+  local merge_target="$hooks_dir/post-merge.d/deobfuscation"
   _render_notes_hook_template "$merge_template" "$notes_dir" > "$merge_target"
   chmod +x "$merge_target"
 
   # Install for post-checkout (deobfuscate after branch checkout)
   ensure_hook_dispatcher post-checkout
-  local checkout_target="$TARGET_DIR/.git/hooks/post-checkout.d/deobfuscation"
+  local checkout_target="$hooks_dir/post-checkout.d/deobfuscation"
   _render_notes_hook_template "$checkout_template" "$notes_dir" > "$checkout_target"
   chmod +x "$checkout_target"
 }

--- a/lib/suppress.sh
+++ b/lib/suppress.sh
@@ -197,13 +197,15 @@ _rewrite_exclude_block() {
   mv -f "$tmp" "$exclude_file"
 }
 
-# Apply an index flag to newline-delimited managed paths in one update-index process.
-# Resolve candidates through NUL-delimited Git output so quoted non-ASCII paths
-# stay exact, while missing stale-state paths are omitted from the batch.
+# Apply index flags to newline-delimited managed paths, one update-index process
+# per flag. Resolve candidates through NUL-delimited Git output so quoted
+# non-ASCII paths stay exact, while missing stale-state paths are omitted.
 _update_index_paths() {
-  local repo_root="${1:?usage: _update_index_paths <repo_root> <flag>}"
-  local flag="${2:?usage: _update_index_paths <repo_root> <flag>}"
-  local path
+  local repo_root="${1:?usage: _update_index_paths <repo_root> <flag...>}"
+  shift
+  [ "$#" -gt 0 ] || return 1
+  local flags=("$@")
+  local flag path
   local paths=()
 
   while IFS= read -r path; do
@@ -211,8 +213,12 @@ _update_index_paths() {
   done
   [ ${#paths[@]} -gt 0 ] || return 0
 
-  GIT_LITERAL_PATHSPECS=1 git -C "$repo_root" ls-files -z -- "${paths[@]}" |
-    git -C "$repo_root" update-index "$flag" -z --stdin 2>/dev/null
+  for flag in "${flags[@]}"; do
+    if ! GIT_LITERAL_PATHSPECS=1 git -C "$repo_root" ls-files -z -- "${paths[@]}" |
+      git -C "$repo_root" update-index "$flag" -z --stdin 2>/dev/null; then
+      return 1
+    fi
+  done
 }
 
 # Set assume-unchanged on obfuscated paths + add exclude entries for readable names.
@@ -264,15 +270,18 @@ clear_status_suppression() {
   local repo_root="$RESOLVED_REPO_ROOT"
   local notes_dir="$RESOLVED_NOTES_DIR"
 
-  # Clear assume-unchanged flags in one index update.
+  # Clear both status-suppression flags so managed opaque paths can be staged
+  # even when a sparse checkout or interrupted operation marked them skipped.
   if [ ${#scoped_ids[@]} -gt 0 ] && [ -n "${scoped_ids[0]}" ]; then
     if ! printf '%s\n' "${scoped_ids[@]/#/$notes_dir/}" |
-      _update_index_paths "$repo_root" --no-assume-unchanged; then
+      _update_index_paths "$repo_root" \
+        --no-assume-unchanged --no-skip-worktree; then
       return 1
     fi
   else
     if ! awk -F '\t' -v prefix="$notes_dir/" '$1 != "" { print prefix $1 }' "$manifest" |
-      _update_index_paths "$repo_root" --no-assume-unchanged; then
+      _update_index_paths "$repo_root" \
+        --no-assume-unchanged --no-skip-worktree; then
       return 1
     fi
   fi

--- a/test/changes_test_helper.bash
+++ b/test/changes_test_helper.bash
@@ -1,4 +1,4 @@
-setup() {
+setup_changes_fixture() {
   export NOTES_CALLER_PWD="$BATS_TEST_TMPDIR"
   source "$REPO_DIR/lib/common.sh"
   source "$REPO_DIR/lib/obfuscate.sh"
@@ -22,6 +22,10 @@ setup() {
   git -C "$NOTES_CALLER_PWD" commit -q -m "initial"
   rename_to_readable "$NOTES_CALLER_PWD/notes" > /dev/null
   set_status_suppression "$NOTES_CALLER_PWD/notes"
+}
+
+setup() {
+  setup_changes_fixture
 }
 
 add_clean_numbered_notes() {

--- a/test/commit.bats
+++ b/test/commit.bats
@@ -217,9 +217,10 @@ HOOK
 # ── full lifecycle ────────────────────────────────────────────
 
 @test "full cycle: edit → stage → commit → clean status" {
-  # Install hooks so post-commit deobfuscates
   source "$REPO_DIR/lib/hooks.sh"
+  install_encryption_hook
   install_obfuscation_hook
+  install_double_tracking_hook
   install_deobfuscation_hook
 
   # Verify clean status before edit

--- a/test/encrypt.bats
+++ b/test/encrypt.bats
@@ -276,3 +276,25 @@ generate_test_key() {
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "Already unlocked."
 }
+
+@test "unlock warns when required pre-commit hooks are missing" {
+  notes setup --yes
+  rm -rf "$TARGET_DIR/.git/hooks/pre-commit" \
+    "$TARGET_DIR/.git/hooks/pre-commit.d"
+
+  run notes unlock
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"pre-commit hooks are missing or stale"* ]]
+  [[ "$output" == *"notes install-hooks --yes"* ]]
+}
+
+@test "unlock warns when a required pre-commit hook is stale" {
+  notes setup --yes
+  printf '\n# stale\n' >> "$TARGET_DIR/.git/hooks/pre-commit.d/obfuscation"
+
+  run notes unlock
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"pre-commit hooks are missing or stale"* ]]
+}

--- a/test/obfuscate.bats
+++ b/test/obfuscate.bats
@@ -306,7 +306,7 @@ SH
   awk_calls=$(grep -c '^awk$' "$call_log" || true)
   grep_calls=$(grep -c '^grep$' "$call_log" || true)
   basename_calls=$(grep -c '^basename$' "$call_log" || true)
-  add_calls=$(grep -c $'^git\t.* add -- notes/' "$call_log" || true)
+  add_calls=$(grep -c $'^git\t.* add --sparse -- notes/' "$call_log" || true)
   rm_calls=$(grep -c $'^git\t.* rm --cached --quiet --ignore-unmatch -- notes/' "$call_log" || true)
   [ "$status" -eq 0 ]
   [[ "$output" == *"Obfuscated 535 file(s)"* ]]
@@ -342,7 +342,7 @@ SH
 
   [ "$status" -eq 0 ]
   [ "$(grep -c $'^git\t.* cat-file --filters :notes/.manifest$' "$call_log" || true)" -eq 1 ]
-  [ "$(grep -c $'^git\t.* add -- notes/' "$call_log" || true)" -eq 1 ]
+  [ "$(grep -c $'^git\t.* add --sparse -- notes/' "$call_log" || true)" -eq 1 ]
   [ "$(grep -c $'^git\t.* rm --cached --quiet --ignore-unmatch -- notes/' "$call_log" || true)" -eq 1 ]
 }
 

--- a/test/obfuscation-hooks.bats
+++ b/test/obfuscation-hooks.bats
@@ -316,6 +316,36 @@ SH
 }
 
 
+@test "auto hook stages a managed opaque path marked skip-worktree" {
+  notes obfuscate
+  local alpha_id
+  alpha_id=$(awk -F '\t' '$2 == "alpha.md" { print $1 }' \
+    "$NOTES_CALLER_PWD/notes/.manifest")
+  git -C "$NOTES_CALLER_PWD" add -A
+  git -C "$NOTES_CALLER_PWD" commit -q --no-verify -m "obfuscated"
+
+  notes deobfuscate
+  notes install-hooks --yes
+  git -C "$NOTES_CALLER_PWD" update-index \
+    --no-assume-unchanged "notes/$alpha_id"
+  git -C "$NOTES_CALLER_PWD" update-index \
+    --skip-worktree "notes/$alpha_id"
+
+  echo "skip-worktree edit" >> "$NOTES_CALLER_PWD/notes/alpha.md"
+  git -C "$NOTES_CALLER_PWD" add -f notes/alpha.md
+
+  run git -C "$NOTES_CALLER_PWD" commit -m "edit skipped alpha"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Auto-obfuscating 1 file(s)"* ]]
+  run git -C "$NOTES_CALLER_PWD" show "HEAD:notes/$alpha_id"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skip-worktree edit"* ]]
+  run git -C "$NOTES_CALLER_PWD" show --name-only --format= HEAD
+  [[ "$output" == *"notes/$alpha_id"* ]]
+  [[ "$output" != *"notes/alpha.md"* ]]
+}
+
 @test "installed hooks run notes from installer, not PATH" {
   notes obfuscate
   git -C "$NOTES_CALLER_PWD" add -A

--- a/test/stage.bats
+++ b/test/stage.bats
@@ -104,6 +104,50 @@ setup() {
   [ -z "$output" ]
 }
 
+@test "notes stage refuses a dispatcher that does not run required fragments" {
+  cat > "$NOTES_CALLER_PWD/.git/hooks/pre-commit" <<'HOOK'
+#!/usr/bin/env bash
+# Looks compatible by mentioning pre-commit.d, but executes nothing.
+exit 0
+HOOK
+  chmod +x "$NOTES_CALLER_PWD/.git/hooks/pre-commit"
+  echo "# Alpha modified" > "$NOTES_CALLER_PWD/notes/alpha.md"
+
+  run notes stage alpha.md
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"pre-commit hooks are missing or stale"* ]]
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
+  [ -z "$output" ]
+
+  notes install-hooks --yes
+  run notes stage alpha.md
+  [ "$status" -eq 0 ]
+  git -C "$NOTES_CALLER_PWD" commit -q -m "repaired dispatcher"
+  run git -C "$NOTES_CALLER_PWD" show --name-only --format= HEAD
+  [[ "$output" != *"notes/alpha.md"* ]]
+}
+
+@test "notes stage checks and repairs the active core.hooksPath" {
+  git -C "$NOTES_CALLER_PWD" config core.hooksPath .active-hooks
+  echo "# Alpha modified" > "$NOTES_CALLER_PWD/notes/alpha.md"
+
+  run notes stage alpha.md
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"pre-commit hooks are missing or stale"* ]]
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
+  [ -z "$output" ]
+
+  notes install-hooks --yes
+  [ -x "$NOTES_CALLER_PWD/.active-hooks/pre-commit" ]
+  run notes stage alpha.md
+  [ "$status" -eq 0 ]
+  git -C "$NOTES_CALLER_PWD" commit -q -m "active hooks path"
+  run git -C "$NOTES_CALLER_PWD" show --name-only --format= HEAD
+  [[ "$output" != *"notes/alpha.md"* ]]
+}
+
 @test "notes stage dry-run remains available without required hooks" {
   rm -rf "$NOTES_CALLER_PWD/.git/hooks/pre-commit" \
     "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d"

--- a/test/stage.bats
+++ b/test/stage.bats
@@ -5,6 +5,14 @@
 load test_helper
 load changes_test_helper
 
+setup() {
+  setup_changes_fixture
+  export TARGET_DIR="$NOTES_CALLER_PWD"
+  install_encryption_hook
+  install_obfuscation_hook
+  install_double_tracking_hook
+}
+
 # ── stage via git add -f ─────────────────────────────────────
 
 @test "git add -f works despite exclude" {
@@ -67,6 +75,46 @@ load changes_test_helper
 
   run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
   [[ "$output" == *"notes/gamma.md"* ]]
+}
+
+@test "notes stage refuses missing required hooks before index mutation" {
+  rm -rf "$NOTES_CALLER_PWD/.git/hooks/pre-commit" \
+    "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d"
+  echo "# Alpha modified" > "$NOTES_CALLER_PWD/notes/alpha.md"
+
+  run notes stage alpha.md
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"pre-commit hooks are missing or stale"* ]]
+  [[ "$output" == *"notes install-hooks --yes"* ]]
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
+  [ -z "$output" ]
+}
+
+@test "notes stage refuses stale required hooks before index mutation" {
+  printf '\n# stale\n' >> \
+    "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d/encryption"
+  echo "# Alpha modified" > "$NOTES_CALLER_PWD/notes/alpha.md"
+
+  run notes stage alpha.md
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"pre-commit hooks are missing or stale"* ]]
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
+  [ -z "$output" ]
+}
+
+@test "notes stage dry-run remains available without required hooks" {
+  rm -rf "$NOTES_CALLER_PWD/.git/hooks/pre-commit" \
+    "$NOTES_CALLER_PWD/.git/hooks/pre-commit.d"
+  echo "# Alpha modified" > "$NOTES_CALLER_PWD/notes/alpha.md"
+
+  run notes stage alpha.md --dry-run
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Would stage:"* ]]
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
+  [ -z "$output" ]
 }
 
 @test "notes stage: explicit unknown path fails instead of silently selecting nothing" {

--- a/test/status-suppression.bats
+++ b/test/status-suppression.bats
@@ -97,6 +97,23 @@ load changes_test_helper
   grep -q "notes/beta.md" "$exclude"
 }
 
+@test "clear_status_suppression clears skip-worktree on managed opaque paths" {
+  local alpha_id
+  alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
+  git -C "$NOTES_CALLER_PWD" update-index \
+    --no-assume-unchanged "notes/$alpha_id"
+  git -C "$NOTES_CALLER_PWD" update-index \
+    --skip-worktree "notes/$alpha_id"
+
+  run git -C "$NOTES_CALLER_PWD" ls-files -v "notes/$alpha_id"
+  [[ "$output" == S* ]]
+
+  clear_status_suppression "$NOTES_CALLER_PWD/notes" "$alpha_id"
+
+  run git -C "$NOTES_CALLER_PWD" ls-files -v "notes/$alpha_id"
+  [[ "$output" != S* ]]
+}
+
 @test "status suppression helpers tolerate empty scope under nounset" {
   run bash -c '
     set -euo pipefail


### PR DESCRIPTION
## Summary

- require the complete current Notes pre-commit hook chain before `notes stage` mutates the index
- warn after `notes unlock` when required hook protection is missing or stale
- clear managed opaque paths' `skip-worktree` state and stage them with sparse-aware Git semantics
- preserve dry-run/no-change behavior, scoped staging, encryption filters, and normal commit cycles

Closes #151.
Closes #152.

## Validation

- 449 BATS tests and 9 Python tests
- all eight configured Codebase lints
- focused stage, encryption, hook, suppression, obfuscation, and commit suites
- disposable current-source reproductions: missing hooks refuse before index mutation; a skipped opaque ID commits through auto-obfuscation
- doctor and README generation/check
- Bash syntax and `git diff --check`
- Fold pre-commit and pre-push
