### PR TITLE
fix: target explicit note operations

### DIFF
--- a/.mise/tasks/changes
+++ b/.mise/tasks/changes
@@ -39,9 +39,13 @@ if [ -n "${usage_files:-}" ]; then
 fi
 
 if [ "${usage_summary:-}" = "true" ]; then
-  # Summary mode: just list changes. An unavailable manifest is a clean result.
+  # Summary mode: explicit paths avoid corpus-wide content hashing.
   detect_status=0
-  changes=$(detect_changes "$abs_notes_dir") || detect_status=$?
+  if [ ${#ARGS[@]} -gt 0 ]; then
+    changes=$(detect_selected_changes "$abs_notes_dir" "${ARGS[@]}") || detect_status=$?
+  else
+    changes=$(detect_changes "$abs_notes_dir") || detect_status=$?
+  fi
   if [ "$detect_status" -ne 0 ]; then
     echo "Error: failed to inspect note changes." >&2
     exit "$detect_status"
@@ -90,9 +94,13 @@ if [ "${usage_summary:-}" = "true" ]; then
     echo "$total change(s): $modified modified, $new new, $deleted deleted, $stale stale-readable"
   fi
 else
-  # Diff mode: show full diffs. An unavailable manifest is a clean result.
+  # Diff mode: explicit paths avoid corpus-wide content hashing.
   detect_status=0
-  changes=$(detect_changes "$abs_notes_dir") || detect_status=$?
+  if [ ${#ARGS[@]} -gt 0 ]; then
+    changes=$(detect_selected_changes "$abs_notes_dir" "${ARGS[@]}") || detect_status=$?
+  else
+    changes=$(detect_changes "$abs_notes_dir") || detect_status=$?
+  fi
   if [ "$detect_status" -ne 0 ]; then
     echo "Error: failed to inspect note changes." >&2
     exit "$detect_status"

--- a/.mise/tasks/changes
+++ b/.mise/tasks/changes
@@ -38,6 +38,10 @@ if [ -n "${usage_files:-}" ]; then
   rm -f "$args_snapshot"
 fi
 
+if [ ${#ARGS[@]} -gt 0 ]; then
+  validate_explicit_readable_note_paths "$abs_notes_dir" "$manifest" "${ARGS[@]}" || exit 1
+fi
+
 if [ "${usage_summary:-}" = "true" ]; then
   # Summary mode: explicit paths avoid corpus-wide content hashing.
   detect_status=0

--- a/.mise/tasks/commit
+++ b/.mise/tasks/commit
@@ -196,7 +196,14 @@ verify_commit_touched_only_notes() {
 
 verify_selected_changes_clean() {
   local remaining bad_selected=() status relpath
-  if remaining=$(detect_changes "$abs_notes_dir"); then
+  if [ "$scope_all" = "true" ]; then
+    if remaining=$(detect_changes "$abs_notes_dir"); then
+      :
+    else
+      echo "Error: failed to verify remaining note changes." >&2
+      return 1
+    fi
+  elif remaining=$(detect_selected_changes "$abs_notes_dir" "${ARGS[@]}"); then
     :
   else
     echo "Error: failed to verify remaining note changes." >&2

--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -71,26 +71,7 @@ scope_matches() {
 }
 
 if [ "$scope_all" != "true" ]; then
-  unknown=()
-  for f in ${ARGS[@]+"${ARGS[@]}"}; do
-    case "$f" in
-      /*|..|../*|*/../*|.|./*|*/./*|*/)
-        unknown+=("$f")
-        continue
-        ;;
-    esac
-    if [ -f "$abs_notes_dir/$f" ] || [ -n "$(manifest_id_for_name "$manifest" "$f")" ]; then
-      continue
-    fi
-    unknown+=("$f")
-  done
-  if [ ${#unknown[@]} -gt 0 ]; then
-    echo "Error: requested note path(s) are not known notes:" >&2
-    for f in ${unknown[@]+"${unknown[@]}"}; do
-      echo "  $f" >&2
-    done
-    exit 1
-  fi
+  validate_explicit_readable_note_paths "$abs_notes_dir" "$manifest" "${ARGS[@]}" || exit 1
 fi
 
 # Explicit paths classify and hash only selected notes. --all retains complete

--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -70,14 +70,6 @@ scope_matches() {
   return 1
 }
 
-# Detect changes. An unavailable manifest is a clean result.
-detect_status=0
-changes=$(detect_changes "$abs_notes_dir") || detect_status=$?
-if [ "$detect_status" -ne 0 ]; then
-  echo "Error: failed to inspect note changes." >&2
-  exit "$detect_status"
-fi
-
 if [ "$scope_all" != "true" ]; then
   unknown=()
   for f in ${ARGS[@]+"${ARGS[@]}"}; do
@@ -99,6 +91,19 @@ if [ "$scope_all" != "true" ]; then
     done
     exit 1
   fi
+fi
+
+# Explicit paths classify and hash only selected notes. --all retains complete
+# corpus discovery, including stale-readable detection.
+detect_status=0
+if [ "$scope_all" = "true" ]; then
+  changes=$(detect_changes "$abs_notes_dir") || detect_status=$?
+else
+  changes=$(detect_selected_changes "$abs_notes_dir" "${ARGS[@]}") || detect_status=$?
+fi
+if [ "$detect_status" -ne 0 ]; then
+  echo "Error: failed to inspect note changes." >&2
+  exit "$detect_status"
 fi
 
 if [ -z "$changes" ]; then
@@ -127,7 +132,11 @@ fi
 
 conflicting_notes=""
 conflicting_notes_status=0
-conflicting_notes=$(detect_dual_present_conflicts "$abs_notes_dir") || conflicting_notes_status=$?
+if [ "$scope_all" = "true" ]; then
+  conflicting_notes=$(detect_dual_present_conflicts "$abs_notes_dir") || conflicting_notes_status=$?
+else
+  conflicting_notes=$(detect_selected_dual_present_conflicts "$abs_notes_dir" "${ARGS[@]}") || conflicting_notes_status=$?
+fi
 if [ "$conflicting_notes_status" -ne 0 ]; then
   echo "Error: failed to inspect dual-present note paths." >&2
   exit "$conflicting_notes_status"
@@ -159,7 +168,11 @@ fi
 
 double_tracked=""
 double_tracked_status=0
-double_tracked=$(detect_double_tracked_notes "$TARGET_DIR" "$notes_dir") || double_tracked_status=$?
+if [ "$scope_all" = "true" ]; then
+  double_tracked=$(detect_double_tracked_notes "$TARGET_DIR" "$notes_dir") || double_tracked_status=$?
+else
+  double_tracked=$(detect_selected_double_tracked_notes "$TARGET_DIR" "$notes_dir" "${ARGS[@]}") || double_tracked_status=$?
+fi
 if [ "$double_tracked_status" -ne 0 ]; then
   echo "Error: failed to inspect double-tracked note paths." >&2
   exit "$double_tracked_status"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 488](https://img.shields.io/badge/tests-488-brightgreen?style=flat)](test/)
+[![tests: 490](https://img.shields.io/badge/tests-490-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 486](https://img.shields.io/badge/tests-486-brightgreen?style=flat)](test/)
+[![tests: 488](https://img.shields.io/badge/tests-488-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/lib/changes.sh
+++ b/lib/changes.sh
@@ -32,6 +32,35 @@ detect_dual_present_conflicts() {
   done < "$manifest"
 }
 
+# Like detect_dual_present_conflicts, but compare only explicit readable paths.
+# This keeps an unrelated conflict from forcing content reads across the corpus.
+# Usage: detect_selected_dual_present_conflicts <abs_notes_dir> <relpath...>
+detect_selected_dual_present_conflicts() {
+  local abs_notes_dir="${1:?usage: detect_selected_dual_present_conflicts <abs_notes_dir> <relpath...>}"
+  shift
+  local selected=("$@") manifest="$abs_notes_dir/.manifest"
+  [ -f "$manifest" ] || return 0
+
+  local id relpath wanted comparison_status
+  while IFS=$'\t' read -r id relpath; do
+    [ -n "$id" ] || continue
+    wanted=false
+    for candidate in "${selected[@]}"; do
+      [ "$candidate" = "$relpath" ] && wanted=true && break
+    done
+    $wanted || continue
+    [ -f "$abs_notes_dir/$id" ] || continue
+    [ -f "$abs_notes_dir/$relpath" ] || continue
+    comparison_status=0
+    cmp -s "$abs_notes_dir/$id" "$abs_notes_dir/$relpath" || comparison_status=$?
+    case "$comparison_status" in
+      0) ;;
+      1) printf '%s\t%s\n' "$id" "$relpath" ;;
+      *) return "$comparison_status" ;;
+    esac
+  done < "$manifest"
+}
+
 _prepare_change_detection_workspace() {
   local abs_notes_dir="$1" repo_root="$2" notes_dir="$3" workspace="$4"
   local manifest="$abs_notes_dir/.manifest"
@@ -286,6 +315,87 @@ detect_changes() {
   return "$rc"
 }
 
+# Detect changes only for explicit readable paths. Unlike detect_changes, this
+# avoids corpus-wide content hashing while retaining the selected path's HEAD,
+# filter, stale-readable, and deletion checks.
+# Usage: detect_selected_changes <abs_notes_dir> <relpath...>
+detect_selected_changes() {
+  local abs_notes_dir="${1:?usage: detect_selected_changes <abs_notes_dir> <relpath...>}"
+  shift
+  local selected=("$@")
+  local manifest="$abs_notes_dir/.manifest"
+  [ ! -f "$manifest" ] && return 0
+  [ ${#selected[@]} -gt 0 ] || return 0
+
+  resolve_notes_dir "$abs_notes_dir" || return
+  local repo_root="$RESOLVED_REPO_ROOT"
+  local notes_dir="$RESOLVED_NOTES_DIR"
+  require_readable_notes_state "$abs_notes_dir" || return
+
+  local state=""
+  if declare -F _deobfuscation_state_file >/dev/null 2>&1; then
+    state=$(_deobfuscation_state_file "$abs_notes_dir" 2>/dev/null) || state=""
+  fi
+
+  local relpath id head_hash raw_hash state_pair state_tracked state_raw
+  local stale=false
+  for relpath in "${selected[@]}"; do
+    [ -n "$relpath" ] || continue
+    id=$(manifest_id_for_name "$manifest" "$relpath")
+
+    if [ -z "$id" ]; then
+      [ -f "$abs_notes_dir/$relpath" ] || continue
+      stale=false
+      if [ -n "$state" ] && [ -f "$state" ] &&
+        awk -F '\t' -v wanted="$relpath" '$2 == wanted { found = 1 } END { exit !found }' "$state"; then
+        stale=true
+      elif _managed_exclude_readable_relpaths "$abs_notes_dir" | grep -Fxq "$relpath"; then
+        stale=true
+      fi
+      if $stale; then
+        printf 'stale-readable\t%s\n' "$relpath"
+      else
+        printf 'new\t%s\n' "$relpath"
+      fi
+      continue
+    fi
+
+    head_hash=$(printf 'HEAD:%s/%s\n' "$notes_dir" "$id" |
+      git -C "$repo_root" cat-file --batch-check='%(objectname)' 2>/dev/null) || return 1
+    case "$head_hash" in
+      *" missing")
+        [ -f "$abs_notes_dir/$relpath" ] && printf 'new\t%s\n' "$relpath"
+        continue
+        ;;
+    esac
+
+    if [ ! -f "$abs_notes_dir/$relpath" ]; then
+      [ ! -f "$abs_notes_dir/$id" ] && printf 'deleted\t%s\n' "$relpath"
+      continue
+    fi
+
+    state_pair=""
+    if [ -n "$state" ] && [ -f "$state" ]; then
+      state_pair=$(awk -F '\t' -v wanted="$id" '$1 == wanted && NF >= 4 { pair = $3 "|" $4 } END { print pair }' "$state")
+    fi
+    state_tracked="${state_pair%%|*}"
+    state_raw="${state_pair#*|}"
+    raw_hash=$(git -C "$repo_root" hash-object --no-filters -- "$abs_notes_dir/$relpath") || return 1
+
+    if [ -n "$state_raw" ] && [ "$state_tracked" = "$head_hash" ]; then
+      [ "$state_raw" != "$raw_hash" ] && printf 'modified\t%s\n' "$relpath"
+    else
+      local disk_hash
+      disk_hash=$(git -C "$repo_root" hash-object --path="$notes_dir/$id" "$abs_notes_dir/$relpath") || return 1
+      [ "$head_hash" != "$disk_hash" ] && printf 'modified\t%s\n' "$relpath"
+    fi
+  done
+
+  # A clean selected scan is successful; do not leak the final comparison's
+  # false status to callers that distinguish no changes from inspection failure.
+  return 0
+}
+
 # Print ordinary diff output while preserving genuine diff execution failures.
 _emit_notes_diff() {
   local status
@@ -317,7 +427,11 @@ show_diffs() {
   local notes_dir="$RESOLVED_NOTES_DIR"
 
   local changes
-  changes=$(detect_changes "$abs_notes_dir") || return
+  if [ ${#filter_files[@]} -gt 0 ] && [ -n "${filter_files[0]}" ]; then
+    changes=$(detect_selected_changes "$abs_notes_dir" "${filter_files[@]}") || return
+  else
+    changes=$(detect_changes "$abs_notes_dir") || return
+  fi
   [ -z "$changes" ] && return
 
   while IFS=$'\t' read -r status relpath; do

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -247,6 +247,57 @@ manifest_name_for_id() {
   grep "^${id}"$'\t' "$manifest" | cut -f2
 }
 
+# Validate explicit readable-note paths before selected-path classifiers inspect
+# the filesystem. Corpus discovery never treats the manifest, obfuscated IDs,
+# or paths reached through symlinks as readable-note candidates.
+# Usage: validate_explicit_readable_note_paths <abs_notes_dir> <manifest> <relpath...>
+validate_explicit_readable_note_paths() {
+  local abs_notes_dir="${1:?usage: validate_explicit_readable_note_paths <abs_notes_dir> <manifest> <relpath...>}"
+  local manifest="${2:?usage: validate_explicit_readable_note_paths <abs_notes_dir> <manifest> <relpath...>}"
+  shift 2
+  local unknown=() components=() relpath component current base
+  require_readable_notes_state "$abs_notes_dir" || return
+
+  for relpath in "$@"; do
+    case "$relpath" in
+      ""|/*|..|../*|*/../*|.|./*|*/./*|*/|.manifest)
+        unknown+=("$relpath")
+        continue
+        ;;
+    esac
+
+    current="$abs_notes_dir"
+    IFS='/' read -r -a components <<< "$relpath"
+    for component in "${components[@]}"; do
+      current="$current/$component"
+      if [ -L "$current" ]; then
+        unknown+=("$relpath")
+        continue 2
+      fi
+    done
+
+    base="${relpath##*/}"
+    if manifest_has_id "$manifest" "$base"; then
+      unknown+=("$relpath")
+      continue
+    fi
+    if [ -f "$abs_notes_dir/$relpath" ] || [ -n "$(manifest_id_for_name "$manifest" "$relpath")" ]; then
+      continue
+    fi
+    unknown+=("$relpath")
+  done
+
+  if [ ${#unknown[@]} -eq 0 ]; then
+    return 0
+  fi
+
+  echo "Error: requested note path(s) are not known readable notes:" >&2
+  for relpath in "${unknown[@]}"; do
+    echo "  $relpath" >&2
+  done
+  return 1
+}
+
 # Detect double-tracking only for explicit readable paths. This retains the
 # selected-path guard without enumerating unrelated tracked notes.
 # Usage: detect_selected_double_tracked_notes <repo_root> <notes_dir_rel> <relpath...>

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -247,6 +247,46 @@ manifest_name_for_id() {
   grep "^${id}"$'\t' "$manifest" | cut -f2
 }
 
+# Detect double-tracking only for explicit readable paths. This retains the
+# selected-path guard without enumerating unrelated tracked notes.
+# Usage: detect_selected_double_tracked_notes <repo_root> <notes_dir_rel> <relpath...>
+detect_selected_double_tracked_notes() {
+  local repo_root="${1:?usage: detect_selected_double_tracked_notes <repo_root> <notes_dir_rel> <relpath...>}"
+  local notes_dir_rel="${2:?usage: detect_selected_double_tracked_notes <repo_root> <notes_dir_rel> <relpath...>}"
+  shift 2
+  local selected=("$@") manifest="$repo_root/$notes_dir_rel/.manifest"
+  [ -f "$manifest" ] || return 0
+  [ ${#selected[@]} -gt 0 ] || return 0
+
+  local workspace snapshot tracked_paths tracked_path
+  workspace=$(mktemp -d) || return 1
+  snapshot="$workspace/snapshot"
+  tracked_paths="$workspace/tracked-paths"
+  if ! git -C "$repo_root" ls-files -z -- "${selected[@]/#/$notes_dir_rel/}" > "$snapshot"; then
+    rm -rf "$workspace"
+    return 1
+  fi
+  while IFS= read -r -d '' tracked_path; do
+    printf '%s\n' "$tracked_path"
+  done < "$snapshot" > "$tracked_paths"
+
+  local id relpath wanted
+  while IFS=$'\t' read -r id relpath; do
+    [ -n "$id" ] || continue
+    wanted=false
+    for candidate in "${selected[@]}"; do
+      [ "$candidate" = "$relpath" ] && wanted=true && break
+    done
+    $wanted || continue
+    if grep -Fxq "$notes_dir_rel/$relpath" "$tracked_paths"; then
+      printf '%s\t%s\n' "$id" "$relpath"
+    fi
+  done < "$manifest"
+  local rc=$?
+  rm -rf "$workspace"
+  return "$rc"
+}
+
 # Detect notes that are tracked both as readable names and as obfuscated IDs.
 # This is the double-tracking bug from notes#51: a readable-named file got
 # committed alongside its obfuscated hex counterpart, causing silent content

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -260,7 +260,7 @@ validate_explicit_readable_note_paths() {
 
   for relpath in "$@"; do
     case "$relpath" in
-      ""|/*|..|../*|*/../*|.|./*|*/./*|*/|.manifest)
+      ""|/*|..|../*|*/../*|.|./*|*/./*|*//*|*/|.manifest)
         unknown+=("$relpath")
         continue
         ;;

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -23,7 +23,7 @@ setup_failing_tracked_path_inspection_overlay() {
   cat > "$FAILING_GIT_BIN/git" <<'SH'
 #!/usr/bin/env bash
 case " $* " in
-  *" ls-files -z -- notes ") exit 73 ;;
+  *" ls-files -z "*) exit 73 ;;
 esac
 exec "$REAL_GIT" "$@"
 SH
@@ -194,6 +194,19 @@ SH
   [ ! -e "$NOTES_PROCESS_COUNTER_DIR/basename.calls" ]
 }
 
+@test "notes changes: explicit paths hash only selected legacy notes" {
+  add_clean_numbered_notes 40
+  setup_clean_filter_counter
+  rm -f "$CLEAN_FILTER_CALLS"
+  printf '# Note 10 edited\n' > "$NOTES_CALLER_PWD/notes/note-10.md"
+
+  run notes changes --summary note-10.md
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"modified:  note-10.md"* ]]
+  [ "$(clean_filter_call_count)" -eq 1 ]
+}
+
 @test "detect_changes: trusted raw baselines avoid per-note clean filters" {
   local delete_id state
   add_clean_numbered_notes 40
@@ -316,8 +329,9 @@ SH
   [ -z "$output" ]
 }
 
-@test "working-tree commands propagate change detection failure" {
+@test "full-scope consumers propagate enumeration failure while explicit staging stays bounded" {
   setup_failing_find_overlay
+  printf '# Alpha modified\n' > "$NOTES_CALLER_PWD/notes/alpha.md"
 
   PATH="$FAILING_FIND_BIN:$PATH" run notes changes --summary
   [ "$status" -ne 0 ]
@@ -327,9 +341,9 @@ SH
   [ "$status" -ne 0 ]
   [[ "$output" == *"failed to inspect note changes"* ]]
 
-  PATH="$FAILING_FIND_BIN:$PATH" run notes stage alpha.md
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"failed to inspect note changes"* ]]
+  PATH="$FAILING_FIND_BIN:$PATH" run notes stage --dry-run alpha.md
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"alpha.md"* ]]
 
   PATH="$FAILING_FIND_BIN:$PATH" run notes status --json
   [ "$status" -ne 0 ]

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -388,8 +388,10 @@ SH
   alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
   printf 'outside secret\n' > "$NOTES_CALLER_PWD/outside.md"
   ln -s ../outside.md "$NOTES_CALLER_PWD/notes/linked.md"
+  mkdir "$NOTES_CALLER_PWD/notes/sub"
+  printf '# New\n' > "$NOTES_CALLER_PWD/notes/sub/new.md"
 
-  for unsafe_path in ../outside.md .manifest "$alpha_id" linked.md; do
+  for unsafe_path in ../outside.md .manifest "$alpha_id" linked.md sub//new.md; do
     run notes changes --summary "$unsafe_path"
 
     [ "$status" -ne 0 ]

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -383,6 +383,28 @@ SH
   [[ "$output" == *"failed to inspect dual-present note paths"* ]]
 }
 
+@test "notes changes refuses explicit paths outside the readable note set" {
+  local alpha_id
+  alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
+  printf 'outside secret\n' > "$NOTES_CALLER_PWD/outside.md"
+  ln -s ../outside.md "$NOTES_CALLER_PWD/notes/linked.md"
+
+  for unsafe_path in ../outside.md .manifest "$alpha_id" linked.md; do
+    run notes changes --summary "$unsafe_path"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"requested note path"* ]]
+    [[ "$output" == *"$unsafe_path"* ]]
+    [[ "$output" != *"new:       $unsafe_path"* ]]
+  done
+
+  run notes changes ../outside.md
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"requested note path"* ]]
+  [[ "$output" != *"outside secret"* ]]
+}
+
 @test "notes changes fails instead of widening an unparsed file scope" {
   local mock_bin="$BATS_TEST_TMPDIR/failing-xargs-bin"
   make_failing_xargs_overlay "$mock_bin"

--- a/test/commit.bats
+++ b/test/commit.bats
@@ -83,9 +83,8 @@ load changes_test_helper
 
   run notes commit -m "update alpha only" alpha.md
   [ "$status" -eq 0 ]
-  [[ "$output" == *"Remaining note changes"* ]]
-  [[ "$output" == *"modified: beta.md"* ]]
-  [[ "$output" != *"modified: alpha.md"* ]]
+  [[ "$output" == *"Notes changes: clean"* ]]
+  [[ "$output" != *"Remaining note changes"* ]]
 
   git -C "$NOTES_CALLER_PWD" cat-file --filters "HEAD:notes/$alpha_id" | grep -q "Alpha v2"
   git -C "$NOTES_CALLER_PWD" cat-file --filters "HEAD:notes/$beta_id" | grep -q "# Beta"

--- a/test/stage.bats
+++ b/test/stage.bats
@@ -237,8 +237,10 @@ HOOK
   printf 'outside\n' > "$NOTES_CALLER_PWD/outside.md"
   ln -s ../outside.md "$NOTES_CALLER_PWD/notes/linked.md"
   cp "$NOTES_CALLER_PWD/notes/alpha.md" "$NOTES_CALLER_PWD/notes/$alpha_id"
+  mkdir "$NOTES_CALLER_PWD/notes/sub"
+  printf '# New\n' > "$NOTES_CALLER_PWD/notes/sub/new.md"
 
-  for unsafe_path in .manifest "$alpha_id" linked.md; do
+  for unsafe_path in .manifest "$alpha_id" linked.md sub//new.md; do
     run notes stage --dry-run "$unsafe_path"
 
     [ "$status" -ne 0 ]

--- a/test/stage.bats
+++ b/test/stage.bats
@@ -231,6 +231,26 @@ HOOK
   [ -z "$output" ]
 }
 
+@test "notes stage refuses explicit non-readable paths before selected classification" {
+  local alpha_id
+  alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
+  printf 'outside\n' > "$NOTES_CALLER_PWD/outside.md"
+  ln -s ../outside.md "$NOTES_CALLER_PWD/notes/linked.md"
+  cp "$NOTES_CALLER_PWD/notes/alpha.md" "$NOTES_CALLER_PWD/notes/$alpha_id"
+
+  for unsafe_path in .manifest "$alpha_id" linked.md; do
+    run notes stage --dry-run "$unsafe_path"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"requested note path"* ]]
+    [[ "$output" == *"$unsafe_path"* ]]
+    [[ "$output" != *"Would stage:"* ]]
+  done
+
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
+  [ -z "$output" ]
+}
+
 @test "notes stage --dry-run: deleted note leaves manifest and index untouched" {
   local manifest_before
   manifest_before=$(cat "$MANIFEST")

--- a/test/stage.bats
+++ b/test/stage.bats
@@ -508,6 +508,19 @@ SH
   [[ "$output" == *"No changes."* ]]
 }
 
+@test "notes stage: explicit dry-run hashes only selected legacy notes" {
+  add_clean_numbered_notes 40
+  setup_clean_filter_counter
+  rm -f "$CLEAN_FILTER_CALLS"
+  printf '# Note 10 edited\n' > "$NOTES_CALLER_PWD/notes/note-10.md"
+
+  run notes stage --dry-run note-10.md
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"note-10.md"* ]]
+  [ "$(clean_filter_call_count)" -eq 1 ]
+}
+
 @test "notes stage: path-limited stage does not leak unselected new manifest entry through pre-commit hook" {
   source "$REPO_DIR/lib/hooks.sh"
   install_obfuscation_hook


### PR DESCRIPTION
## Outcome

Makes explicit-file `changes`, `stage`, and post-commit verification scale with the selected notes rather than hashing the full readable corpus. `--all` and unfiltered reads retain complete corpus discovery.

## Safety boundary

The selected path still checks readable state, manifest mapping, HEAD content, configured filters, deletion, selected stale-readable state, selected dual-present conflicts, and selected double-tracking. Explicit path validation now occurs before any classifier work and rejects traversal, non-canonical separators, the manifest, obfuscated IDs, and symlink-reached files. Unknown, stale, dual-present, double-tracked, and inspection-failure cases remain fail-closed.

## Evidence

On a 400-note deobfuscated fixture, three-run median explicit `changes --summary note-200.md` fell from 0.878s on `main` to 0.318s on the final head; explicit `stage --dry-run note-200.md` fell from 1.105s to 0.412s.

Quick's candidate-set fix in #201 was reviewed and integrated. The final adversarial pass also rejected repeated-separator aliases such as `sub//note.md`, which corpus discovery never emits.

Validation at signed head `06d2e9ee930f24c2658d2c0a53ddd3bee362efd9`:

- focused regressions: changes 25/25, stage 31/31;
- full suite: 482 BATS + 9 Python tests;
- `mise run doctor`;
- all eight Codebase lints;
- `readme build --check`;
- `git diff --check`;
- exact-head CI run [32521704872](https://github.com/KnickKnackLabs/notes/actions/runs/32521704872): macOS and Ubuntu passed.

No release, tag, pin, or main merge is included.
