### PR TITLE
fix: refuse incomplete sparse onboarding

### DIFF
--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -65,14 +65,17 @@ if ! write_tracked_readable_notes \
   exit 1
 fi
 tracked_readable_count=$(tracked_readable_note_count "$tracked_readable_snapshot")
-rm -f "$tracked_readable_snapshot"
 
 repo_was_initialized=false
 is_initialized && repo_was_initialized=true
 unlock_requested=${usage_unlock:-false}
-require_tracked_plaintext_setup_ready \
-  "$TARGET_DIR" "$tracked_readable_count" \
-  "$repo_was_initialized" "$unlock_requested"
+if ! require_tracked_plaintext_setup_ready \
+    "$TARGET_DIR" "$tracked_readable_snapshot" "$tracked_readable_count" \
+    "$repo_was_initialized" "$unlock_requested"; then
+  rm -f "$tracked_readable_snapshot"
+  exit 1
+fi
+rm -f "$tracked_readable_snapshot"
 
 setup_confirmation_message="notes setup will initialize/update git-crypt, .gitattributes, $NOTES_DIR/.manifest, and git hooks for $NOTES_DIR/ in this repo."
 if [ "$tracked_readable_count" -gt 0 ]; then

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 474](https://img.shields.io/badge/tests-474-brightgreen?style=flat)](test/)
+[![tests: 475](https://img.shields.io/badge/tests-475-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/lib/setup.sh
+++ b/lib/setup.sh
@@ -59,13 +59,24 @@ tracked_readable_note_count() {
   printf '%s\n' "$count"
 }
 
-# A tracked-plaintext migration must begin clean, and an existing locked repo
-# must unlock before setup changes .gitattributes.
+# A tracked-plaintext migration must begin with every candidate available as a
+# regular worktree file. Sparse or otherwise absent candidates cannot be staged
+# and would leave plaintext blobs behind the new encryption attributes.
+# Existing locked repositories must also unlock before setup changes attributes.
 require_tracked_plaintext_setup_ready() {
-  local repo="$1" tracked_count="$2" initialized="$3" unlock_requested="$4"
-  local status_snapshot
+  local repo="$1" tracked_snapshot="$2" tracked_count="$3"
+  local initialized="$4" unlock_requested="$5"
+  local tracked_path status_snapshot
 
   [ "$tracked_count" -gt 0 ] || return 0
+
+  while IFS= read -r -d '' tracked_path; do
+    if [ ! -f "$repo/$tracked_path" ] || [ -L "$repo/$tracked_path" ]; then
+      echo "Error: tracked plaintext note is not available as a regular worktree file: $tracked_path" >&2
+      echo "Materialize all tracked plaintext notes (for example, expand or disable sparse checkout), then rerun notes setup." >&2
+      return 1
+    fi
+  done < "$tracked_snapshot"
 
   status_snapshot=$(mktemp) || return 1
   if ! git -C "$repo" status --porcelain > "$status_snapshot"; then

--- a/test/encrypt.bats
+++ b/test/encrypt.bats
@@ -159,6 +159,24 @@ SH
   [ ! -f "$TARGET_DIR/notes/.manifest" ]
 }
 
+@test "setup refuses sparse tracked plaintext onboarding before mutation" {
+  commit_tracked_plaintext_notes
+  git -C "$TARGET_DIR" sparse-checkout init --no-cone
+  git -C "$TARGET_DIR" sparse-checkout set --no-cone \
+    '/*' '!/*/' '/notes/alpha.md'
+  [ -f "$TARGET_DIR/notes/alpha.md" ]
+  [ ! -e "$TARGET_DIR/notes/beta.md" ]
+
+  run notes setup --yes
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not available as a regular worktree file"* ]]
+  [[ "$output" == *"expand or disable sparse checkout"* ]]
+  [ ! -d "$TARGET_DIR/.git/git-crypt" ]
+  [ ! -f "$TARGET_DIR/.gitattributes" ]
+  [ ! -f "$TARGET_DIR/notes/.manifest" ]
+}
+
 @test "setup --unlock unlocks existing repo before setup mutation" {
   commit_tracked_plaintext_notes
   mkdir -p "$TARGET_DIR/.git/git-crypt"


### PR DESCRIPTION
## Summary

- refuse tracked-plaintext onboarding when a candidate is absent from the worktree
- keep sparse-checkout failures before git-crypt, attributes, manifest, or hook mutation
- retain the candidate snapshot through setup readiness validation

## Why

PR #197 counts tracked plaintext from the full index, but `notes stage --all` can only process materialized readable files. In a sparse checkout, setup could report two candidates, stage one, and commit the other as a plaintext readable path behind the new `notes/**` encryption attribute. The ordinary commit hooks allowed that mixed tree; `notes verify-blobs --strict` then failed on the omitted path.

This focused fix makes incomplete materialization a clear pre-mutation refusal.

## Validation

- sparse regression: pass
- complete repository suite: 467 BATS cases (461 passed, 6 existing environment skips) and 9/9 Python passed
- all 8 configured Codebase lints
- `mise run doctor` (README and lints pass; optional clone-local pre-commit hook absent)
- `readme build --check`
- Bash syntax and `git diff --check`

Fix-it for KnickKnackLabs/notes#197. Targets `junior/onboard-existing-plaintext`; does not merge or release.
