### PR TITLE
fix: validate selected readable note paths

### DIFF
--- a/.mise/tasks/changes
+++ b/.mise/tasks/changes
@@ -38,6 +38,10 @@ if [ -n "${usage_files:-}" ]; then
   rm -f "$args_snapshot"
 fi
 
+if [ ${#ARGS[@]} -gt 0 ]; then
+  validate_explicit_readable_note_paths "$abs_notes_dir" "$manifest" "${ARGS[@]}" || exit 1
+fi
+
 if [ "${usage_summary:-}" = "true" ]; then
   # Summary mode: explicit paths avoid corpus-wide content hashing.
   detect_status=0

--- a/.mise/tasks/stage
+++ b/.mise/tasks/stage
@@ -71,26 +71,7 @@ scope_matches() {
 }
 
 if [ "$scope_all" != "true" ]; then
-  unknown=()
-  for f in ${ARGS[@]+"${ARGS[@]}"}; do
-    case "$f" in
-      /*|..|../*|*/../*|.|./*|*/./*|*/)
-        unknown+=("$f")
-        continue
-        ;;
-    esac
-    if [ -f "$abs_notes_dir/$f" ] || [ -n "$(manifest_id_for_name "$manifest" "$f")" ]; then
-      continue
-    fi
-    unknown+=("$f")
-  done
-  if [ ${#unknown[@]} -gt 0 ]; then
-    echo "Error: requested note path(s) are not known notes:" >&2
-    for f in ${unknown[@]+"${unknown[@]}"}; do
-      echo "  $f" >&2
-    done
-    exit 1
-  fi
+  validate_explicit_readable_note_paths "$abs_notes_dir" "$manifest" "${ARGS[@]}" || exit 1
 fi
 
 # Explicit paths classify and hash only selected notes. --all retains complete

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Collective memory, encrypted.**
 
-[![tests: 488](https://img.shields.io/badge/tests-488-brightgreen?style=flat)](test/)
+[![tests: 490](https://img.shields.io/badge/tests-490-brightgreen?style=flat)](test/)
 ![lints: 8](https://img.shields.io/badge/lints-8-blue?style=flat)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)](LICENSE)
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -247,6 +247,57 @@ manifest_name_for_id() {
   grep "^${id}"$'\t' "$manifest" | cut -f2
 }
 
+# Validate explicit readable-note paths before selected-path classifiers inspect
+# the filesystem. Corpus discovery never treats the manifest, obfuscated IDs,
+# or paths reached through symlinks as readable-note candidates.
+# Usage: validate_explicit_readable_note_paths <abs_notes_dir> <manifest> <relpath...>
+validate_explicit_readable_note_paths() {
+  local abs_notes_dir="${1:?usage: validate_explicit_readable_note_paths <abs_notes_dir> <manifest> <relpath...>}"
+  local manifest="${2:?usage: validate_explicit_readable_note_paths <abs_notes_dir> <manifest> <relpath...>}"
+  shift 2
+  local unknown=() components=() relpath component current base
+  require_readable_notes_state "$abs_notes_dir" || return
+
+  for relpath in "$@"; do
+    case "$relpath" in
+      ""|/*|..|../*|*/../*|.|./*|*/./*|*/|.manifest)
+        unknown+=("$relpath")
+        continue
+        ;;
+    esac
+
+    current="$abs_notes_dir"
+    IFS='/' read -r -a components <<< "$relpath"
+    for component in "${components[@]}"; do
+      current="$current/$component"
+      if [ -L "$current" ]; then
+        unknown+=("$relpath")
+        continue 2
+      fi
+    done
+
+    base="${relpath##*/}"
+    if manifest_has_id "$manifest" "$base"; then
+      unknown+=("$relpath")
+      continue
+    fi
+    if [ -f "$abs_notes_dir/$relpath" ] || [ -n "$(manifest_id_for_name "$manifest" "$relpath")" ]; then
+      continue
+    fi
+    unknown+=("$relpath")
+  done
+
+  if [ ${#unknown[@]} -eq 0 ]; then
+    return 0
+  fi
+
+  echo "Error: requested note path(s) are not known readable notes:" >&2
+  for relpath in "${unknown[@]}"; do
+    echo "  $relpath" >&2
+  done
+  return 1
+}
+
 # Detect double-tracking only for explicit readable paths. This retains the
 # selected-path guard without enumerating unrelated tracked notes.
 # Usage: detect_selected_double_tracked_notes <repo_root> <notes_dir_rel> <relpath...>

--- a/test/changes.bats
+++ b/test/changes.bats
@@ -383,6 +383,28 @@ SH
   [[ "$output" == *"failed to inspect dual-present note paths"* ]]
 }
 
+@test "notes changes refuses explicit paths outside the readable note set" {
+  local alpha_id
+  alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
+  printf 'outside secret\n' > "$NOTES_CALLER_PWD/outside.md"
+  ln -s ../outside.md "$NOTES_CALLER_PWD/notes/linked.md"
+
+  for unsafe_path in ../outside.md .manifest "$alpha_id" linked.md; do
+    run notes changes --summary "$unsafe_path"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"requested note path"* ]]
+    [[ "$output" == *"$unsafe_path"* ]]
+    [[ "$output" != *"new:       $unsafe_path"* ]]
+  done
+
+  run notes changes ../outside.md
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"requested note path"* ]]
+  [[ "$output" != *"outside secret"* ]]
+}
+
 @test "notes changes fails instead of widening an unparsed file scope" {
   local mock_bin="$BATS_TEST_TMPDIR/failing-xargs-bin"
   make_failing_xargs_overlay "$mock_bin"

--- a/test/stage.bats
+++ b/test/stage.bats
@@ -231,6 +231,26 @@ HOOK
   [ -z "$output" ]
 }
 
+@test "notes stage refuses explicit non-readable paths before selected classification" {
+  local alpha_id
+  alpha_id=$(manifest_id_for_name "$MANIFEST" "alpha.md")
+  printf 'outside\n' > "$NOTES_CALLER_PWD/outside.md"
+  ln -s ../outside.md "$NOTES_CALLER_PWD/notes/linked.md"
+  cp "$NOTES_CALLER_PWD/notes/alpha.md" "$NOTES_CALLER_PWD/notes/$alpha_id"
+
+  for unsafe_path in .manifest "$alpha_id" linked.md; do
+    run notes stage --dry-run "$unsafe_path"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"requested note path"* ]]
+    [[ "$output" == *"$unsafe_path"* ]]
+    [[ "$output" != *"Would stage:"* ]]
+  done
+
+  run git -C "$NOTES_CALLER_PWD" diff --cached --name-only
+  [ -z "$output" ]
+}
+
 @test "notes stage --dry-run: deleted note leaves manifest and index untouched" {
   local manifest_before
   manifest_before=$(cat "$MANIFEST")


### PR DESCRIPTION
## Finding fixed

The new selected-path classifier accepted paths that corpus discovery never treats as readable notes. `notes changes ../outside.md` could read and print a file outside `notes/`; `.manifest`, an existing obfuscated manifest ID, and symlink-reached files were classified as new readable notes. `notes stage --dry-run` likewise offered the manifest, an obfuscated side of a dual-present pair, and symlinks for staging.

This adds one shared pre-classification validator for `changes`, `stage`, and therefore `commit`. It preserves legitimate existing/new/deleted readable paths while rejecting traversal, the manifest, manifest IDs, and paths with symlink components.

## Evidence

- Added traversal/content-disclosure coverage for `changes`.
- Added manifest, obfuscated-ID, and symlink refusal coverage for `stage`.
- Full suite: 482 BATS + 9 Python tests.
- Additive local stress: selected stale-readable, dual-present, and double-tracked isolation; `--all` corpus-wide dual-present/double-tracked/discovery; selected legacy tracked-ID clean filters.
- `mise run doctor`, all eight Codebase lints, `readme build --check`, and `git diff --check` pass.

Targets PR #200's branch at exact reviewed head `f93e1bb65d9a65a8a0c42e1458b21bb79715dd56`.
